### PR TITLE
Remove Fluentd config from Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -18,6 +18,3 @@ update_configs:
     update_schedule: "live"
     version_requirement_updates: "off"
 
-  - package_manager: "ruby:bundler"
-    directory: "/infrastructure/fluentd"
-    update_schedule: "live"


### PR DESCRIPTION
As Fluentd is no longer used in the project.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
