### PR TITLE
Inviting team members POC

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -1,34 +1,34 @@
 class ResponsiblePersons::TeamMembersController < ApplicationController
   before_action :set_responsible_person
-  before_action :set_team_member, only: %i[new create]
   skip_before_action :create_or_join_responsible_person
 
-  def new; end
+  def new
+    @new_account_form = Registration::NewAccountForm.new
+  end
 
   def create
-    @responsible_person.save
-    if @responsible_person.errors.empty?
-      send_invite_email
+    new_account_form.responsible_person = @responsible_person
+    if new_account_form.save
       redirect_to responsible_person_team_members_path(@responsible_person)
     else
       render :new
     end
   end
 
-  def join
-    pending_requests = PendingResponsiblePersonUser.pending_requests_to_join_responsible_person(
-      current_user,
-      @responsible_person,
-    )
+  # def join
+  #   pending_requests = PendingResponsiblePersonUser.pending_requests_to_join_responsible_person(
+  #     current_user,
+  #     @responsible_person,
+  #   )
 
-    if pending_requests.any?
-      @responsible_person.add_user(current_user)
-      Rails.logger.info "Team member added to Responsible Person"
-      pending_requests.delete_all
-    end
+  #   if pending_requests.any?
+  #     @responsible_person.add_user(current_user)
+  #     Rails.logger.info "Team member added to Responsible Person"
+  #     pending_requests.delete_all
+  #   end
 
-    redirect_to responsible_person_path(@responsible_person)
-  end
+  #   redirect_to responsible_person_path(@responsible_person)
+  # end
 
 private
 
@@ -37,14 +37,12 @@ private
     authorize @responsible_person, :show?
   end
 
-  def team_member_params
-    params.fetch(:team_member, {}).permit(
-      :email_address,
-    )
+  def new_account_form
+    @new_account_form ||= Registration::NewAccountForm.new(new_account_form_params)
   end
 
-  def set_team_member
-    @team_member = @responsible_person.pending_responsible_person_users.build(team_member_params)
+  def new_account_form_params
+    params.require(:registration_new_account_form).permit(:full_name, :email)
   end
 
   def send_invite_email

--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -8,6 +8,7 @@ class ResponsiblePersons::TeamMembersController < ApplicationController
 
   def create
     new_account_form.responsible_person = @responsible_person
+    new_account_form.inviting_user_name = current_user.name
     if new_account_form.save
       redirect_to responsible_person_team_members_path(@responsible_person)
     else

--- a/cosmetics-web/app/forms/registration/new_account_form.rb
+++ b/cosmetics-web/app/forms/registration/new_account_form.rb
@@ -5,6 +5,7 @@ module Registration
 
     attribute :full_name
     attribute :responsible_person
+    attribute :inviting_user_name
 
     private_class_method def self.error_message(attr, key)
       I18n.t(key, scope: "new_account.#{attr}")
@@ -20,7 +21,13 @@ module Registration
 
       user = SubmitUser.new(name: full_name, email: email)
       ActiveRecord::Base.transaction do
+        if responsible_person
+          user.responsible_person = responsible_person
+          user.inviting_user_name = inviting_user_name
+        end
+
         user.save(validate: false)
+
         if responsible_person
           responsible_person.add_user(user)
         end

--- a/cosmetics-web/app/forms/registration/new_account_form.rb
+++ b/cosmetics-web/app/forms/registration/new_account_form.rb
@@ -4,6 +4,7 @@ module Registration
     include ActiveModel::Attributes
 
     attribute :full_name
+    attribute :responsible_person
 
     private_class_method def self.error_message(attr, key)
       I18n.t(key, scope: "new_account.#{attr}")
@@ -16,8 +17,14 @@ module Registration
       return false unless self.valid?
       return true if user_exists?
 
+
       user = SubmitUser.new(name: full_name, email: email)
-      user.save(validate: false)
+      ActiveRecord::Base.transaction do
+        user.save(validate: false)
+        if responsible_person
+          responsible_person.add_user(user)
+        end
+      end
       user
     end
 

--- a/cosmetics-web/app/models/responsible_person.rb
+++ b/cosmetics-web/app/models/responsible_person.rb
@@ -18,7 +18,7 @@ class ResponsiblePerson < ApplicationRecord
   validates :postal_code, presence: true, on: %i[enter_details create]
 
   def add_user(user)
-    responsible_person_users << ResponsiblePersonUser.create(user: user)
+    ResponsiblePersonUser.create!(user: user, responsible_person: self)
   end
 
   def address_lines

--- a/cosmetics-web/app/models/submit_user.rb
+++ b/cosmetics-web/app/models/submit_user.rb
@@ -13,6 +13,8 @@ class SubmitUser < User
   has_one :user_attributes, dependent: :destroy
   validates :mobile_number, presence: true
 
+  attr_writer :responsible_person, :inviting_user_name
+
   def self.confirm_by_token(token)
     user = super(token)
     user.persisted? ? user : nil
@@ -57,7 +59,11 @@ class SubmitUser < User
       generate_confirmation_token!
     end
 
-    NotifyMailer.send_account_confirmation_email(self).deliver_later
+    if @responsible_person && @inviting_user_name
+      NotifyMailer.send_responsible_person_invite_email(@responsible_person, self, @inviting_user_name).deliver_later
+    else
+      NotifyMailer.send_account_confirmation_email(self).deliver_later
+    end
   end
 
   def send_reset_password_instructions_notification(token)

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -21,18 +21,21 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% @responsible_person.pending_responsible_person_users.each do |user| %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">-</td>
-            <td class="govuk-table__cell"><%= user.email_address %></td>
-            <td class="govuk-table__cell">Pending</td>
-          </tr>
-        <% end %>
         <% @responsible_person.responsible_person_users.each do |user| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= user.name %></td>
-            <td class="govuk-table__cell"><%= user.email_address %></td>
-            <td class="govuk-table__cell">-</td>
+            <td class="govuk-table__cell"><%= user.user.name %></td>
+            <td class="govuk-table__cell"><%= user.user.email %></td>
+            <td class="govuk-table__cell">
+              <% if user.user == current_user %>
+                You
+              <% else %>
+                <% if user.user.account_security_completed %>
+                  Active
+                <% else %>
+                  Pending
+                <% end %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
@@ -3,9 +3,9 @@
   <%= render "layouts/navbar" %>
 <% end %>
 
-<%= form_with model: @team_member, scope: :team_member, url: responsible_person_team_members_path(@responsible_person), method: :post do |form| %>
+<%= form_with model: @new_account_form, url: responsible_person_team_members_path(@responsible_person), method: :post do |form| %>
   <div class="govuk-grid-row">
-    <%= error_summary_for(@team_member) %>
+    <%= error_summary_for(@new_account_form) %>
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Invite a team member</h1>
 
@@ -16,7 +16,8 @@
         <li>submit cosmetic product notifications</li>
       </ul>
 
-      <%= render "form_components/govuk_input", form: form, key: :email_address, type: :email_field, label: { text: "Email address" } %>
+      <%= form_input @new_account_form, :full_name %>
+      <%= email_input @new_account_form %>
 
       <div class="govuk-form-group">
         <%= govukButton text: "Send invitation" %>


### PR DESCRIPTION
Different approach to inviting team member. It:
- simplifies process by using current registration flow
- instead of using `PendingResponsiblePersonUser`, it simply adds invited user to `ResponsiblePerson` (via `ResponsiblePersonUser`
- on invite form, reuses `Registration::NewUserForm`

To make it working:
- [ ] send proper email notification
- [ ] determine team member status based on the `User` `registration_completed` field
- [ ] move tests from @scruti PR