### PR TITLE
Fix review apps deletion

### DIFF
--- a/.github/workflows/review-apps-delete-dangling.yml
+++ b/.github/workflows/review-apps-delete-dangling.yml
@@ -1,0 +1,72 @@
+name: Delete dangling review apps
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # Every night at 1am
+
+jobs:
+  cleanup_reviewapp:
+    name: Delete dangling review apps
+    runs-on: ubuntu-latest
+    env:
+      SPACE: int
+      CF_USERNAME: ${{ secrets.PaaSUsernameInt }}
+      CF_PASSWORD: ${{ secrets.PaaSPasswordInt }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install cf7 client
+      env:
+        CF_CLI_VERSION: 7.0.0-beta.25
+      run: |
+        curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
+        sudo cp /tmp/cf7 /usr/local/bin/cf7
+    - name: Retrieve list of active pull requests
+      run: |
+        # Gets open PR numbers and builds the review app name for each PR. Returns an array.
+        active_prs=(`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/UKGovernmentBEIS/beis-opss-cosmetics/pulls | jq -r '.[] | "cosmetics-pr-\(.number)"'`)
+
+        # Makes the active prs list available for further steps
+        echo "::set-env name=ACTIVE_PRS::${active_prs[@]}"
+    - name: Retrieve list of current review apps
+      run: |
+        cf7 api api.london.cloud.service.gov.uk
+        cf7 auth
+        cf7 target -o 'beis-opss' -s $SPACE
+
+        # Stores name of the review apps as an array
+        review_apps=(`cf7 apps | grep cosmetics-pr- | awk '{print $1}'`)
+        cf7 logout
+
+        # Makes the review apps list available for further steps
+        echo "::set-env name=REVIEW_APPS::${review_apps[@]}"
+    - name: Identify dangling review apps
+      run: |
+        # Iterates through review apps list and adds them to the dangling list
+        # unless they correspond to one of the open pull requests.
+        dangling_review_apps=()
+        for review_app in ${REVIEW_APPS[@]}; do
+          review_app_is_active="false"
+          for active in ${ACTIVE_PRS[@]}; do
+            if [ "$review_app" = "$active" ]; then
+              review_app_is_active="true"
+              break
+            fi
+          done
+          if [ "$review_app_is_active" = "false" ]; then
+            dangling_review_apps+=($review_app)
+          fi
+        done
+
+        # Makes the dangling review apps list available for further steps
+        echo "::set-env name=DANGLING_REVIEW_APPS::${dangling_review_apps[@]}"
+    - name: Delete dangling review apps
+      run: |
+        cf7 api api.london.cloud.service.gov.uk
+        cf7 auth
+        cf7 target -o 'beis-opss' -s $SPACE
+        for dangling in ${DANGLING_REVIEW_APPS[@]}; do
+          echo "Deleting ${dangling}"
+          cf7 delete -f -r ${dangling}
+          cf7 delete-service -f cosmetics-review-redis-${dangling:13} # Substring from 13th char contains the PR number
+        done
+        cf7 logout

--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
 jobs:
   cleanup_reviewapp:
     name: Delete review app
@@ -15,25 +18,15 @@ jobs:
     steps:
     - uses: actions/checkout@v1
       if: github.event.pull_request.merged == true
+
     - name: Install cf7 client
       env:
         CF_CLI_VERSION: 7.0.0-beta.25
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf7
-    - name: Get Pull Request ID using GitHub API
-      if: github.event.pull_request.merged == true
-      run: |
-        pr_number=`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/UKGovernmentBEIS/beis-opss/commits/$GITHUB_SHA/pulls | ./infrastructure/env/jq '.[0] | .number'`
-        echo "::set-env name=PR_NUMBER::$pr_number"
-    - name: Get Pull Request ID from GITHUB_REF
-      if: github.event.pull_request.merged != true
-      run: |
-        pr_number=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
-        echo "::set-env name=PR_NUMBER::$pr_number"
+
     - name: Delete review app
-      env:
-        PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth
@@ -41,9 +34,9 @@ jobs:
         cf7 delete -f -r cosmetics-pr-$PR_NUMBER
         cf7 delete-service -f cosmetics-review-redis-$PR_NUMBER
         cf7 logout
+
     - name: Deactivate Github deploy
       env:
-        PR_NUMBER: ${{ env.PR_NUMBER }}
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
       run: |
         source cosmetics-web/deploy-github-functions.sh


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-875

## Description:
This PR:
- Fixes the deletion of a review app when the pull request is merged/closed.
- Adds a new github workflow to regularly check for dangling review apps (without matching open PR) and delete them.

The one/off action triggered when closing a PR should avoid leaving dangling review apps that not belong to any active Pull Request, but sometimes it fails and the dangling review app stays permanently active unless it gets manually removed. After a while the numbers of dangling review apps turn into dozens, becoming a big waste of resources.

This is why we added a second workflow that will be executed every night to sweep for any dangling review app to be removed.

At this point we could just use the daily schedule deletion and remove the immediate one/off deletion triggered by PRs being closed. 
But lets leave both for a while at least. We may want to revisit the schedule and turn it into once per week/month as a daily sweep is probably an overkill.

### One/off deletion when a PR is closed:
![image](https://user-images.githubusercontent.com/1227578/94707184-0cf0e600-033b-11eb-911f-120351fa93b8.png)

###  Regular cleaning task
![image](https://user-images.githubusercontent.com/1227578/95079904-2dd88300-070f-11eb-912d-beff5fc85d7a.png)

