### PR TITLE
Move to stable cf v7 client on Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install cf client
       env:
-        CF_CLI_VERSION: 7.0.0-beta.25
+        CF_CLI_VERSION: v7
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
-        sudo cp /tmp/cf7 /usr/local/bin/cf7
+        sudo cp /tmp/cf7 /usr/local/bin/cf
 
     - name: Create GitHub deployment for Staging
       env:
@@ -48,12 +48,12 @@ jobs:
         CF_USERNAME: ${{ secrets.PaaSUsernameStaging }}
         CF_PASSWORD: ${{ secrets.PaaSPasswordStaging }}
       run: |
-        cf7 api api.london.cloud.service.gov.uk
-        cf7 auth
-        cf7 target -o 'beis-opss' -s $SPACE
+        cf api api.london.cloud.service.gov.uk
+        cf auth
+        cf target -o 'beis-opss' -s $SPACE
         chmod +x ./cosmetics-web/deploy.sh
         ./cosmetics-web/deploy.sh
-        cf7 logout
+        cf logout
 
     - name: Update Staging deployment status (success)
       if: success()
@@ -102,11 +102,11 @@ jobs:
         CF_USERNAME: ${{ secrets.PaaSUsernameProduction }}
         CF_PASSWORD: ${{ secrets.PaaSPasswordProduction }}
       run: |
-        cf7 api api.london.cloud.service.gov.uk
-        cf7 auth
-        cf7 target -o 'beis-opss' -s $SPACE
+        cf api api.london.cloud.service.gov.uk
+        cf auth
+        cf target -o 'beis-opss' -s $SPACE
         ./cosmetics-web/deploy.sh
-        cf7 logout
+        cf logout
 
     - name: Update Production deployment status (success)
       if: success()

--- a/.github/workflows/review-apps-delete-dangling.yml
+++ b/.github/workflows/review-apps-delete-dangling.yml
@@ -14,12 +14,12 @@ jobs:
       CF_PASSWORD: ${{ secrets.PaaSPasswordInt }}
     steps:
     - uses: actions/checkout@v1
-    - name: Install cf7 client
+    - name: Install cf client
       env:
-        CF_CLI_VERSION: 7.0.0-beta.25
+        CF_CLI_VERSION: v7
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
-        sudo cp /tmp/cf7 /usr/local/bin/cf7
+        sudo cp /tmp/cf7 /usr/local/bin/cf
     - name: Retrieve list of active pull requests
       run: |
         # Gets open PR numbers and builds the review app name for each PR. Returns an array.
@@ -29,13 +29,13 @@ jobs:
         echo "::set-env name=ACTIVE_PRS::${active_prs[@]}"
     - name: Retrieve list of current review apps
       run: |
-        cf7 api api.london.cloud.service.gov.uk
-        cf7 auth
-        cf7 target -o 'beis-opss' -s $SPACE
+        cf api api.london.cloud.service.gov.uk
+        cf auth
+        cf target -o 'beis-opss' -s $SPACE
 
         # Stores name of the review apps as an array
-        review_apps=(`cf7 apps | grep cosmetics-pr- | awk '{print $1}'`)
-        cf7 logout
+        review_apps=(`cf apps | grep cosmetics-pr- | awk '{print $1}'`)
+        cf logout
 
         # Makes the review apps list available for further steps
         echo "::set-env name=REVIEW_APPS::${review_apps[@]}"
@@ -61,12 +61,12 @@ jobs:
         echo "::set-env name=DANGLING_REVIEW_APPS::${dangling_review_apps[@]}"
     - name: Delete dangling review apps
       run: |
-        cf7 api api.london.cloud.service.gov.uk
-        cf7 auth
-        cf7 target -o 'beis-opss' -s $SPACE
+        cf api api.london.cloud.service.gov.uk
+        cf auth
+        cf target -o 'beis-opss' -s $SPACE
         for dangling in ${DANGLING_REVIEW_APPS[@]}; do
           echo "Deleting ${dangling}"
-          cf7 delete -f -r ${dangling}
-          cf7 delete-service -f cosmetics-review-redis-${dangling:13} # Substring from 13th char contains the PR number
+          cf delete -f -r ${dangling}
+          cf delete-service -f cosmetics-review-redis-${dangling:13} # Substring from 13th char contains the PR number
         done
-        cf7 logout
+        cf logout

--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -19,21 +19,21 @@ jobs:
     - uses: actions/checkout@v1
       if: github.event.pull_request.merged == true
 
-    - name: Install cf7 client
+    - name: Install cf client
       env:
-        CF_CLI_VERSION: 7.0.0-beta.25
+        CF_CLI_VERSION: v7
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
-        sudo cp /tmp/cf7 /usr/local/bin/cf7
+        sudo cp /tmp/cf7 /usr/local/bin/cf
 
     - name: Delete review app
       run: |
-        cf7 api api.london.cloud.service.gov.uk
-        cf7 auth
-        cf7 target -o 'beis-opss' -s $SPACE
-        cf7 delete -f -r cosmetics-pr-$PR_NUMBER
-        cf7 delete-service -f cosmetics-review-redis-$PR_NUMBER
-        cf7 logout
+        cf api api.london.cloud.service.gov.uk
+        cf auth
+        cf target -o 'beis-opss' -s $SPACE
+        cf delete -f -r cosmetics-pr-$PR_NUMBER
+        cf delete-service -f cosmetics-review-redis-$PR_NUMBER
+        cf logout
 
     - name: Deactivate Github deploy
       env:

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -36,10 +36,10 @@ jobs:
 
     - name: Install cf client
       env:
-        CF_CLI_VERSION: 7.0.0-beta.25
+        CF_CLI_VERSION: v7
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
-        sudo cp /tmp/cf7 /usr/local/bin/cf7
+        sudo cp /tmp/cf7 /usr/local/bin/cf
 
     - name: Deploy
       env:
@@ -47,15 +47,15 @@ jobs:
         CF_USERNAME: ${{ secrets.PaaSUsernameInt }}
         CF_PASSWORD: ${{ secrets.PaaSPasswordInt }}
       run: |
-        cf7 api api.london.cloud.service.gov.uk
-        cf7 auth
-        cf7 target -o 'beis-opss' -s $SPACE
+        cf api api.london.cloud.service.gov.uk
+        cf auth
+        cf target -o 'beis-opss' -s $SPACE
         export DB_VERSION=`cat cosmetics-web/db/schema.rb | grep 'ActiveRecord::Schema.define' | grep -o '[0-9_]\+'`
         export REVIEW_INSTANCE_NAME=pr-$PR_NUMBER
         export DB_NAME=cosmetics-db-$DB_VERSION
         export REDIS_NAME=cosmetics-review-redis-$PR_NUMBER
         ./cosmetics-web/deploy-review.sh
-        cf7 logout
+        cf logout
 
     - name: Update deployment status (success)
       if: success()

--- a/cosmetics-web/deploy-review.sh
+++ b/cosmetics-web/deploy-review.sh
@@ -23,28 +23,28 @@ if [ -z "$DB_NAME" ]
 then
   DB_NAME=cosmetics-review-database
 fi
-cf7 create-service postgres small-10 $DB_NAME
+cf create-service postgres small-10 $DB_NAME
 
 # Wait until db is prepared, might take up to 10 minutes
-until cf7 service $DB_NAME > /tmp/db_exists && grep "create succeeded" /tmp/db_exists; do sleep 20; echo "Waiting for db"; done
+until cf service $DB_NAME > /tmp/db_exists && grep "create succeeded" /tmp/db_exists; do sleep 20; echo "Waiting for db"; done
 
 if [ -z "$REDIS_NAME" ]
 then
   REDIS_NAME=cosmetics-review-redis
 fi
-cf7 create-service redis tiny-3.2 $REDIS_NAME
+cf create-service redis tiny-3.2 $REDIS_NAME
 
 # Wait until redis service is prepared, might take up to 10 minutes
-until cf7 service $REDIS_NAME > /tmp/redis_exists && grep "create succeeded" /tmp/redis_exists; do sleep 20; echo "Waiting for redis"; done
+until cf service $REDIS_NAME > /tmp/redis_exists && grep "create succeeded" /tmp/redis_exists; do sleep 20; echo "Waiting for redis"; done
 
 
 # Copy files from infrastructure env
 cp -a ./infrastructure/env/. ./cosmetics-web/env/
 
 # Deploy the submit app and set the hostname
-cf7 push $APP -f $MANIFEST_FILE --var cosmetics-instance-name=$INSTANCE_NAME --var cosmetics-web-database=$DB_NAME --var submit-host=$SUBMIT_APP.$DOMAIN --var search-host=$SEARCH_APP.$DOMAIN --var cosmetics-host=$SUBMIT_APP.$DOMAIN --var cosmetics-redis-service=$REDIS_NAME --var sentry-current-env=$REVIEW_INSTANCE_NAME --strategy rolling
+cf push $APP -f $MANIFEST_FILE --var cosmetics-instance-name=$INSTANCE_NAME --var cosmetics-web-database=$DB_NAME --var submit-host=$SUBMIT_APP.$DOMAIN --var search-host=$SEARCH_APP.$DOMAIN --var cosmetics-host=$SUBMIT_APP.$DOMAIN --var cosmetics-redis-service=$REDIS_NAME --var sentry-current-env=$REVIEW_INSTANCE_NAME --strategy rolling
 
-cf7 scale $APP --process worker -i 1
+cf scale $APP --process worker -i 1
 
 # Remove the copied infrastructure env files to clean up
 rm -R cosmetics-web/env/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
We can use stable v7 on the client version and then use its alias to CF command.