### PR TITLE
Visual fixes

### DIFF
--- a/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
@@ -14,6 +14,7 @@ module SecondaryAuthenticationConcern
       session[:secondary_authentication_redirect_to] = redirect_to
       session[:secondary_authentication_user_id] = user_id_for_secondary_authentication
       session[:secondary_authentication_notice] = notice
+      session[:secondary_authentication_confirmation] = confirmation
       auth = SecondaryAuthentication.new(user)
       auth.generate_and_send_code(current_operation)
       redirect_to new_secondary_authentication_path

--- a/cosmetics-web/app/controllers/my_account_email_controller.rb
+++ b/cosmetics-web/app/controllers/my_account_email_controller.rb
@@ -19,7 +19,7 @@ class MyAccountEmailController < ApplicationController
       user.send_new_email_confirmation_email
       render "users/check_your_email/show"
     end
-  rescue
+  rescue StandardError
     render "my_account/email"
   end
 

--- a/cosmetics-web/app/controllers/my_account_email_controller.rb
+++ b/cosmetics-web/app/controllers/my_account_email_controller.rb
@@ -14,19 +14,20 @@ class MyAccountEmailController < ApplicationController
 
     @user.new_email = dig_params(:new_email)
 
-    if @user.save
+    ActiveRecord::Base.transaction do
+      @user.save!
       user.send_new_email_confirmation_email
-      redirect_to my_account_path, notice: "Confirmation email sent. Please follow instructions from email"
-    else
-      render "my_account/email"
+      render "users/check_your_email/show"
     end
+  rescue
+    render "my_account/email"
   end
 
   def confirm
     User.new_email!(params[:confirmation_token])
-    redirect_to my_account_path, notice: "Email changed successfully"
+    redirect_to my_account_path, confirmation: "Email changed successfully"
   rescue ArgumentError
-    redirect_to my_account_path, notice: "Email can not be changed, confirmation token is incorrect. Please try again."
+    redirect_to my_account_path, alert: "Email can not be changed, confirmation token is incorrect. Please try again."
   end
 
 private

--- a/cosmetics-web/app/controllers/my_account_mobile_number_controller.rb
+++ b/cosmetics-web/app/controllers/my_account_mobile_number_controller.rb
@@ -16,7 +16,7 @@ class MyAccountMobileNumberController < ApplicationController
     @user.mobile_number_verified = false
 
     if @user.save
-      redirect_to my_account_path, notice: "Mobile number changed successfully"
+      redirect_to my_account_path, confirmation: "Mobile number changed successfully"
     else
       render "my_account/mobile_number"
     end

--- a/cosmetics-web/app/controllers/my_account_name_controller.rb
+++ b/cosmetics-web/app/controllers/my_account_name_controller.rb
@@ -10,7 +10,7 @@ class MyAccountNameController < ApplicationController
     @user.name = dig_params(:name)
 
     if @user.save
-      redirect_to my_account_path, notice: "Name changed successfully"
+      redirect_to my_account_path, confirmation: "Name changed successfully"
     else
       render "my_account/name"
     end

--- a/cosmetics-web/app/controllers/my_account_password_controller.rb
+++ b/cosmetics-web/app/controllers/my_account_password_controller.rb
@@ -17,7 +17,7 @@ class MyAccountPasswordController < ApplicationController
 
     if @user.save
       sign_in(@user, bypass: true)
-      redirect_to my_account_path, notice: "Password changed successfully"
+      redirect_to my_account_path, confirmation: "Password changed successfully"
     else
       render "my_account/password"
     end

--- a/cosmetics-web/app/controllers/secondary_authentications_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentications_controller.rb
@@ -32,7 +32,7 @@ private
   def redirect_to_saved_path
     session[:secondary_authentication_user_id] = nil
     if session[:secondary_authentication_redirect_to]
-      redirect_to session.delete(:secondary_authentication_redirect_to), notice: session.delete(:secondary_authentication_notice)
+      redirect_to session.delete(:secondary_authentication_redirect_to), notice: session.delete(:secondary_authentication_notice), confirmation: session.delete(:secondary_authentication_confirmation)
     else
       redirect_to root_path
     end

--- a/cosmetics-web/app/models/contact_person.rb
+++ b/cosmetics-web/app/models/contact_person.rb
@@ -2,6 +2,10 @@ class ContactPerson < ApplicationRecord
   belongs_to :responsible_person
 
   validates :name, presence: true
-  validates :email_address, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email_address,
+            email: {
+              message: I18n.t(:wrong_format, scope: "contact_person.email_address"),
+            }
+  validates_presence_of :email_address, message: I18n.t(:blank, scope: "contact_person.email_address")
   validates :phone_number, presence: true
 end

--- a/cosmetics-web/app/views/layouts/application.html.erb
+++ b/cosmetics-web/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
       <% end %>
 
       <% if confirmation %>
+        <div class="govuk-!-margin-top-4"></div>
         <%= render "components/hmcts_banner", text: confirmation, type: "success" %>
       <% end %>
 

--- a/cosmetics-web/app/views/my_account/email.html.erb
+++ b/cosmetics-web/app/views/my_account/email.html.erb
@@ -1,4 +1,4 @@
-<% title = "Change your email" %>
+<% title = "Change your email address" %>
 <% page_title title, errors: @user.errors.any? %>
 
 <% content_for(:after_header) do %>
@@ -29,12 +29,12 @@
         form: form,
         classes: "app-!-max-width-two-thirds",
         label: {
-          text: "New email"
+          text: "New email address"
         },
         value: nil,
         id: "new_email"
         %>
-      <%= govukButton(text: "Save") %>
+      <%= govukButton(text: "Continue") %>
     <% end %>
   </div>
 </div>

--- a/cosmetics-web/app/views/my_account/mobile_number.html.erb
+++ b/cosmetics-web/app/views/my_account/mobile_number.html.erb
@@ -34,7 +34,7 @@
         value: nil,
         id: "new_mobile_number"
         %>
-      <%= govukButton(text: "Save") %>
+      <%= govukButton(text: "Continue") %>
     <% end %>
   </div>
 </div>

--- a/cosmetics-web/app/views/my_account/name.html.erb
+++ b/cosmetics-web/app/views/my_account/name.html.erb
@@ -23,7 +23,7 @@
         value: nil,
         id: "name"
         %>
-      <%= govukButton(text: "Save") %>
+      <%= govukButton(text: "Continue") %>
     <% end %>
   </div>
 </div>

--- a/cosmetics-web/app/views/my_account/name.html.erb
+++ b/cosmetics-web/app/views/my_account/name.html.erb
@@ -18,7 +18,7 @@
         form: form,
         classes: "app-!-max-width-two-thirds",
         label: {
-          text: "Name"
+          text: "Full name"
         },
         value: nil,
         id: "name"

--- a/cosmetics-web/app/views/my_account/password.html.erb
+++ b/cosmetics-web/app/views/my_account/password.html.erb
@@ -18,7 +18,7 @@
         form: form,
         classes: "app-!-max-width-two-thirds",
         label: {
-          text: "Old password"
+          text: "Current password"
         },
         value: nil,
         id: "old_password"

--- a/cosmetics-web/app/views/my_account/show.html.erb
+++ b/cosmetics-web/app/views/my_account/show.html.erb
@@ -9,7 +9,7 @@
       classes: "app-summary-list--key-weight-regular",
       rows: [
         {
-          key: { text: "Name" },
+          key: { text: "Full name" },
           value: { text: current_user.name },
           actions: {
             items: [

--- a/cosmetics-web/app/views/my_account/show.html.erb
+++ b/cosmetics-web/app/views/my_account/show.html.erb
@@ -1,7 +1,7 @@
 <% title = "Your account" %>
 <% page_title title %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
+  <div class="govuk-grid-column-full">
 
     <h1 class="govuk-heading-l"><%= title %></h1>
 

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -37,5 +37,10 @@
         <% end %>
       </tbody>
     </table>
+
+    <div class="govuk-inset-text">
+      For help with accounts, including removing a team member, email <%= mail_to t(:enquiries_email), nil, class: "govuk-link" %>
+    </div>
   </div>
 </div>
+

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -38,7 +38,7 @@
       </tbody>
     </table>
 
-    <div class="govuk-grid-columnt-two-third">
+    <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">
         For help with accounts, including removing a team member, email <%= mail_to t(:enquiries_email), nil, class: "govuk-link" %>
       </p>

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -38,11 +38,12 @@
       </tbody>
     </table>
 
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">
-        For help with accounts, including removing a team member, email <%= mail_to t(:enquiries_email), nil, class: "govuk-link" %>
-      </p>
-    </div>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      For help with accounts, including removing a team member, email <%= mail_to t(:enquiries_email), nil, class: "govuk-link" %>
+    </p>
   </div>
 </div>
 

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -38,8 +38,10 @@
       </tbody>
     </table>
 
-    <div class="govuk-inset-text">
-      For help with accounts, including removing a team member, email <%= mail_to t(:enquiries_email), nil, class: "govuk-link" %>
+    <div class="govuk-grid-columnt-two-third">
+      <p class="govuk-body">
+        For help with accounts, including removing a team member, email <%= mail_to t(:enquiries_email), nil, class: "govuk-link" %>
+      </p>
     </div>
   </div>
 </div>

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Team members</h1>
-    <%= link_to "Invite a colleague", new_responsible_person_team_member_path, class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19" %>
+    <%= link_to "Invite a team member", new_responsible_person_team_member_path, class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19" %>
   </div>
 </div>
 

--- a/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
@@ -1,6 +1,8 @@
+
 <% content_for :page_title, "Invite a team member" %>
 <% content_for :after_header do %>
   <%= render "layouts/navbar" %>
+  <%= link_to "Back", responsible_person_team_members_path(@responsible_person), class: "govuk-back-link" %>
 <% end %>
 
 <%= form_with model: @team_member, scope: :team_member, url: responsible_person_team_members_path(@responsible_person), method: :post do |form| %>

--- a/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
@@ -12,8 +12,9 @@
       <p>Inviting a team member will allow them to:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>see all cosmetic products</li>
-        <li>submit cosmetic product notifications</li>
+        <li>See all cosmetic products</li>
+        <li>Submit cosmetic product notifications</li>
+        <li>Invite team members</li>
       </ul>
 
       <%= render "form_components/govuk_input", form: form, key: :email_address, type: :email_field, label: { text: "Email address" } %>

--- a/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
@@ -12,9 +12,9 @@
       <p>Inviting a team member will allow them to:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>See all cosmetic products</li>
-        <li>Submit cosmetic product notifications</li>
-        <li>Invite team members</li>
+        <li>see all cosmetic products</li>
+        <li>submit cosmetic product notifications</li>
+        <li>invite team members</li>
       </ul>
 
       <%= render "form_components/govuk_input", form: form, key: :email_address, type: :email_field, label: { text: "Email address" } %>

--- a/cosmetics-web/config/initializers/devise.rb
+++ b/cosmetics-web/config/initializers/devise.rb
@@ -186,7 +186,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -127,6 +127,8 @@ en:
           attributes:
             mobile_number:
               invalid: "Enter your mobile number in the correct format, like 07700 900 982"
+            password:
+              too_short: "Password must be at least 8 characters"
   activemodel:
     attributes:
       registration/account_security_form:
@@ -140,6 +142,7 @@ en:
               blank: "Please enter mobile number"
             password:
               blank: "Please enter password"
+              too_short: "Password must be at least 8 characters"
             full_name:
               blank: "Enter your full name"
   enquiries_email: "opss.enquiries@beis.gov.uk"

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -228,3 +228,7 @@ en:
     mobile_number:
       invalid: "Enter your mobile number in the correct format, like 07700 900 982"
       blank: "Please enter mobile number"
+  contact_person:
+    email_address:
+      wrong_format: "Enter your email address in the correct format, like name@example.com"
+      blank: "Enter your email address"

--- a/cosmetics-web/spec/features/account/change_email_spec.rb
+++ b/cosmetics-web/spec/features/account/change_email_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe "Changing email address", :with_2fa, :with_stubbed_mailer, :with_
       it "changes password properly" do
         fill_in "Password", with: user.password
         fill_in "New email", with: "new@example.org"
-        click_on "Save"
+        click_on "Continue"
 
         expect_to_be_on_my_account_page
-        expect(page).to have_text(/Confirmation email sent. Please follow instructions from email/)
+        expect(page).to have_text(/A message with a confirmation link has been sent to your email address/)
         email = delivered_emails.first
         expect(email.recipient).to eq "new@example.org"
 
@@ -58,7 +58,7 @@ RSpec.describe "Changing email address", :with_2fa, :with_stubbed_mailer, :with_
       it "does not get updated when password is wrong" do
         fill_in "Password", with: "user.password"
         fill_in "New email", with: "new@example.org"
-        click_on "Save"
+        click_on "Continue"
 
         expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
         expect(page).to have_link("Password is incorrect", href: "#password")
@@ -67,7 +67,7 @@ RSpec.describe "Changing email address", :with_2fa, :with_stubbed_mailer, :with_
       it "does not get updated when new email is incorrect" do
         fill_in "Password", with: user.password
         fill_in "New email", with: "new@example"
-        click_on "Save"
+        click_on "Continue"
 
         expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
         expect(page).to have_link("", href: "#new_email")
@@ -77,10 +77,10 @@ RSpec.describe "Changing email address", :with_2fa, :with_stubbed_mailer, :with_
         before do
           fill_in "Password", with: user.password
           fill_in "New email", with: "new@example.org"
-          click_on "Save"
+          click_on "Continue"
 
           expect_to_be_on_my_account_page
-          expect(page).to have_text(/Confirmation email sent. Please follow instructions from email/)
+          expect(page).to have_text(/A message with a confirmation link has been sent to your email address/)
           email = delivered_emails.last
           expect(email.recipient).to eq "new@example.org"
 

--- a/cosmetics-web/spec/features/account/change_mobile_number_spec.rb
+++ b/cosmetics-web/spec/features/account/change_mobile_number_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Changing mobile number", :with_2fa, :with_stubbed_mailer, :with_
     it "changes password properly" do
       fill_in "Password", with: user.password
       fill_in "New mobile number", with: "07234234234"
-      click_on "Save"
+      click_on "Continue"
 
       expect(page).to have_css("h1", text: "Check your phone")
       fill_in "Enter security code", with: "#{otp_code} "
@@ -48,7 +48,7 @@ RSpec.describe "Changing mobile number", :with_2fa, :with_stubbed_mailer, :with_
     it "does not get updated when password is wrong" do
       fill_in "Password", with: "user.password"
       fill_in "New mobile number", with: "07500111000"
-      click_on "Save"
+      click_on "Continue"
 
       expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
       expect(page).to have_link("Password is incorrect", href: "#password")
@@ -60,7 +60,7 @@ RSpec.describe "Changing mobile number", :with_2fa, :with_stubbed_mailer, :with_
     xit "does not get updated when new mobile number is empty" do
       fill_in "Password", with: user.password
       fill_in "New mobile number", with: ""
-      click_on "Save"
+      click_on "Continue"
 
       expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
       expect(page).to have_link("Mobile number can not be blank", href: "#mobile_number")

--- a/cosmetics-web/spec/features/account/change_name_spec.rb
+++ b/cosmetics-web/spec/features/account/change_name_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe "Changing name", :with_2fa, :with_stubbed_mailer, :with_stubbed_n
 
 
     it "changes name properly" do
-      fill_in "Name", with: ""
-      click_button "Save"
+      fill_in "Full name", with: ""
+      click_button "Continue"
 
       expect(page).to have_link("Name can not be blank", href: "#name")
 
-      fill_in "Name", with: "Joe Smith"
-      click_button "Save"
+      fill_in "Full name", with: "Joe Smith"
+      click_button "Continue"
       expect_to_be_on_my_account_page
       expect(page).to have_text(/Name changed successfully/)
     end

--- a/cosmetics-web/spec/features/account/change_password_spec.rb
+++ b/cosmetics-web/spec/features/account/change_password_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Changing password", :with_2fa, :with_stubbed_mailer, :with_stubb
 
     context "when the password change is fine" do
       it "changes password properly" do
-        fill_in "Old password", with: user.password
+        fill_in "Current password", with: user.password
         fill_in "New password", with: "user.password"
         fill_in "New password confirmation", with: "user.password"
         click_on "Save"
@@ -35,7 +35,7 @@ RSpec.describe "Changing password", :with_2fa, :with_stubbed_mailer, :with_stubb
 
     context "when the update cant be done" do
       it "does not get updated when old password is wrong" do
-        fill_in "Old password", with: "user.password"
+        fill_in "Current password", with: "user.password"
         fill_in "New password", with: "user.password"
         fill_in "New password confirmation", with: "user.password"
         click_on "Save"
@@ -45,17 +45,17 @@ RSpec.describe "Changing password", :with_2fa, :with_stubbed_mailer, :with_stubb
       end
 
       it "does not get updated when new password does not fit to requirement" do
-        fill_in "Old password", with: user.password
+        fill_in "Current password", with: user.password
         fill_in "New password", with: "user"
         fill_in "New password confirmation", with: "user.password"
         click_on "Save"
 
         expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-        expect(page).to have_link("Password is too short (minimum is 6 characters)", href: "#password")
+        expect(page).to have_link("Password must be at least 8 characters", href: "#password")
       end
 
       it "does not get updated when new password confirmation is wrong" do
-        fill_in "Old password", with: user.password
+        fill_in "Current password", with: user.password
         fill_in "New password", with: "user.password"
         fill_in "New password confirmation", with: "user"
         click_on "Save"

--- a/cosmetics-web/spec/features/account/forgotten_password_spec.rb
+++ b/cosmetics-web/spec/features/account/forgotten_password_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
           click_on "Continue"
 
           expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-          expect(page).to have_link("Password is too short", href: "#password")
+          expect(page).to have_link("Password must be at least 8 characters", href: "#password")
 
           expect(page).to have_field("username", type: "email", with: user.email, disabled: true)
         end

--- a/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
+++ b/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Inviting a colleague", :with_stubbed_antivirus, :with_stubbed_notify, :with_stubbed_mailer, :with_2fa, type: :feature do
+RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_notify, :with_stubbed_mailer, :with_2fa, type: :feature do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:user) { create(:submit_user) }
   let(:invited_user) { create(:submit_user, name: "John Doeinvited", email: "inviteduser@example.com") }
@@ -15,7 +15,7 @@ RSpec.describe "Inviting a colleague", :with_stubbed_antivirus, :with_stubbed_no
 
     wait_time = SecondaryAuthentication::TIMEOUTS[SecondaryAuthentication::INVITE_USER] + 1
     travel_to(Time.now.utc + wait_time.seconds) do
-      click_on "Invite a colleague"
+      click_on "Invite a team member"
 
       complete_secondary_authentication_for(user)
 
@@ -50,7 +50,7 @@ RSpec.describe "Inviting a colleague", :with_stubbed_antivirus, :with_stubbed_no
 
     wait_time = SecondaryAuthentication::TIMEOUTS[SecondaryAuthentication::INVITE_USER] + 1
     travel_to(Time.now.utc + wait_time.seconds) do
-      click_on "Invite a colleague"
+      click_on "Invite a team member"
 
       complete_secondary_authentication_for(user)
 
@@ -74,7 +74,7 @@ RSpec.describe "Inviting a colleague", :with_stubbed_antivirus, :with_stubbed_no
 
     wait_time = SecondaryAuthentication::TIMEOUTS[SecondaryAuthentication::INVITE_USER] + 1
     travel_to(Time.now.utc + wait_time.seconds) do
-      click_on "Invite a colleague"
+      click_on "Invite a team member"
 
       complete_secondary_authentication_for(user)
 
@@ -99,7 +99,7 @@ RSpec.describe "Inviting a colleague", :with_stubbed_antivirus, :with_stubbed_no
 
     wait_time = PendingResponsiblePersonUser::INVITATION_TOKEN_VALID_FOR + 1
     travel_to(Time.now.utc + wait_time.seconds) do
-      click_on "Invite a colleague"
+      click_on "Invite a team member"
 
       complete_secondary_authentication_for(user)
 
@@ -135,7 +135,7 @@ RSpec.describe "Inviting a colleague", :with_stubbed_antivirus, :with_stubbed_no
     # User sends the original invitation to the team
     sign_in_as_member_of_responsible_person(responsible_person, user)
     visit "/responsible_persons/#{responsible_person.id}/team_members"
-    click_on "Invite a colleague"
+    click_on "Invite a team member"
 
     expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/team_members/new")
     fill_in "Email address", with: "newusertoregister@example.com"
@@ -170,7 +170,7 @@ RSpec.describe "Inviting a colleague", :with_stubbed_antivirus, :with_stubbed_no
     sign_in(user)
 
     visit "/responsible_persons/#{responsible_person.id}/team_members"
-    click_on "Invite a colleague"
+    click_on "Invite a team member"
 
     expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/team_members/new")
     fill_in "Email address", with: "newusertoregister@example.com"
@@ -300,7 +300,7 @@ RSpec.describe "Inviting a colleague", :with_stubbed_antivirus, :with_stubbed_no
     wait_time = SecondaryAuthentication::TIMEOUTS[SecondaryAuthentication::INVITE_USER] + 1
     travel_to(Time.now.utc + wait_time.seconds)
 
-    click_on "Invite a colleague"
+    click_on "Invite a team member"
 
     complete_secondary_authentication_for(user)
 

--- a/cosmetics-web/spec/forms/registration/account_security_form_spec.rb
+++ b/cosmetics-web/spec/forms/registration/account_security_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Registration::AccountSecurityForm do
 
     it "contains errors" do
       form.valid?
-      expect(form.errors.full_messages_for(:password)).to eq ["Password is too short (minimum is 8 characters)"]
+      expect(form.errors.full_messages_for(:password)).to eq ["Password must be at least 8 characters"]
     end
   end
 

--- a/cosmetics-web/spec/models/contact_person_spec.rb
+++ b/cosmetics-web/spec/models/contact_person_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe ContactPerson, type: :model do
   it "fails if an email address is not specified" do
     contact_person.email_address = nil
     expect(contact_person.save).to be false
-    expect(contact_person.errors[:email_address]).to include("Email address can not be blank")
+    expect(contact_person.errors[:email_address]).to include("Enter your email address in the correct format, like name@example.com")
   end
 
   it "fails if the email address format is invalid" do
     contact_person.email_address = "invalid_format"
 
     expect(contact_person.save).to be false
-    expect(contact_person.errors[:email_address]).to include("Email address is invalid")
+    expect(contact_person.errors[:email_address]).to include("Enter your email address in the correct format, like name@example.com")
   end
 end

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -645,6 +645,11 @@ def fill_in_rp_contact_details
   click_on "Continue"
   expect(page).to have_h1("Contact person details")
   fill_in "Full name", with: "Auto-test contact person"
+  fill_in "Email address", with: "auto-test@foo"
+  fill_in "Phone number", with: "07984563072"
+  click_on "Continue"
+  expect(page).to have_text("Enter your email address in the correct format")
+  fill_in "Full name", with: "Auto-test contact person"
   fill_in "Email address", with: "auto-test@exaple.com"
   fill_in "Phone number", with: "07984563072"
   click_on "Continue"


### PR DESCRIPTION
COSBETA-668 — adds 'Invite team members' to the explanation of what a team member can do
COSBETA-671 — adds instructions on how to remove a team member on the team members page
COSBETA-879 — corrects password too short error message
COSBETA-878 — changes 'Invite colleague' to 'Invite a team member'
COSBETA-880 — adds to validation of email format for Contact Person
COSBETA-881 — changes 'Name' to 'Full name' on Your account and Change your name
COSBETA-846 — increases the minimum number of characters in a password to 8