### PR TITLE
Fix email validation error link on team user invite

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
@@ -1,4 +1,6 @@
-<% content_for :page_title, "Invite a team member" %>
+<% title = "Invite a team member" %>
+<% page_title(title, errors: @team_member.errors.any?) %>
+
 <% content_for :after_header do %>
   <%= render "layouts/navbar" %>
 <% end %>
@@ -16,7 +18,7 @@
         <li>submit cosmetic product notifications</li>
       </ul>
 
-      <%= render "form_components/govuk_input", form: form, key: :email_address, id: "email_address", type: :email_field, label: { text: "Email address" } %>
+      <%= render "form_components/govuk_input", form: form, key: :email_address, id: "pending_responsible_person_user_email_address", type: :email_field, label: { text: "Email address" } %>
 
       <div class="govuk-form-group">
         <%= govukButton text: "Send invitation" %>

--- a/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/new.html.erb
@@ -16,7 +16,7 @@
         <li>submit cosmetic product notifications</li>
       </ul>
 
-      <%= render "form_components/govuk_input", form: form, key: :email_address, type: :email_field, label: { text: "Email address" } %>
+      <%= render "form_components/govuk_input", form: form, key: :email_address, id: "email_address", type: :email_field, label: { text: "Email address" } %>
 
       <div class="govuk-form-group">
         <%= govukButton text: "Send invitation" %>


### PR DESCRIPTION
When clicking on the email validation error the focus wasn't switching to the email input.
Fixed if by changing the email input id to match the attribute with the validation error.
