### PR TITLE
Replace cf7 with cf in deploy script

### DIFF
--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -20,9 +20,9 @@ MANIFEST_FILE=./cosmetics-web/manifest.yml
 cp -a ./infrastructure/env/. ./cosmetics-web/env/
 
 # Deploy the submit app and set the hostname
-cf7 push $APP_NAME -f $MANIFEST_FILE --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --strategy rolling
+cf push $APP_NAME -f $MANIFEST_FILE --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --strategy rolling
 
-cf7 scale $APP_NAME --process worker -i 1
+cf scale $APP_NAME --process worker -i 1
 
 # Remove the copied infrastructure env files to clean up
 rm -R cosmetics-web/env/


### PR DESCRIPTION
The `cf7` command has been replaced with `cf`. 
I forgot to replace the command in the deploy script, breaking the deploy pipeline. Sorryyyy.
