### PR TITLE
Do not check for mobile number verification when 2FA is disabled

### DIFF
--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -3,7 +3,6 @@ module ResponsiblePersonConcern
 
   def create_or_join_responsible_person
     return unless fully_signed_in_submit_user?
-    return unless current_user.mobile_number_verified?
 
     responsible_person = current_responsible_person
 
@@ -43,7 +42,7 @@ private
 
   def fully_signed_in_submit_user?
     if Rails.configuration.secondary_authentication_enabled
-      user_signed_in? && secondary_authentication_present?
+      user_signed_in? && secondary_authentication_present? && current_user.mobile_number_verified?
     else
       user_signed_in?
     end


### PR DESCRIPTION
Originally solving a bug, but now just turned into a method code simplification.
We do not need to check for user mobile number verification unless the 2FA is enabled in the environment, as the mobile number gets verified when passing 2FA.