### PR TITLE
Refactor suggestion: Extract Responsible Person related code to concern

### DIFF
--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -1,8 +1,34 @@
 module ResponsiblePersonConcern
   extend ActiveSupport::Concern
 
-  included do
-    before_action :validate_responsible_person
+  def create_or_join_responsible_person
+    return unless fully_signed_in_submit_user?
+    return unless current_user.mobile_number_verified?
+
+    responsible_person = current_responsible_person
+
+    if responsible_person.blank?
+      if current_user.responsible_persons.present?
+        redirect_to select_responsible_persons_path
+      else
+        redirect_to account_path(:overview)
+      end
+    elsif responsible_person.contact_persons.empty?
+      redirect_to new_responsible_person_contact_person_path(responsible_person)
+    end
+  end
+
+  def current_responsible_person
+    rp = current_user.responsible_persons.find_by id: session[:current_responsible_person_id]
+    if rp.nil? && current_user.responsible_persons.count == 1
+      current_user.responsible_persons.first
+    else
+      rp
+    end
+  end
+
+  def set_current_responsible_person(responsible_person)
+    session[:current_responsible_person_id] = responsible_person.id
   end
 
   def validate_responsible_person
@@ -10,6 +36,16 @@ module ResponsiblePersonConcern
 
     if @responsible_person != current_responsible_person
       redirect_to select_responsible_persons_path
+    end
+  end
+
+private
+
+  def fully_signed_in_submit_user?
+    if Rails.configuration.secondary_authentication_enabled
+      user_signed_in? && secondary_authentication_present?
+    else
+      user_signed_in?
     end
   end
 end

--- a/cosmetics-web/app/controllers/nanomaterial_notifications_controller.rb
+++ b/cosmetics-web/app/controllers/nanomaterial_notifications_controller.rb
@@ -1,6 +1,6 @@
 class NanomaterialNotificationsController < SubmitApplicationController
   before_action :set_responsible_person, only: %w[index new create]
-  include ResponsiblePersonConcern
+  before_action :validate_responsible_person
 
   before_action :set_nanomaterial_notification_from_url, only: %i[notified_to_eu update_notified_to_eu upload_file update_file review name update_name submit confirmation_page]
 

--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -2,7 +2,7 @@ require "will_paginate/array"
 
 class ResponsiblePersons::NotificationsController < SubmitApplicationController
   before_action :set_responsible_person
-  include ResponsiblePersonConcern
+  before_action :validate_responsible_person
   before_action :set_notification, only: %i[show edit confirm]
 
   def index

--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -2,8 +2,7 @@ class ResponsiblePersons::TeamMembersController < SubmitApplicationController
   before_action :set_responsible_person
   before_action :set_team_member, only: %i[new create]
   before_action :authorize_responsible_person, only: %i[index new create]
-  include ResponsiblePersonConcern
-  skip_before_action :validate_responsible_person, only: %i[join sign_out_before_joining]
+  before_action :validate_responsible_person, except: %i[join sign_out_before_joining]
 
   skip_before_action :authenticate_user!, only: :join
   skip_before_action :create_or_join_responsible_person

--- a/cosmetics-web/app/controllers/responsible_persons_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons_controller.rb
@@ -1,7 +1,7 @@
 class ResponsiblePersonsController < SubmitApplicationController
   before_action :set_responsible_person, only: %i[show]
   skip_before_action :create_or_join_responsible_person, only: %i[select change]
-  include ResponsiblePersonConcern
+  before_action :validate_responsible_person
 
   def show; end
 

--- a/cosmetics-web/app/controllers/submit_application_controller.rb
+++ b/cosmetics-web/app/controllers/submit_application_controller.rb
@@ -1,17 +1,11 @@
 class SubmitApplicationController < ApplicationController
+  include ResponsiblePersonConcern
+
   before_action :allow_only_submit_domain
   before_action :try_to_finish_account_setup
   before_action :has_accepted_declaration
   before_action :create_or_join_responsible_person
 
-  def current_responsible_person
-    rp = current_user.responsible_persons.find_by id: session[:current_responsible_person_id]
-    if rp.nil? && current_user.responsible_persons.count == 1
-      current_user.responsible_persons.first
-    else
-      rp
-    end
-  end
   helper_method :current_responsible_person
 
 private
@@ -29,36 +23,7 @@ private
     end
   end
 
-  def create_or_join_responsible_person
-    return unless fully_signed_in_submit_user?
-    return unless current_user.mobile_number_verified?
-
-    responsible_person = current_responsible_person
-
-    if responsible_person.blank?
-      if current_user.responsible_persons.present?
-        redirect_to select_responsible_persons_path
-      else
-        redirect_to account_path(:overview)
-      end
-    elsif responsible_person.contact_persons.empty?
-      redirect_to new_responsible_person_contact_person_path(responsible_person)
-    end
-  end
-
-  def fully_signed_in_submit_user?
-    if Rails.configuration.secondary_authentication_enabled
-      user_signed_in? && secondary_authentication_present?
-    else
-      user_signed_in?
-    end
-  end
-
   def authorize_user!
     redirect_to invalid_account_path if current_user && !current_user.is_a?(SubmitUser)
-  end
-
-  def set_current_responsible_person(responsible_person)
-    session[:current_responsible_person_id] = responsible_person.id
   end
 end


### PR DESCRIPTION
The idea originally [raised on the PR](https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/pull/1787#discussion_r512671382) was to either rename the concern into something more explicit like `ValidateCorrectResponsiblePersonConcern` or either keep `ResponsiblePersonConcern` but moving into it all the logic related to Responsible Person.

This PR shows the second approach where we basically wrap all the responsible person controller methods into the `ResponsiblePersonConcern` module, include it into the `SubmitApplicationController` and from there use the module methods on `before_action` calls as needed in the `SubmitApplicationController` or any of its inheriting controllers.

