### PR TITLE
Show user responsible person pending invitations after registration

### DIFF
--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -9,6 +9,8 @@ module ResponsiblePersonConcern
     if responsible_person.blank?
       if current_user.responsible_persons.present?
         redirect_to select_responsible_persons_path
+      elsif pending_responsible_person_invitations.any?
+        redirect_to account_path(:pending_invitations)
       else
         redirect_to account_path(:overview)
       end
@@ -46,5 +48,10 @@ private
     else
       user_signed_in?
     end
+  end
+
+  def pending_responsible_person_invitations
+    @pending_responsible_person_invitations ||=
+      PendingResponsiblePersonUser.where(email_address: current_user.email).includes(:responsible_person)
   end
 end

--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -9,6 +9,8 @@ module ResponsiblePersonConcern
     if responsible_person.blank?
       if current_user.responsible_persons.present?
         redirect_to select_responsible_persons_path
+      elsif pending_invitations.any?
+        redirect_to account_path(:pending_invitations)
       else
         redirect_to account_path(:overview)
       end

--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -9,7 +9,7 @@ module ResponsiblePersonConcern
     if responsible_person.blank?
       if current_user.responsible_persons.present?
         redirect_to select_responsible_persons_path
-      elsif pending_responsible_person_invitations.any?
+      elsif pending_invitations.any?
         redirect_to account_path(:pending_invitations)
       else
         redirect_to account_path(:overview)
@@ -50,24 +50,16 @@ private
     end
   end
 
-  def pending_responsible_person_invitations
-    @pending_responsible_person_invitations ||= invitations_grouped_by_responsible_person
+  def pending_responsible_persons_invitations_text
+    @pending_responsible_persons_invitations_text ||= PendingResponsiblePersonInvitationsPresenter
+      .new(pending_invitations)
+      .responsible_persons_invitations_text
   end
 
   def pending_invitations
-    PendingResponsiblePersonUser.where(email_address: current_user.email)
-                                .includes(:responsible_person, :inviting_user)
-                                .order(created_at: :desc)
-  end
-
-  def invitations_grouped_by_responsible_person
-    pending_invitations.each_with_object(ActiveSupport::OrderedHash.new) do |invitation, hash|
-      rp_id = invitation.responsible_person_id
-      if hash[rp_id]
-        hash[rp_id] << invitation
-      else
-        hash[rp_id] = [invitation]
-      end
-    end
+    @pending_invitations ||= PendingResponsiblePersonUser
+      .where(email_address: current_user.email)
+      .includes(:responsible_person, :inviting_user)
+      .order(created_at: :desc)
   end
 end

--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -56,7 +56,7 @@ private
 
   def pending_invitations
     PendingResponsiblePersonUser.where(email_address: current_user.email)
-                                .includes(:inviting_user)
+                                .includes(:responsible_person, :inviting_user)
                                 .order(created_at: :desc)
   end
 

--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -50,12 +50,6 @@ private
     end
   end
 
-  def pending_responsible_persons_invitations_text
-    @pending_responsible_persons_invitations_text ||= PendingResponsiblePersonInvitationsPresenter
-      .new(pending_invitations)
-      .responsible_persons_invitations_text
-  end
-
   def pending_invitations
     @pending_invitations ||= PendingResponsiblePersonUser
       .where(email_address: current_user.email)

--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -9,8 +9,6 @@ module ResponsiblePersonConcern
     if responsible_person.blank?
       if current_user.responsible_persons.present?
         redirect_to select_responsible_persons_path
-      elsif pending_invitations.any?
-        redirect_to account_path(:pending_invitations)
       else
         redirect_to account_path(:overview)
       end

--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -51,7 +51,23 @@ private
   end
 
   def pending_responsible_person_invitations
-    @pending_responsible_person_invitations ||=
-      PendingResponsiblePersonUser.where(email_address: current_user.email).includes(:responsible_person)
+    @pending_responsible_person_invitations ||= invitations_grouped_by_responsible_person
+  end
+
+  def pending_invitations
+    PendingResponsiblePersonUser.where(email_address: current_user.email)
+                                .includes(:inviting_user)
+                                .order(created_at: :desc)
+  end
+
+  def invitations_grouped_by_responsible_person
+    pending_invitations.each_with_object(ActiveSupport::OrderedHash.new) do |invitation, hash|
+      rp_id = invitation.responsible_person_id
+      if hash[rp_id]
+        hash[rp_id] << invitation
+      else
+        hash[rp_id] = [invitation]
+      end
+    end
   end
 end

--- a/cosmetics-web/app/controllers/registration/account_security_controller.rb
+++ b/cosmetics-web/app/controllers/registration/account_security_controller.rb
@@ -32,6 +32,8 @@ module Registration
       if (invitation = PendingResponsiblePersonUser.find_by(id: invitation_id))
         join_responsible_person_team_members_path(invitation.responsible_person_id,
                                                   invitation_token: invitation.invitation_token)
+      elsif pending_invitations.any?
+        account_path(:pending_invitations)
       else
         declaration_path
       end

--- a/cosmetics-web/app/controllers/registration/account_security_controller.rb
+++ b/cosmetics-web/app/controllers/registration/account_security_controller.rb
@@ -28,9 +28,10 @@ module Registration
     end
 
     def after_creation_path
-      if (pending_team_invitation = PendingResponsiblePersonUser.find_by(email_address: current_user.email))
-        join_responsible_person_team_members_path(pending_team_invitation.responsible_person_id,
-                                                  invitation_token: pending_team_invitation.invitation_token)
+      invitation_id = session.delete(:registered_from_responsible_person_invitation_id)
+      if (invitation = PendingResponsiblePersonUser.find_by(id: invitation_id))
+        join_responsible_person_team_members_path(invitation.responsible_person_id,
+                                                  invitation_token: invitation.invitation_token)
       else
         declaration_path
       end

--- a/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
@@ -6,7 +6,7 @@ class ResponsiblePersons::AccountWizardController < SubmitApplicationController
   # Using directly the id parameter as'step' is set to nil at this point and 'if' condition gets ignored. Wicked Wizard magic...
   skip_before_action :has_accepted_declaration, if: -> { params[:id] == "pending_invitations" }
   skip_before_action :create_or_join_responsible_person
-  before_action :pending_responsible_persons_invitations_text, if: -> { step == :pending_invitations }
+  before_action :pending_invitations, if: -> { step == :pending_invitations }
   before_action :clear_session, if: -> { step == :overview }
   before_action :set_responsible_person, only: %i[show update]
   before_action :store_responsible_person, only: %i[update]

--- a/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
@@ -4,7 +4,7 @@ class ResponsiblePersons::AccountWizardController < SubmitApplicationController
   steps :pending_invitations, :overview, :create_or_join_existing, :join_existing, :select_type, :enter_details
 
   skip_before_action :create_or_join_responsible_person
-  before_action :pending_responsible_person_invitations, if: -> { step == :pending_invitations }
+  before_action :pending_responsible_persons_invitations_text, if: -> { step == :pending_invitations }
   before_action :clear_session, if: -> { step == :overview }
   before_action :set_responsible_person, only: %i[show update]
   before_action :store_responsible_person, only: %i[update]

--- a/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
@@ -1,9 +1,10 @@
 class ResponsiblePersons::AccountWizardController < SubmitApplicationController
   include Wicked::Wizard
 
-  steps :overview, :create_or_join_existing, :join_existing, :select_type, :enter_details
+  steps :pending_invitations, :overview, :create_or_join_existing, :join_existing, :select_type, :enter_details
 
   skip_before_action :create_or_join_responsible_person
+  before_action :pending_responsible_person_invitations, if: -> { step == :pending_invitations }
   before_action :clear_session, if: -> { step == :overview }
   before_action :set_responsible_person, only: %i[show update]
   before_action :store_responsible_person, only: %i[update]

--- a/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
@@ -3,6 +3,8 @@ class ResponsiblePersons::AccountWizardController < SubmitApplicationController
 
   steps :pending_invitations, :overview, :create_or_join_existing, :join_existing, :select_type, :enter_details
 
+  # Using directly the id parameter as'step' is set to nil at this point and 'if' condition gets ignored. Wicked Wizard magic...
+  skip_before_action :has_accepted_declaration, if: -> { params[:id] == "pending_invitations" }
   skip_before_action :create_or_join_responsible_person
   before_action :pending_responsible_persons_invitations_text, if: -> { step == :pending_invitations }
   before_action :clear_session, if: -> { step == :overview }

--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -72,7 +72,9 @@ private
   end
 
   def set_team_member
-    @team_member = @responsible_person.pending_responsible_person_users.build(team_member_params)
+    @team_member = @responsible_person.pending_responsible_person_users.build(
+      team_member_params.merge(inviting_user: current_user),
+    )
   end
 
   def authorize_responsible_person

--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -42,6 +42,7 @@ class ResponsiblePersons::TeamMembersController < SubmitApplicationController
         u.save(validate: false)
       end
       bypass_sign_in(user)
+      session[:registered_from_responsible_person_invitation_id] = pending_request.id
       redirect_to registration_new_account_security_path
     end
   rescue ActiveRecord::RecordNotFound

--- a/cosmetics-web/app/models/pending_responsible_person_user.rb
+++ b/cosmetics-web/app/models/pending_responsible_person_user.rb
@@ -2,6 +2,7 @@ class PendingResponsiblePersonUser < ApplicationRecord
   INVITATION_TOKEN_VALID_FOR = 3 * 24 * 3600 # 3 days
   EMAIL_ERROR_MESSAGE_SCOPE = %i[activerecord errors models pending_responsible_person_user attributes email_address].freeze
 
+  belongs_to :inviting_user, class_name: :SubmitUser, inverse_of: :pending_responsible_person_users
   belongs_to :responsible_person
 
   validates :email_address,

--- a/cosmetics-web/app/models/pending_responsible_person_user.rb
+++ b/cosmetics-web/app/models/pending_responsible_person_user.rb
@@ -47,6 +47,7 @@ private
     PendingResponsiblePersonUser.where(
       responsible_person_id: responsible_person.id,
       email_address: email_address,
+      inviting_user: inviting_user,
     ).delete_all
   end
 end

--- a/cosmetics-web/app/models/pending_responsible_person_user.rb
+++ b/cosmetics-web/app/models/pending_responsible_person_user.rb
@@ -21,7 +21,7 @@ class PendingResponsiblePersonUser < ApplicationRecord
   end
 
   def expired?
-    invitation_token_expires_at < Time.zone.now
+    invitation_token_expires_at && invitation_token_expires_at < Time.zone.now
   end
 
   def refresh_token_expiration!

--- a/cosmetics-web/app/models/submit_user.rb
+++ b/cosmetics-web/app/models/submit_user.rb
@@ -9,6 +9,7 @@ class SubmitUser < User
   has_many :notification_files, dependent: :destroy
   has_many :responsible_person_users, dependent: :destroy, foreign_key: :user_id, inverse_of: :user
   has_many :responsible_persons, through: :responsible_person_users
+  has_many :pending_responsible_person_users, dependent: :destroy, foreign_key: :creator_id, inverse_of: :inviting_user
 
   has_one :user_attributes, dependent: :destroy
   validates :mobile_number, presence: true

--- a/cosmetics-web/app/presenters/pending_responsible_person_invitations_presenter.rb
+++ b/cosmetics-web/app/presenters/pending_responsible_person_invitations_presenter.rb
@@ -1,0 +1,64 @@
+class PendingResponsiblePersonInvitationsPresenter
+  include DateHelper
+
+  attr_reader :invitations
+
+  ACTIVE_INVITES_PREFIX = "Check your email inbox for your invite, sent".freeze
+  EXPIRED_INVITES_PREFIX = "Your invite has expired and needs to be resent. You were invited by".freeze
+
+  def initialize(invitations)
+    @invitations = invitations
+  end
+
+  def responsible_persons_invitations_text
+    responsible_persons_invitations.transform_values do |rp_invites|
+      if rp_invites.size == 1
+        single_invitation_text(rp_invites.first)
+      elsif rp_invites.size > 1
+        multiple_invitations_text(rp_invites)
+      end
+    end
+  end
+
+private
+
+  def responsible_persons_invitations
+    invitations.each_with_object(ActiveSupport::OrderedHash.new) do |invitation, hash|
+      responsible_person = invitation.responsible_person.name
+      if hash[responsible_person]
+        hash[responsible_person] << invitation
+      else
+        hash[responsible_person] = [invitation]
+      end
+    end
+  end
+
+  def single_invitation_text(invite)
+    if invite.expired?
+      "#{EXPIRED_INVITES_PREFIX} <span class='no-wrap'>#{invite.inviting_user.name}.</span>"
+    else
+      "#{ACTIVE_INVITES_PREFIX} <span class='no-wrap'>#{display_full_month_date(invite.created_at)}.</span>"
+    end
+  end
+
+  def multiple_invitations_text(invites)
+    if invites.all?(&:expired?)
+      EXPIRED_INVITES_PREFIX + " " + inviting_user_names_list(invites)
+    else
+      latest_invite_date = display_full_month_date(invites.reject(&:expired?).map(&:created_at).max)
+      "#{ACTIVE_INVITES_PREFIX} <span class='no-wrap'>#{latest_invite_date}.</span>"
+    end
+  end
+
+  def inviting_user_names_list(invites)
+    names_list = "<span class='no-wrap'>#{invites.first.inviting_user.name}</span>"
+    invites.drop(1).each_with_index do |invite, index|
+      names_list << if index == invites.size - 2 # Last element index after removing the first invite from the array
+                      " and <span class='no-wrap'>#{invite.inviting_user.name}.</span>"
+                    else
+                      ", <span class='no-wrap'>#{invite.inviting_user.name}</span>"
+                    end
+    end
+    names_list
+  end
+end

--- a/cosmetics-web/app/presenters/pending_responsible_person_invitations_presenter.rb
+++ b/cosmetics-web/app/presenters/pending_responsible_person_invitations_presenter.rb
@@ -10,7 +10,7 @@ class PendingResponsiblePersonInvitationsPresenter
     @invitations = invitations
   end
 
-  def responsible_persons_invitations_text
+  def invitations_text
     responsible_persons_invitations.transform_values do |rp_invites|
       if rp_invites.size == 1
         single_invitation_text(rp_invites.first)

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
@@ -4,11 +4,34 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
-    <% @pending_responsible_person_invitations.each do |invitation| %>
+    <% @pending_responsible_person_invitations.each do |_rp_id, invitations| %>
       <p>
-        <strong><%= invitation.responsible_person.name%></strong>
+        <strong><%= invitations.first.responsible_person.name%></strong>
         <br>
-        Check your email inbox for your invite, sent <%= display_full_month_date(invitation.created_at) %>.
+        <% if invitations.size > 1 %>
+          <% if invitations.all?(&:expired?) %>
+            <%
+              names_list = invitations.first.inviting_user.name
+              invitations.drop(1).each_with_index do |invitation, index|
+                if index == invitations.size - 2 # Last element index after removing the first invitation from the array
+                  names_list << " and #{invitation.inviting_user.name}"
+                else
+                  names_list << ", #{invitation.inviting_user.name}"
+                end
+              end
+            %>
+            Your invite has expired and needs to be resent. You were invited by <%= names_list %>.
+          <% else %>
+            Check your email inbox for your invite, sent <%= display_full_month_date(invitations.first.created_at) %>.
+          <% end %>
+        <% else %>
+          <% invitation = invitations.first %>
+          <% if invitation.expired? %>
+            Your invite has expired and needs to be resent. You were invited by <%= invitation.inviting_user.name %>."
+          <% else %>
+            Check your email inbox for your invite, sent <%= display_full_month_date(invitation.created_at) %>.
+          <% end %>
+        <% end %>
       </p>
     <% end %>
     <p>or</p>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
@@ -6,7 +6,7 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
     <% @pending_responsible_person_invitations.each do |_rp_id, invitations| %>
       <p>
-        <strong><%= invitations.first.responsible_person.name%></strong>
+        <span class="no-wrap"><strong><%= invitations.first.responsible_person.name%></strong></span>
         <br>
         <% if invitations.size > 1 %>
           <% if invitations.all?(&:expired?) %>
@@ -14,22 +14,22 @@
               names_list = invitations.first.inviting_user.name
               invitations.drop(1).each_with_index do |invitation, index|
                 if index == invitations.size - 2 # Last element index after removing the first invitation from the array
-                  names_list << " and #{invitation.inviting_user.name}"
+                  names_list << " and <span class='no-wrap'>#{invitation.inviting_user.name}</span>"
                 else
-                  names_list << ", #{invitation.inviting_user.name}"
+                  names_list << ", <span class='no-wrap'>#{invitation.inviting_user.name}</span>"
                 end
               end
             %>
-            Your invite has expired and needs to be resent. You were invited by <%= names_list %>.
+            Your invite has expired and needs to be resent. You were invited by <%= raw(names_list) %>.
           <% else %>
-            Check your email inbox for your invite, sent <%= display_full_month_date(invitations.first.created_at) %>.
+            Check your email inbox for your invite, sent <span class="no-wrap"><%= display_full_month_date(invitations.first.created_at) %>.</span>
           <% end %>
         <% else %>
           <% invitation = invitations.first %>
           <% if invitation.expired? %>
             Your invite has expired and needs to be resent. You were invited by <%= invitation.inviting_user.name %>."
           <% else %>
-            Check your email inbox for your invite, sent <%= display_full_month_date(invitation.created_at) %>.
+            Check your email inbox for your invite, sent <span class="no-wrap"><%= display_full_month_date(invitation.created_at) %>.</span>
           <% end %>
         <% end %>
       </p>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
@@ -4,7 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
-    <% @pending_responsible_persons_invitations_text.each do |rp_name, text| %>
+    <% invitations_text = PendingResponsiblePersonInvitationsPresenter.new(@pending_invitations).invitations_text %>
+    <% invitations_text.each do |rp_name, text| %>
       <p>
         <span class="no-wrap"><strong><%= rp_name %></strong></span>
         <br>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
@@ -1,0 +1,20 @@
+<% title = "Who do you want to submit cosmetic product notifications for?" %>
+<% page_title(title) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <% @pending_responsible_person_invitations.each do |invitation| %>
+      <p>
+        <strong><%= invitation.responsible_person.name%></strong>
+        <br>
+        Check your email inbox for your invite, sent <%= display_full_month_date(invitation.created_at) %>.
+      </p>
+    <% end %>
+    <p>or</p>
+    <p>
+      another organisation —
+      <%= link_to("create a new Responsible Person", account_path(:select_type), class: "govuk-link govuk-link--no-visited-state") %>.
+    </p>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/pending_invitations.html.erb
@@ -4,34 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
-    <% @pending_responsible_person_invitations.each do |_rp_id, invitations| %>
+    <% @pending_responsible_persons_invitations_text.each do |rp_name, text| %>
       <p>
-        <span class="no-wrap"><strong><%= invitations.first.responsible_person.name%></strong></span>
+        <span class="no-wrap"><strong><%= rp_name %></strong></span>
         <br>
-        <% if invitations.size > 1 %>
-          <% if invitations.all?(&:expired?) %>
-            <%
-              names_list = invitations.first.inviting_user.name
-              invitations.drop(1).each_with_index do |invitation, index|
-                if index == invitations.size - 2 # Last element index after removing the first invitation from the array
-                  names_list << " and <span class='no-wrap'>#{invitation.inviting_user.name}</span>"
-                else
-                  names_list << ", <span class='no-wrap'>#{invitation.inviting_user.name}</span>"
-                end
-              end
-            %>
-            Your invite has expired and needs to be resent. You were invited by <%= raw(names_list) %>.
-          <% else %>
-            Check your email inbox for your invite, sent <span class="no-wrap"><%= display_full_month_date(invitations.first.created_at) %>.</span>
-          <% end %>
-        <% else %>
-          <% invitation = invitations.first %>
-          <% if invitation.expired? %>
-            Your invite has expired and needs to be resent. You were invited by <%= invitation.inviting_user.name %>."
-          <% else %>
-            Check your email inbox for your invite, sent <span class="no-wrap"><%= display_full_month_date(invitation.created_at) %>.</span>
-          <% end %>
-        <% end %>
+        <%= sanitize(text, tags: %w(span)) %>
       </p>
     <% end %>
     <p>or</p>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/select_type.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/select_type.html.erb
@@ -1,10 +1,12 @@
 <% content_for :page_title, "Responsible person type" %>
 <% content_for :after_header do %>
-  <% if current_user.responsible_persons.none? %>
-    <%= link_to "Back", wizard_path(:create_or_join_existing), class: "govuk-back-link" %>
-  <% else %>
-    <%= link_to "Back", responsible_person_path(current_responsible_person), class: "govuk-back-link" %>
-  <% end %>
+  <% default_back_path =  if current_user.responsible_persons.none?
+                            wizard_path(:create_or_join_existing)
+                          else
+                            responsible_person_path(current_responsible_person)
+                          end
+  %>
+  <%= link_to "Back", request.referer.present? ? request.referer : default_back_path, class: "govuk-back-link" %>
 <% end %>
 
 <%= form_with model: @responsible_person, url: wizard_path, method: :put do |form| %>

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -17,6 +17,7 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Name</th>
           <th class="govuk-table__header" scope="col">Email address</th>
+          <th class="govuk-table__header" scope="col">Invited by</th>
           <th class="govuk-table__header" scope="col"></th>
         </tr>
       </thead>
@@ -25,6 +26,7 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">-</td>
             <td class="govuk-table__cell"><%= user.email_address %></td>
+            <td class="govuk-table__cell"><%= user.inviting_user.name %></td>
             <td class="govuk-table__cell"><%= link_to "Resend invitation", resend_invitation_responsible_person_team_member_path(@responsible_person, user) %></td>
           </tr>
         <% end %>
@@ -32,6 +34,7 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= user.name %></td>
             <td class="govuk-table__cell"><%= user.email_address %></td>
+            <td class="govuk-table__cell"></td>
             <td class="govuk-table__cell"></td>
           </tr>
         <% end %>

--- a/cosmetics-web/db/migrate/20201106130915_add_inviting_user_to_pending_responsible_person_users.rb
+++ b/cosmetics-web/db/migrate/20201106130915_add_inviting_user_to_pending_responsible_person_users.rb
@@ -1,0 +1,8 @@
+class AddInvitingUserToPendingResponsiblePersonUsers < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :pending_responsible_person_users, :inviting_user, references: :users, foreign_key: { to_table: :users }, type: :uuid, index: false
+    add_index :pending_responsible_person_users, :inviting_user_id, algorithm: :concurrently
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_28_092140) do
+ActiveRecord::Schema.define(version: 2020_11_06_130915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -180,7 +180,9 @@ ActiveRecord::Schema.define(version: 2020_10_28_092140) do
     t.bigint "responsible_person_id"
     t.string "invitation_token"
     t.datetime "invitation_token_expires_at"
+    t.uuid "inviting_user_id"
     t.index ["invitation_token"], name: "index_pending_responsible_person_users_on_invitation_token"
+    t.index ["inviting_user_id"], name: "index_pending_responsible_person_users_on_inviting_user_id"
     t.index ["responsible_person_id"], name: "index_pending_responsible_person_users_on_responsible_person_id"
   end
 
@@ -295,6 +297,7 @@ ActiveRecord::Schema.define(version: 2020_10_28_092140) do
   add_foreign_key "notification_files", "responsible_persons"
   add_foreign_key "notifications", "responsible_persons"
   add_foreign_key "pending_responsible_person_users", "responsible_persons"
+  add_foreign_key "pending_responsible_person_users", "users", column: "inviting_user_id"
   add_foreign_key "range_formulas", "components"
   add_foreign_key "responsible_person_users", "responsible_persons"
   add_foreign_key "trigger_question_elements", "trigger_questions"

--- a/cosmetics-web/spec/controllers/responsible_persons/team_members_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/team_members_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ResponsiblePersons::TeamMembersController, :with_stubbed_mailer, 
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:user) { create(:submit_user) }
   let(:email_address) { "user@example.com" }
-  let(:pending_responsible_person_user) { create(:pending_responsible_person_user, responsible_person: responsible_person) }
   let(:params) { { responsible_person_id: responsible_person.id, invitation_token: pending_responsible_person_user.invitation_token } }
 
   before do
@@ -16,6 +15,8 @@ RSpec.describe ResponsiblePersons::TeamMembersController, :with_stubbed_mailer, 
   end
 
   describe "GET #index" do
+    let(:params) { { responsible_person_id: responsible_person.id } }
+
     it "assigns @responsible_person" do
       get :index, params: params
       expect(assigns(:responsible_person)).to eq(responsible_person)
@@ -28,6 +29,8 @@ RSpec.describe ResponsiblePersons::TeamMembersController, :with_stubbed_mailer, 
   end
 
   describe "PUT #create" do
+    let(:params) { { responsible_person_id: responsible_person.id } }
+
     it "render back to add team member form if no email address added" do
       put(:create, params: params.merge(team_member: { email_address: "" }))
       expect(response).to render_template(:new)
@@ -36,6 +39,13 @@ RSpec.describe ResponsiblePersons::TeamMembersController, :with_stubbed_mailer, 
     it "render back to add team member form if user already a member of the team" do
       put(:create, params: params.merge(team_member: { email_address: responsible_person.responsible_person_users.first.email_address }))
       expect(response).to render_template(:new)
+    end
+
+    it "registers the user that created the invitation" do
+      expect {
+        put(:create, params: params.merge(team_member: { email_address: email_address }))
+      }.to change(PendingResponsiblePersonUser, :count).by(1)
+      expect(PendingResponsiblePersonUser.last.inviting_user).to eq user
     end
 
     it "sends responsible person invite email" do
@@ -53,6 +63,9 @@ RSpec.describe ResponsiblePersons::TeamMembersController, :with_stubbed_mailer, 
   end
 
   describe "GET #join" do
+    let(:pending_responsible_person_user) { create(:pending_responsible_person_user, responsible_person: responsible_person, inviting_user: user) }
+    let(:params) { { responsible_person_id: responsible_person.id, invitation_token: pending_responsible_person_user.invitation_token } }
+
     context "when signed in as the invited user" do
       before do
         invited_user = create(:submit_user, email: pending_responsible_person_user.email_address)

--- a/cosmetics-web/spec/factories/pending_responsible_person_users.rb
+++ b/cosmetics-web/spec/factories/pending_responsible_person_users.rb
@@ -5,11 +5,15 @@ FactoryBot.define do
     association :inviting_user, factory: :submit_user
 
     trait :expired do
-      # rubocop:disable Rails/SkipsModelValidations
-      after(:create) do |obj|
-        obj.update_attribute(:invitation_token_expires_at, 1.second.ago)
+      after(:stub, :build) do |obj|
+        obj.invitation_token_expires_at = 1.second.ago
       end
-      # rubocop:enable Rails/SkipsModelValidations
+
+      after(:create) do |obj|
+        # rubocop:disable Rails/SkipsModelValidations
+        obj.update_attribute(:invitation_token_expires_at, 1.second.ago)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
     end
   end
 end

--- a/cosmetics-web/spec/factories/pending_responsible_person_users.rb
+++ b/cosmetics-web/spec/factories/pending_responsible_person_users.rb
@@ -2,5 +2,14 @@ FactoryBot.define do
   factory :pending_responsible_person_user do
     sequence(:email_address) { |n| "pending#{n}@example.com" }
     association :responsible_person, factory: :responsible_person
+    association :inviting_user, factory: :submit_user
+
+    trait :expired do
+      # rubocop:disable Rails/SkipsModelValidations
+      after(:create) do |obj|
+        obj.update_attribute(:invitation_token_expires_at, 1.second.ago)
+      end
+      # rubocop:enable Rails/SkipsModelValidations
+    end
   end
 end

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    name { "John Doe" }
+    sequence(:name) { |n| "John Doe#{n}" }
     sequence(:email) { |n| "john.doe#{n}@example.org" }
     mobile_number { "07500 000 000" }
     password { "testpassword123" }

--- a/cosmetics-web/spec/features/creating_an_account_when_having_pending_responsible_person_invitations_spec.rb
+++ b/cosmetics-web/spec/features/creating_an_account_when_having_pending_responsible_person_invitations_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "Creating an account when having pending responsible person invitations", :with_2fa, :with_stubbed_notify, :with_stubbed_mailer, type: :feature do
+  let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+  let(:responsible_person2) { create(:responsible_person, :with_a_contact_person) }
+  let(:invited_user_email) { "invited_user@example.com" }
+  let(:user) { User.find_by(email: invited_user_email) }
+
+  before do
+    configure_requests_for_submit_domain
+  end
+
+  scenario "user is invited by multiple responsible persons" do
+    # Given user is already invited by more than one responsible persons
+    create(:pending_responsible_person_user,
+           email_address: invited_user_email,
+           responsible_person: responsible_person)
+    create(:pending_responsible_person_user,
+           email_address: invited_user_email,
+           responsible_person: responsible_person2)
+
+    # When user create an account with same email
+    user_creates_an_account_with_invitation_email
+
+    # Then user should see RP invites list showing when user is invited
+    expect(page).to have_css("h1", text: "Who do you want to submit cosmetic product notifications for?")
+    expect(page).to have_text(responsible_person.name)
+    expect(page).to have_text(responsible_person2.name)
+
+    # And create account link
+    expect(page).to have_link("create a new Responsible Person", href: "/responsible_persons/account/select_type")
+  end
+
+  def user_creates_an_account_with_invitation_email
+    visit "/"
+    click_on "Create an account"
+    expect(page).to have_current_path("/create-an-account")
+
+    fill_in "Full name", with: "Joe Doe"
+    fill_in "Email address", with: invited_user_email
+    click_button "Continue"
+
+    expect(page).to have_css("h1", text: "Check your email")
+    expect(page).to have_css(".govuk-body", text: "A message with a confirmation link has been sent to your email address.")
+
+    email = delivered_emails.last
+    expect(email.recipient).to eq invited_user_email
+    expect(email.personalization[:name]).to eq("Joe Doe")
+
+    verify_url = email.personalization[:verify_email_url]
+    visit verify_url
+
+    fill_in "Mobile number", with: "07000000000"
+    fill_in "Password", with: "userpassword", match: :prefer_exact
+    click_button "Continue"
+
+    expect_to_be_on_secondary_authentication_page
+    expect_user_to_have_received_sms_code(otp_code)
+    complete_secondary_authentication_with(otp_code)
+
+    expect_to_be_on_declaration_page
+    click_button "I confirm"
+  end
+end

--- a/cosmetics-web/spec/features/creating_an_account_when_having_pending_responsible_person_invitations_spec.rb
+++ b/cosmetics-web/spec/features/creating_an_account_when_having_pending_responsible_person_invitations_spec.rb
@@ -131,8 +131,5 @@ RSpec.describe "Creating an account when having pending responsible person invit
     expect_to_be_on_secondary_authentication_page
     expect_user_to_have_received_sms_code(otp_code)
     complete_secondary_authentication_with(otp_code)
-
-    expect_to_be_on_declaration_page
-    click_button "I confirm"
   end
 end

--- a/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
+++ b/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
@@ -105,8 +105,9 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "accepting an invitation for a new user when not signed in" do
-    pending = PendingResponsiblePersonUser.create(email_address: "newusertoregister@example.com",
-                                                  responsible_person: responsible_person)
+    pending = create(:pending_responsible_person_user,
+                     email_address: "newusertoregister@example.com",
+                     responsible_person: responsible_person)
 
     visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
     expect(page).to have_current_path("/account-security")
@@ -135,8 +136,9 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     responsible_person2 = create(:responsible_person, :with_a_contact_person)
     create(:responsible_person_user, user: invited_user, responsible_person: responsible_person2)
 
-    pending = PendingResponsiblePersonUser.create(email_address: invited_user.email,
-                                                  responsible_person: responsible_person)
+    pending = create(:pending_responsible_person_user,
+                     email_address: invited_user.email,
+                     responsible_person: responsible_person)
     visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
     sign_in(invited_user)
     expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/notifications")
@@ -250,8 +252,9 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     configure_requests_for_submit_domain
     sign_in invited_user
 
-    invitation = PendingResponsiblePersonUser.create(email_address: invited_user.email,
-                                                     responsible_person: responsible_person)
+    invitation = create(:pending_responsible_person_user,
+                        email_address: invited_user.email,
+                        responsible_person: responsible_person)
 
     join_path = "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{invitation.invitation_token}"
 
@@ -307,8 +310,9 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     configure_requests_for_submit_domain
     sign_in invited_user
 
-    pending = PendingResponsiblePersonUser.create(email_address: invited_user.email,
-                                                  responsible_person: responsible_person)
+    pending = create(:pending_responsible_person_user,
+                     email_address: invited_user.email,
+                     responsible_person: responsible_person)
 
     visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
     expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/notifications")
@@ -321,8 +325,9 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
 
     sign_in different_user
 
-    pending = PendingResponsiblePersonUser.create(email_address: invited_user.email,
-                                                  responsible_person: responsible_person)
+    pending = create(:pending_responsible_person_user,
+                     email_address: invited_user.email,
+                     responsible_person: responsible_person)
 
     visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
     expect(page).to have_css("h1", text: "You are already signed in")
@@ -404,8 +409,9 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   scenario "accepting an invitation for a new user for second time after originally accepting it without completing the user registration" do
     configure_requests_for_submit_domain
 
-    pending = PendingResponsiblePersonUser.create(email_address: "newusertoregister@example.com",
-                                                  responsible_person: responsible_person)
+    pending = create(:pending_responsible_person_user,
+                     email_address: "newusertoregister@example.com",
+                     responsible_person: responsible_person)
 
     # Invited user originally accepts the invitation
     visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
@@ -444,8 +450,9 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   scenario "accepting an invitation for an existent user when not signed in" do
     configure_requests_for_submit_domain
 
-    pending = PendingResponsiblePersonUser.create(email_address: invited_user.email,
-                                                  responsible_person: responsible_person)
+    pending = create(:pending_responsible_person_user,
+                     email_address: invited_user.email,
+                     responsible_person: responsible_person)
 
     visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
     expect(page).to have_css("h1", text: "Sign in")

--- a/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
+++ b/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
@@ -462,7 +462,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
 end
 
 def complete_secondary_authentication_for(user)
-  expect_user_to_have_received_sms_code(user.reload.direct_otp, user)
   expect_to_be_on_secondary_authentication_page
+  expect_user_to_have_received_sms_code(user.reload.direct_otp, user)
   complete_secondary_authentication_with(user.direct_otp)
 end

--- a/cosmetics-web/spec/models/pending_responsible_person_user_spec.rb
+++ b/cosmetics-web/spec/models/pending_responsible_person_user_spec.rb
@@ -31,13 +31,25 @@ RSpec.describe PendingResponsiblePersonUser, type: :model do
       expect(pending_responsible_person.errors[:email_address]).to include("This email address already belongs to member of this team")
     end
 
-    it "succeeds when the email is already in pending request but does not add a new instance" do
-      pending_responsible_person.save
-      pending_responsible_person_same_email = build(:pending_responsible_person_user, email_address: pending_responsible_person.email_address,
-                                                                                      responsible_person: pending_responsible_person.responsible_person)
+    context "when there is already a pending rp user for the email from the same inviting user" do
+      let(:duplicated_pending_responsible_person) do
+        build(:pending_responsible_person_user,
+              email_address: pending_responsible_person.email_address,
+              responsible_person: pending_responsible_person.responsible_person,
+              inviting_user: pending_responsible_person.inviting_user)
+      end
 
-      expect { pending_responsible_person_same_email.save }.not_to change(described_class, :count)
-      expect(pending_responsible_person_same_email.save).to be true
+      before do
+        pending_responsible_person.save
+      end
+
+      it "succeeds" do
+        expect(duplicated_pending_responsible_person.save).to be true
+      end
+
+      it "does not add a new instance" do
+        expect { duplicated_pending_responsible_person.save }.not_to change(described_class, :count)
+      end
     end
 
     context "when inviting existing search user (by mistake)" do

--- a/cosmetics-web/spec/policies/responsible_person_policy_spec.rb
+++ b/cosmetics-web/spec/policies/responsible_person_policy_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ResponsiblePersonPolicy, type: :policy do
     end
 
     it "permits when user is invited by responsible person" do
-      PendingResponsiblePersonUser.create(email_address: user.email, responsible_person: responsible_person)
+      create(:pending_responsible_person_user, email_address: user.email, responsible_person: responsible_person)
 
       expect(policy).to permit(:show)
     end

--- a/cosmetics-web/spec/presenters/pending_responsible_person_invitations_presenter_spec.rb
+++ b/cosmetics-web/spec/presenters/pending_responsible_person_invitations_presenter_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe PendingResponsiblePersonInvitationsPresenter do
+  describe "#invitations_by_responsible_person" do
+    subject(:presenter) { described_class.new(invitations) }
+
+    before do
+      travel_to Time.zone.local(2020, 11, 24)
+    end
+
+    context "when having invitations for different responsible persons" do
+      let(:invitations) { build_stubbed_list(:pending_responsible_person_user, 2) }
+
+      it "returns a hash with the responsible person names from the invitations as keys" do
+        expect(presenter.responsible_persons_invitations_text.keys)
+          .to eq [invitations.first.responsible_person.name, invitations.last.responsible_person.name]
+      end
+    end
+
+    context "when having a single invitation for a responsible person" do
+      let(:invitations) { [build_stubbed(:pending_responsible_person_user)] }
+
+      it "displays the date of invitation" do
+        rp_name = invitations.first.responsible_person.name
+        expect(presenter.responsible_persons_invitations_text[rp_name]).to eq(
+          "Check your email inbox for your invite, sent <span class='no-wrap'>24 November 2020.</span>",
+        )
+      end
+    end
+
+    context "when having a single expired invitation for a responsible person" do
+      let(:invitations) { [build_stubbed(:pending_responsible_person_user, :expired)] }
+
+      it "displays the name of the user who sent of invitation" do
+        rp_name = invitations.first.responsible_person.name
+        expect(presenter.responsible_persons_invitations_text[rp_name]).to eq(
+          "Your invite has expired and needs to be resent. " \
+          "You were invited by <span class='no-wrap'>#{invitations.first.inviting_user.name}.</span>",
+        )
+      end
+    end
+
+    context "when having multiple expired invitations for a responsible person" do
+      let(:invitations) do
+        build_stubbed_list(:pending_responsible_person_user, 3, :expired, responsible_person: build_stubbed(:responsible_person))
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it "displays the name of the user who sent of invitation" do
+        rp_name = invitations.first.responsible_person.name
+        expect(presenter.responsible_persons_invitations_text[rp_name]).to eq(
+          "Your invite has expired and needs to be resent. You were invited by " \
+          "<span class='no-wrap'>#{invitations.first.inviting_user.name}</span>, " \
+          "<span class='no-wrap'>#{invitations.second.inviting_user.name}</span> " \
+          "and <span class='no-wrap'>#{invitations.third.inviting_user.name}.</span>",
+        )
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+
+    context "when having multiple invitations including some expired for a responsible person" do
+      let(:responsible_person) { build_stubbed(:responsible_person) }
+      let(:invitations) do
+        [
+          build_stubbed(:pending_responsible_person_user, :expired, responsible_person: responsible_person, created_at: 3.days.ago),
+          build_stubbed(:pending_responsible_person_user, responsible_person: responsible_person, created_at: 1.day.ago),
+          build_stubbed(:pending_responsible_person_user, responsible_person: responsible_person),
+          build_stubbed(:pending_responsible_person_user, :expired, responsible_person: responsible_person, created_at: 2.days.ago),
+        ]
+      end
+
+      it "displays the date of the newest active invitation" do
+        rp_name = invitations.first.responsible_person.name
+        expect(presenter.responsible_persons_invitations_text[rp_name]).to eq(
+          "Check your email inbox for your invite, sent <span class='no-wrap'>24 November 2020.</span>",
+        )
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/presenters/pending_responsible_person_invitations_presenter_spec.rb
+++ b/cosmetics-web/spec/presenters/pending_responsible_person_invitations_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PendingResponsiblePersonInvitationsPresenter do
       let(:invitations) { build_stubbed_list(:pending_responsible_person_user, 2) }
 
       it "returns a hash with the responsible person names from the invitations as keys" do
-        expect(presenter.responsible_persons_invitations_text.keys)
+        expect(presenter.invitations_text.keys)
           .to eq [invitations.first.responsible_person.name, invitations.last.responsible_person.name]
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe PendingResponsiblePersonInvitationsPresenter do
 
       it "displays the date of invitation" do
         rp_name = invitations.first.responsible_person.name
-        expect(presenter.responsible_persons_invitations_text[rp_name]).to eq(
+        expect(presenter.invitations_text[rp_name]).to eq(
           "Check your email inbox for your invite, sent <span class='no-wrap'>24 November 2020.</span>",
         )
       end
@@ -33,7 +33,7 @@ RSpec.describe PendingResponsiblePersonInvitationsPresenter do
 
       it "displays the name of the user who sent of invitation" do
         rp_name = invitations.first.responsible_person.name
-        expect(presenter.responsible_persons_invitations_text[rp_name]).to eq(
+        expect(presenter.invitations_text[rp_name]).to eq(
           "Your invite has expired and needs to be resent. " \
           "You were invited by <span class='no-wrap'>#{invitations.first.inviting_user.name}.</span>",
         )
@@ -48,7 +48,7 @@ RSpec.describe PendingResponsiblePersonInvitationsPresenter do
       # rubocop:disable RSpec/ExampleLength
       it "displays the name of the user who sent of invitation" do
         rp_name = invitations.first.responsible_person.name
-        expect(presenter.responsible_persons_invitations_text[rp_name]).to eq(
+        expect(presenter.invitations_text[rp_name]).to eq(
           "Your invite has expired and needs to be resent. You were invited by " \
           "<span class='no-wrap'>#{invitations.first.inviting_user.name}</span>, " \
           "<span class='no-wrap'>#{invitations.second.inviting_user.name}</span> " \
@@ -71,7 +71,7 @@ RSpec.describe PendingResponsiblePersonInvitationsPresenter do
 
       it "displays the date of the newest active invitation" do
         rp_name = invitations.first.responsible_person.name
-        expect(presenter.responsible_persons_invitations_text[rp_name]).to eq(
+        expect(presenter.invitations_text[rp_name]).to eq(
           "Check your email inbox for your invite, sent <span class='no-wrap'>24 November 2020.</span>",
         )
       end

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -60,7 +60,7 @@ def expect_to_be_on_reset_password_page
 end
 
 def expect_to_be_on_declaration_page
-  expect(page).to have_current_path("/declaration")
+  expect(page).to have_current_path("/declaration", ignore_query: true)
 end
 
 def expect_to_be_on_check_your_email_page
@@ -81,9 +81,6 @@ def expect_incorrect_email_or_password
 end
 
 def otp_code(email = nil)
-  #  puts user
-
-  #  p SubmitUser.pluck(:direct_otp)
   user_with_code = User.find_by(email: email) || user
   user_with_code.reload.direct_otp
 end


### PR DESCRIPTION
[Ticket COSBETA-667](https://regulatorydelivery.atlassian.net/browse/COSBETA-667)

## Description
An email address has been invited to one/multiple responsible persons by one/multiple members of the team.
The user for that email instead of following the invitation link registers to the Submit Cosmetics service like any other user.
The user will be prompted with a page that will show the list of Responsible Persons they have been invited to.
For each Responsible Person the user has been invited to:
- If there are active invitations for that responsible person, the user will be displayed the date of the latest invitation sent.
- If all the invitations for that responsible person are expired, users will be displayed the name of the RP members who invited them, so they can contact them asking for be re-invited.

## Implementation notes
As part of the work, we added the possibility of having multiple invitations for the same email on the same responsible person, as long as the users who sent them are different. We modified the Team Members page to display the user who sent the invitation for the pending users elements, so they don't seem duplicated and each invitation can be re-sent independently through their link.

**Note: Ignore the line wrapping of the name on the screenshot, this has been fixed**
![Screenshot from 2020-11-09 12-27-02](https://user-images.githubusercontent.com/1227578/98541330-2a449880-2287-11eb-89f5-76f090736ba0.png)


![Screenshot from 2020-11-10 09-27-45](https://user-images.githubusercontent.com/1227578/98656094-2de42800-2338-11eb-8a42-68889d2d2c3c.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
