### PR TITLE
Bugfix: remove any invitations when joining team

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -33,7 +33,7 @@ class ResponsiblePersons::TeamMembersController < SubmitApplicationController
       user_joins_responsible_person(user, responsible_person)
       redirect_to responsible_person_notifications_path(responsible_person)
     else
-      set_user_from_invitation(pending_request, user)
+      login_user_from_invitation?(pending_request, user)
       redirect_to registration_new_account_security_path
     end
   rescue ActiveRecord::RecordNotFound
@@ -96,7 +96,7 @@ private
     set_current_responsible_person(responsible_person)
   end
 
-  def set_user_from_invitation(pending_request, user)
+  def login_user_from_invitation?(pending_request, user)
     # User will be already set at this point if was created but not completed security details
     user ||= SubmitUser.new(email: pending_request.email_address).tap do |u|
       u.dont_send_confirmation_instructions!

--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -31,8 +31,7 @@ class ResponsiblePersons::TeamMembersController < SubmitApplicationController
     if user&.account_security_completed?
       authenticate_user!
       responsible_person.add_user(user)
-      # delete accepted pending request
-      pending_request.delete
+      PendingResponsiblePersonUser.where(email_address: user.email).delete_all
 
       set_current_responsible_person(responsible_person)
       redirect_to responsible_person_notifications_path(responsible_person)

--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -27,21 +27,13 @@ class ResponsiblePersons::TeamMembersController < SubmitApplicationController
     user = SubmitUser.find_by(email: pending_request.email_address)
     return render("signed_as_another_user", locals: { user: user }) if signed_as_another_user?(pending_request)
 
-    responsible_person = pending_request.responsible_person
     if user&.account_security_completed?
       authenticate_user!
-      responsible_person.add_user(user)
-      PendingResponsiblePersonUser.where(email_address: user.email).delete_all
-
-      set_current_responsible_person(responsible_person)
+      responsible_person = pending_request.responsible_person
+      user_joins_responsible_person(user, responsible_person)
       redirect_to responsible_person_notifications_path(responsible_person)
     else
-      user ||= SubmitUser.new(email: pending_request.email_address).tap do |u|
-        u.dont_send_confirmation_instructions!
-        u.save(validate: false)
-      end
-      bypass_sign_in(user)
-      session[:registered_from_responsible_person_invitation_id] = pending_request.id
+      set_user_from_invitation(pending_request, user)
       redirect_to registration_new_account_security_path
     end
   rescue ActiveRecord::RecordNotFound
@@ -96,6 +88,22 @@ private
 
   def signed_as_another_user?(invitation)
     current_user && current_user.email != invitation.email_address
+  end
+
+  def user_joins_responsible_person(user, responsible_person)
+    responsible_person.add_user(user)
+    PendingResponsiblePersonUser.where(email_address: user.email).delete_all
+    set_current_responsible_person(responsible_person)
+  end
+
+  def set_user_from_invitation(pending_request, user)
+    # User will be already set at this point if was created but not completed security details
+    user ||= SubmitUser.new(email: pending_request.email_address).tap do |u|
+      u.dont_send_confirmation_instructions!
+      u.save(validate: false)
+    end
+    bypass_sign_in(user)
+    session[:registered_from_responsible_person_invitation_id] = pending_request.id
   end
 
   # See: SecondaryAuthenticationConcern

--- a/cosmetics-web/app/models/pending_responsible_person_user.rb
+++ b/cosmetics-web/app/models/pending_responsible_person_user.rb
@@ -14,7 +14,7 @@ class PendingResponsiblePersonUser < ApplicationRecord
   validate :email_address_not_in_team?
 
   before_create :generate_token
-  before_create :remove_duplicate_pending_responsible_users
+  before_create :remove_duplicate
 
   def self.key_validity_duration
     1.day
@@ -43,7 +43,7 @@ private
     end
   end
 
-  def remove_duplicate_pending_responsible_users
+  def remove_duplicate
     PendingResponsiblePersonUser.where(
       responsible_person_id: responsible_person.id,
       email_address: email_address,

--- a/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
+++ b/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
@@ -170,8 +170,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "re-sending an invitation to a new user that accepted the original invitation but didn't complete their user account" do
-    configure_requests_for_submit_domain
-
     team = create(:responsible_person, :with_a_contact_person)
     create(:responsible_person_user, user: invited_user, responsible_person: team)
 
@@ -278,7 +276,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "accepting an expired invitation for an existing user" do
-    configure_requests_for_submit_domain
     sign_in invited_user
 
     invitation = create(:pending_responsible_person_user,
@@ -297,7 +294,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "accepting an invitation for an existing user" do
-    configure_requests_for_submit_domain
     sign_in invited_user
 
     pending = create(:pending_responsible_person_user,
@@ -310,7 +306,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "accepting an invitation for an existent user when signed in as different user" do
-    configure_requests_for_submit_domain
     different_user = create(:submit_user, name: "John Doedifferent")
 
     sign_in different_user
@@ -337,8 +332,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "accepting an invitation for a new user when signed in as different user" do
-    configure_requests_for_submit_domain
-
     # User invites a new member to the team
     sign_in_as_member_of_responsible_person(responsible_person, user)
 
@@ -397,8 +390,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "accepting an invitation for a new user for second time after originally accepting it without completing the user registration" do
-    configure_requests_for_submit_domain
-
     pending = create(:pending_responsible_person_user,
                      email_address: "newusertoregister@example.com",
                      responsible_person: responsible_person)
@@ -438,8 +429,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "accepting an invitation for an existent user when not signed in" do
-    configure_requests_for_submit_domain
-
     pending = create(:pending_responsible_person_user,
                      email_address: invited_user.email,
                      responsible_person: responsible_person)
@@ -458,7 +447,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
   end
 
   scenario "following an invitation link with a token that does not match any invitation" do
-    configure_requests_for_submit_domain
     join_path = "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=8cfa59f3-6b61-44f9-871b-c471651f234b"
     visit join_path
 

--- a/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
+++ b/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
@@ -305,6 +305,28 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     expect(invited_user.responsible_persons).to include(responsible_person)
   end
 
+  scenario "accepting one of multiple invitations to same responsible person for an existing user" do
+    sign_in invited_user
+
+    pending = create(:pending_responsible_person_user,
+                     email_address: invited_user.email,
+                     responsible_person: responsible_person)
+
+    different_inviting_user = create(:submit_user)
+    create(:pending_responsible_person_user,
+           email_address: invited_user.email,
+           responsible_person: responsible_person,
+           inviting_user: different_inviting_user)
+
+    visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
+    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/notifications")
+    expect(invited_user.responsible_persons).to include(responsible_person)
+
+    # User only shows up once on the team members list
+    click_link "Team members"
+    expect(page).to have_text(invited_user.email).once
+  end
+
   scenario "accepting an invitation for an existent user when signed in as different user" do
     different_user = create(:submit_user, name: "John Doedifferent")
 

--- a/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
+++ b/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
@@ -104,47 +104,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     )
   end
 
-  scenario "accepting an invitation for a new user when not signed in" do
-    pending = create(:pending_responsible_person_user,
-                     email_address: "newusertoregister@example.com",
-                     responsible_person: responsible_person)
-
-    visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
-    expect(page).to have_current_path("/account-security")
-    expect(page).to have_css("h1", text: "Create an account")
-
-    fill_in "Full name", with: "Joe Doe"
-    fill_in "Mobile number", with: "07000000000"
-    fill_in "Password", with: "userpassword", match: :prefer_exact
-    click_button "Continue"
-
-    invited_user = SubmitUser.find_by!(email: "newusertoregister@example.com")
-    complete_secondary_authentication_for(invited_user)
-
-    expect(page).to have_current_path("/declaration", ignore_query: true)
-    expect(page).to have_css("h1", text: "Responsible Person Declaration")
-    click_button "I confirm"
-
-    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/notifications")
-    expect(page).to have_css("h1", text: "Your cosmetic products")
-
-    invited_user = SubmitUser.find_by!(email: "newusertoregister@example.com")
-    expect(invited_user.responsible_persons).to include(responsible_person)
-  end
-
-  scenario "accepting an invitation by an new user who belongs to another team" do
-    responsible_person2 = create(:responsible_person, :with_a_contact_person)
-    create(:responsible_person_user, user: invited_user, responsible_person: responsible_person2)
-
-    pending = create(:pending_responsible_person_user,
-                     email_address: invited_user.email,
-                     responsible_person: responsible_person)
-    visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
-    sign_in(invited_user)
-    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/notifications")
-    expect(page).to have_css("h1", text: "Your cosmetic products")
-  end
-
   scenario "sending an invitation to an user with an expired previous invitation" do
     create(:pending_responsible_person_user,
            email_address: invited_user.email,
@@ -179,6 +138,35 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
                            responsible_person: responsible_person.name },
       )
     end
+  end
+
+  scenario "re-sending an invitation" do
+    sign_in_as_member_of_responsible_person(responsible_person, user)
+
+    invitation = create(:pending_responsible_person_user, responsible_person: responsible_person)
+
+    team_path = "/responsible_persons/#{responsible_person.id}/team_members"
+    visit team_path
+
+    time_now = (Time.zone.at(Time.zone.now.to_i) + (PendingResponsiblePersonUser::INVITATION_TOKEN_VALID_FOR + 1))
+    travel_to time_now
+
+    click_on "Resend invitation"
+
+    complete_secondary_authentication_for(user)
+
+    expect(invitation.reload.invitation_token_expires_at).to eq(time_now + PendingResponsiblePersonUser::INVITATION_TOKEN_VALID_FOR)
+    email = delivered_emails.last
+
+    expect(email).to have_attributes(
+      recipient: invitation.email_address,
+      template: SubmitNotifyMailer::TEMPLATES[:responsible_person_invitation],
+      personalization: { invitation_url: "http://#{ENV['SUBMIT_HOST']}/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{invitation.invitation_token}",
+                         invite_sender: user.name,
+                         responsible_person: responsible_person.name },
+    )
+
+    expect(page.current_path).to eq team_path
   end
 
   scenario "re-sending an invitation to a new user that accepted the original invitation but didn't complete their user account" do
@@ -248,6 +236,47 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     )
   end
 
+  scenario "accepting an invitation for a new user when not signed in" do
+    pending = create(:pending_responsible_person_user,
+                     email_address: "newusertoregister@example.com",
+                     responsible_person: responsible_person)
+
+    visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
+    expect(page).to have_current_path("/account-security")
+    expect(page).to have_css("h1", text: "Create an account")
+
+    fill_in "Full name", with: "Joe Doe"
+    fill_in "Mobile number", with: "07000000000"
+    fill_in "Password", with: "userpassword", match: :prefer_exact
+    click_button "Continue"
+
+    invited_user = SubmitUser.find_by!(email: "newusertoregister@example.com")
+    complete_secondary_authentication_for(invited_user)
+
+    expect(page).to have_current_path("/declaration", ignore_query: true)
+    expect(page).to have_css("h1", text: "Responsible Person Declaration")
+    click_button "I confirm"
+
+    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/notifications")
+    expect(page).to have_css("h1", text: "Your cosmetic products")
+
+    invited_user = SubmitUser.find_by!(email: "newusertoregister@example.com")
+    expect(invited_user.responsible_persons).to include(responsible_person)
+  end
+
+  scenario "accepting an invitation by an new user who belongs to another team" do
+    responsible_person2 = create(:responsible_person, :with_a_contact_person)
+    create(:responsible_person_user, user: invited_user, responsible_person: responsible_person2)
+
+    pending = create(:pending_responsible_person_user,
+                     email_address: invited_user.email,
+                     responsible_person: responsible_person)
+    visit "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{pending.invitation_token}"
+    sign_in(invited_user)
+    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/notifications")
+    expect(page).to have_css("h1", text: "Your cosmetic products")
+  end
+
   scenario "accepting an expired invitation for an existing user" do
     configure_requests_for_submit_domain
     sign_in invited_user
@@ -265,45 +294,6 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
       expect(page).to have_css("h1", text: "This invitation has expired")
       expect(invited_user.responsible_persons).not_to include(responsible_person)
     end
-  end
-
-  scenario "Resending an invitation" do
-    sign_in_as_member_of_responsible_person(responsible_person, user)
-
-    invitation = create(:pending_responsible_person_user, responsible_person: responsible_person)
-
-    team_path = "/responsible_persons/#{responsible_person.id}/team_members"
-    visit team_path
-
-    time_now = (Time.zone.at(Time.zone.now.to_i) + (PendingResponsiblePersonUser::INVITATION_TOKEN_VALID_FOR + 1))
-    travel_to time_now
-
-    click_on "Resend invitation"
-
-    complete_secondary_authentication_for(user)
-
-    expect(invitation.reload.invitation_token_expires_at).to eq(time_now + PendingResponsiblePersonUser::INVITATION_TOKEN_VALID_FOR)
-    email = delivered_emails.last
-
-    expect(email).to have_attributes(
-      recipient: invitation.email_address,
-      template: SubmitNotifyMailer::TEMPLATES[:responsible_person_invitation],
-      personalization: { invitation_url: "http://#{ENV['SUBMIT_HOST']}/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{invitation.invitation_token}",
-                         invite_sender: user.name,
-                         responsible_person: responsible_person.name },
-    )
-
-    expect(page.current_path).to eq team_path
-  end
-
-  scenario "following an invitation link with a token that does not match any invitation" do
-    configure_requests_for_submit_domain
-    join_path = "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=8cfa59f3-6b61-44f9-871b-c471651f234b"
-    visit join_path
-
-    expect(page).to have_current_path("/")
-    expect(page).to have_css("h1", text: "Submit cosmetic product notifications")
-    expect(page).to have_link("Sign in")
   end
 
   scenario "accepting an invitation for an existing user" do
@@ -465,6 +455,16 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
 
     expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/notifications")
     expect(invited_user.responsible_persons).to include(responsible_person)
+  end
+
+  scenario "following an invitation link with a token that does not match any invitation" do
+    configure_requests_for_submit_domain
+    join_path = "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=8cfa59f3-6b61-44f9-871b-c471651f234b"
+    visit join_path
+
+    expect(page).to have_current_path("/")
+    expect(page).to have_css("h1", text: "Submit cosmetic product notifications")
+    expect(page).to have_link("Sign in")
   end
 end
 


### PR DESCRIPTION
[Ticket: COSBETA-939](https://regulatorydelivery.atlassian.net/browse/COSBETA-939)

Once an user joins a responsible person/team, any other pending invitations for that user need to be deleted.

Also included few tiny refactors like:
- extracting methods with meaningful name for flow readability.
- method rename.
- reorder few feature specs so similar scenarios are together.