### PR TITLE
Expose Redis port on docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
   redis:
     image: redis
     hostname: redis
+    ports:
+      - "6379:6379"
 
   cosmetics-web:
     command: ["./bin/rails", "s", "-p", "3000", "-b", "0.0.0.0"]


### PR DESCRIPTION
So we can connect to Redis running on Docker on local development.
Needed for running Sidekiq locally when Redis is dockerized.