### PR TITLE
Bugfix: Registration flow broken when 2FA is disabled

### DIFF
--- a/cosmetics-web/app/controllers/application_controller.rb
+++ b/cosmetics-web/app/controllers/application_controller.rb
@@ -73,8 +73,7 @@ private
   def authorize_user!; end
 
   def has_accepted_declaration
-    return unless user_signed_in?
-    return unless current_user.mobile_number_verified?
+    return unless user_signed_in? && current_user&.account_security_completed? && current_user&.mobile_number_verified?
 
     redirect_path = request.original_fullpath unless request.original_fullpath == root_path
 

--- a/cosmetics-web/app/controllers/application_controller.rb
+++ b/cosmetics-web/app/controllers/application_controller.rb
@@ -73,7 +73,9 @@ private
   def authorize_user!; end
 
   def has_accepted_declaration
-    return unless user_signed_in? && current_user&.account_security_completed? && current_user&.mobile_number_verified?
+    return unless user_signed_in?
+    return unless current_user&.account_security_completed?
+    return unless current_user&.mobile_number_verified?
 
     redirect_path = request.original_fullpath unless request.original_fullpath == root_path
 

--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -44,10 +44,14 @@ private
 
   def fully_signed_in_submit_user?
     if Rails.configuration.secondary_authentication_enabled
-      user_signed_in? && secondary_authentication_present? && current_user.mobile_number_verified?
+      fully_registered_user? && secondary_authentication_present? && current_user.mobile_number_verified?
     else
-      user_signed_in?
+      fully_registered_user?
     end
+  end
+
+  def fully_registered_user?
+    user_signed_in? && current_user&.account_security_completed?
   end
 
   def pending_invitations

--- a/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_concern.rb
@@ -44,14 +44,14 @@ private
 
   def fully_signed_in_submit_user?
     if Rails.configuration.secondary_authentication_enabled
-      fully_registered_user? && secondary_authentication_present? && current_user.mobile_number_verified?
+      current_user_fully_registered? && secondary_authentication_present? && current_user.mobile_number_verified?
     else
-      fully_registered_user?
+      current_user_fully_registered?
     end
   end
 
-  def fully_registered_user?
-    user_signed_in? && current_user&.account_security_completed?
+  def current_user_fully_registered?
+    current_user && current_user.account_security_completed?
   end
 
   def pending_invitations

--- a/cosmetics-web/app/controllers/registration/account_security_controller.rb
+++ b/cosmetics-web/app/controllers/registration/account_security_controller.rb
@@ -3,6 +3,8 @@ module Registration
     before_action :check_user
     skip_before_action :require_secondary_authentication
     skip_before_action :try_to_finish_account_setup
+    skip_before_action :has_accepted_declaration
+    skip_before_action :create_or_join_responsible_person
 
     def new
       @account_security_form = AccountSecurityForm.new(user: current_user)

--- a/cosmetics-web/app/controllers/registration/account_security_controller.rb
+++ b/cosmetics-web/app/controllers/registration/account_security_controller.rb
@@ -3,8 +3,6 @@ module Registration
     before_action :check_user
     skip_before_action :require_secondary_authentication
     skip_before_action :try_to_finish_account_setup
-    skip_before_action :has_accepted_declaration
-    skip_before_action :create_or_join_responsible_person
 
     def new
       @account_security_form = AccountSecurityForm.new(user: current_user)

--- a/cosmetics-web/app/controllers/users_controller.rb
+++ b/cosmetics-web/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < SearchApplicationController
     @user = SearchUser.find(params[:id])
     return render("errors/forbidden", status: :forbidden) if params[:invitation] != @user.invitation_token
 
-    @user.assign_attributes(new_user_attributes)
+    @user.assign_attributes(new_user_attributes.merge(account_security_completed: true))
 
     if @user.save(context: :registration_completion)
       sign_in :search_user, @user

--- a/cosmetics-web/spec/features/account/creating_an_account_from_an_invitation_spec.rb
+++ b/cosmetics-web/spec/features/account/creating_an_account_from_an_invitation_spec.rb
@@ -24,15 +24,7 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_mailer, :w
 
     fill_in "Enter security code", with: otp_code
     click_on "Continue"
-
-    # FIXME: TODO:
-    # For some reason, we dont have declaration, only when spec when is being run
-    # as single example
-    begin
-      click_button "I accept"
-    rescue StandardError
-      nil
-    end
+    click_button "I accept"
     expect_to_be_signed_in_as_search_user
 
     # Now sign out and use those credentials to sign back in
@@ -71,9 +63,6 @@ RSpec.feature "Creating an account from an invitation", :with_stubbed_mailer, :w
 
     fill_in "Enter security code", with: otp_code
     click_on "Continue"
-
-    # FIXME: TODO:
-    # For some reason, here we have declaration, but we dont have in happy path spec...
     click_button "I accept"
     expect_to_be_signed_in_as_search_user
   end

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -46,6 +46,43 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_stubbed_notify, :w
     expect_to_be_on_declaration_page
   end
 
+  scenario "user signs up and verifies its email with 2FA disabled for the environment", with_2fa: false do
+    visit "/"
+    click_on "Create an account"
+    expect(page).to have_current_path("/create-an-account")
+    # First attempt with validation errors
+    fill_in "Full name", with: ""
+    fill_in "Email address", with: "signing_up.example.com"
+    click_button "Continue"
+
+    expect(page).to have_current_path("/create-an-account")
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Enter your full name", href: "#full_name")
+    expect(page).to have_css("span#full_name-error", text: "Enter your full name")
+
+    expect(page).to have_link("Enter your email address", href: "#email")
+    expect(page).to have_css("span#email-error", text: "Enter your email address")
+
+    fill_in "Full name", with: "Joe Doe"
+    fill_in "Email address", with: "signing_up@example.com"
+    click_button "Continue"
+
+    expect_to_be_on_check_your_email_page
+
+    email = delivered_emails.last
+    expect(email.recipient).to eq "signing_up@example.com"
+    expect(email.personalization[:name]).to eq("Joe Doe")
+
+    verify_url = email.personalization[:verify_email_url]
+    visit verify_url
+
+    fill_in "Mobile number", with: "07000000000"
+    fill_in "Password", with: "userpassword", match: :prefer_exact
+    click_button "Continue"
+
+    expect_to_be_on_declaration_page
+  end
+
   scenario "user signs up and verifies its email with, confirmation expired during the process" do
     visit "/"
     click_on "Create an account"


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-961)

**Bugfixes:**
- Fix registration when 2FA is disabled, avoiding declaration being shown before account security step.
- Fix users registered through an invitation link not being marked as `account_security_completed`.

**First issue:**
Currently the registration flow is broken **when 2FA is disabled** due to the Responsible person Declaration and Creation/Join  filters being triggered in the account security step.

These filters are skipped when 2FA is enabled as, when reached at registration account security point, the user is not "signed in". But when 2FA is disabled, the user is "signed in" and the filters are applied.

In order to solve this we're extending the conditions, so the user needs to have completed its registration in order for the filters to run.

**Second issue**
There were some issues with the declaration page in the feature specs corresponding to the user registration through an invitation flow. By flagging "account_security_completed" when the user submits their username, password and mobile number, now the behaviour of the Declaration page became consistent through the specs.

