### PR TITLE
Setup Content Security Policy header for reporting (will not block resources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Start by setting up the following credentials:
     cf cups cosmetics-sentry-env -p '{
         "SENTRY_DSN": "XXX",
         "SENTRY_CURRENT_ENV": "<<SPACE>>"
+        "SENTRY_SECURITY_HEADER_ENDPOINT": "<<URL>>"
     }'
 
 * To enable and add basic auth to the entire application (useful for deployment or non-production environments):

--- a/cosmetics-web/app/views/layouts/_footer.html.erb
+++ b/cosmetics-web/app/views/layouts/_footer.html.erb
@@ -41,7 +41,7 @@
   </div>
 </footer>
 
-<script>
+<%= javascript_tag nonce: true do -%>
   if (typeof window.GOVUKFrontend === 'undefined') document.body.className = document.body.className.replace('js-enabled', '')
   window.GOVUKFrontend.initAll()
-</script>
+<% end -%>

--- a/cosmetics-web/app/views/layouts/_head.html.erb
+++ b/cosmetics-web/app/views/layouts/_head.html.erb
@@ -1,7 +1,7 @@
 <head>
   <% # Google Analytics %>
   <% if Rails.env.production? %>
-    <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-126364208-2">
+    <%= javascript_tag src: "https://www.googletagmanager.com/gtag/js?id=UA-126364208-2", async: true, nonce: true do -%>
       window.dataLayer = window.dataLayer || [];
 
       function gtag() {
@@ -10,7 +10,7 @@
 
       gtag('js', new Date());
       gtag('config', 'UA-126364208-2');
-    </script>
+    <% end -%>
   <% end %>
   <meta charset="utf-8" />
   <title><%= yield :page_title %><%= " - #{@service_name}" %></title>

--- a/cosmetics-web/app/views/layouts/_head.html.erb
+++ b/cosmetics-web/app/views/layouts/_head.html.erb
@@ -23,11 +23,11 @@
   <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_path("media/images/govuk-apple-touch-icon-152x152.png") %>">
   <link rel="apple-touch-icon" href="<%= asset_pack_path("media/images/govuk-apple-touch-icon.png") %>">
   <!--[if !IE 8]><!-->
-    <%= javascript_pack_tag "application" %>
+    <%= javascript_pack_tag "application", nonce: true %>
     <%= stylesheet_pack_tag "application" %>
   <!--<![endif]-->
   <!--[if lte IE 8]>
-    <%= javascript_pack_tag "application-ie8" %>
+    <%= javascript_pack_tag "application-ie8", nonce: true %>
     <%= stylesheet_pack_tag "application-ie8" %>
   <![endif]-->
   <%= csrf_meta_tags %>

--- a/cosmetics-web/app/views/layouts/_header.html.erb
+++ b/cosmetics-web/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
-<script>
+<%= javascript_tag nonce: true do -%>
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-</script>
+<% end -%>
 <a class="govuk-skip-link" href="#main-content">Skip to main content</a>
 
 <header class="govuk-header" role="banner" data-module="govuk-header">

--- a/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
@@ -51,9 +51,9 @@
 
 
 <% if params[:tab].present? %>
-  <script>
+  <%= javascript_tag nonce: true do -%>
     document.addEventListener("DOMContentLoaded", function() {
       window.location = window.location.href.split('#')[0] + '#<%= params[:tab] %>';
     })
-  </script>
+  <% end -%>
 <% end %>

--- a/cosmetics-web/config/initializers/content_security_policy.rb
+++ b/cosmetics-web/config/initializers/content_security_policy.rb
@@ -24,6 +24,18 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
 # Rails.application.config.content_security_policy_report_only = true
 
+Rails.application.config.content_security_policy_report_only = true
+
 Rails.application.config.content_security_policy do |policy|
   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, :https
+  policy.style_src   :self, :https
+
+  # Specify URI for violation reports
+  policy.report_uri ENV.fetch("SENTRY_SECURITY_HEADER_ENDPOINT", "")
 end

--- a/cosmetics-web/config/initializers/content_security_policy.rb
+++ b/cosmetics-web/config/initializers/content_security_policy.rb
@@ -27,6 +27,7 @@
 Rails.application.config.content_security_policy_report_only = true
 
 Rails.application.config.content_security_policy do |policy|
+  policy.base_uri    :self
   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
   policy.default_src :self, :https
   policy.font_src    :self, :https, :data

--- a/cosmetics-web/config/initializers/content_security_policy.rb
+++ b/cosmetics-web/config/initializers/content_security_policy.rb
@@ -26,15 +26,6 @@
 
 defaults = %i[self https]
 ga_urls = %w[https://www.googletagmanager.com https://www.google-analytics.com]
-# Modern browsers supporting CSP3 will apply "nonce + strict-dynamic" more restrictive policies. They will ignore "unsafe-inline".
-# "unsafe-inline" adds backwards compatibility with older browsers not supporting CSP3 .
-allowed_script_srcs = defaults + %i[strict_dynamic unsafe_inline] + ga_urls
-
-if Rails.env.production?
-  production_urls = %w[https://*.london.cloudapps.digital
-                       https://*.cosmetic-product-notifications.service.gov.uk]
-  allowed_script_srcs += production_urls
-end
 
 Rails.application.config.content_security_policy do |policy|
   policy.base_uri(:self)
@@ -43,7 +34,9 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src(*defaults, :data)
   policy.img_src(*defaults, :data, *ga_urls)
   policy.object_src(:none)
-  policy.script_src(*allowed_script_srcs)
+  # Modern browsers supporting CSP3 will apply "nonce + strict-dynamic" more restrictive policies. They will ignore "unsafe-inline".
+  # "unsafe-inline" adds backwards compatibility with older browsers not supporting nonce from CSP3
+  policy.script_src(*defaults, :strict_dynamic, :unsafe_inline, *ga_urls)
   policy.style_src(*defaults, :unsafe_inline)
 
   # Specify URI for violation reports

--- a/cosmetics-web/config/initializers/content_security_policy.rb
+++ b/cosmetics-web/config/initializers/content_security_policy.rb
@@ -30,11 +30,11 @@ Rails.application.config.content_security_policy do |policy|
   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
   policy.default_src :self, :https
   policy.font_src    :self, :https, :data
-  policy.img_src     :self, :https, :data, "https://www.google-analytics.com"
+  policy.img_src     :self, :https, :data, "google-analytics.com"
   policy.object_src  :none
   # Modern browsers supporting CSP3 will apply "nonce + strict-dynamic" more restrictive policies. They will ignore "unsafe-inline".
   # "unsafe-inline" adds backwards compatibility with older browsers not supporting CSP3 .
-  policy.script_src  :self, :https, "strict-dynamic", "unsafe-inline", "https://www.googletagmanager.com", "https://www.google-analytics.com"
+  policy.script_src  :self, :https, :strict_dynamic, :unsafe_inline, "googletagmanager.com", "google-analytics.com"
   policy.style_src   :self, :https, :unsafe_inline
 
   # Specify URI for violation reports

--- a/cosmetics-web/config/initializers/content_security_policy.rb
+++ b/cosmetics-web/config/initializers/content_security_policy.rb
@@ -34,7 +34,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.img_src     :self, :https, :data
   policy.object_src  :none
   policy.script_src  :self, :https
-  policy.style_src   :self, :https
+  policy.style_src   :self, :https, :unsafe_inline
 
   # Specify URI for violation reports
   policy.report_uri ENV.fetch("SENTRY_SECURITY_HEADER_ENDPOINT", "")

--- a/cosmetics-web/config/initializers/content_security_policy.rb
+++ b/cosmetics-web/config/initializers/content_security_policy.rb
@@ -28,12 +28,13 @@ Rails.application.config.content_security_policy_report_only = true
 
 Rails.application.config.content_security_policy do |policy|
   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
-
   policy.default_src :self, :https
   policy.font_src    :self, :https, :data
-  policy.img_src     :self, :https, :data
+  policy.img_src     :self, :https, :data, "https://www.google-analytics.com"
   policy.object_src  :none
-  policy.script_src  :self, :https
+  # Modern browsers supporting CSP3 will apply "nonce + strict-dynamic" more restrictive policies. They will ignore "unsafe-inline".
+  # "unsafe-inline" adds backwards compatibility with older browsers not supporting CSP3 .
+  policy.script_src  :self, :https, "strict-dynamic", "unsafe-inline", "https://www.googletagmanager.com", "https://www.google-analytics.com"
   policy.style_src   :self, :https, :unsafe_inline
 
   # Specify URI for violation reports

--- a/cosmetics-web/config/initializers/content_security_policy.rb
+++ b/cosmetics-web/config/initializers/content_security_policy.rb
@@ -39,3 +39,6 @@ Rails.application.config.content_security_policy do |policy|
   # Specify URI for violation reports
   policy.report_uri ENV.fetch("SENTRY_SECURITY_HEADER_ENDPOINT", "")
 end
+
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src]

--- a/cosmetics-web/env.example
+++ b/cosmetics-web/env.example
@@ -29,6 +29,7 @@ AWS_S3_BUCKET=
 
 # Sentry error monitoring
 SENTRY_DSN=
+SENTRY_SECURITY_HEADER_ENDPOINT=
 
 # Rails
 SECRET_KEY_BASE=


### PR DESCRIPTION
One of the outputs of a pentest auditory over the service was the need of setting the Content Security Policy header to decrease the chances of XSS attacks on the service users.

As starting point, we're enabling the CSP in "report only" mode. So the violations of the CSP will be reported to Sentry, but they won't be blocked.

The approach taken has been to add a "nonce" (some sort of id regenerated by each request) tagging the few inline scripts we have and the webpack js scripts. CSP will check that only the scripts with the correct nonce will be allowed to be loaded by the browsers.

So far the configuration we set up in this PR passes the check by Google CSP evaluation tool:
![image](https://user-images.githubusercontent.com/1227578/101626644-28e8c600-3a15-11eb-81d1-21111d52c8fe.png)


## Next Steps
1. Merging it into Staging and monitor warnings there.
2. Remove the "report only mode" so the non allowed sources get effectively blocked.