### PR TITLE
Add note about CF headers forwarding on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Start by setting up the following credentials:
         "BASIC_AUTH_PASSWORD": "XXX"
     }'
 
+    If the username/password set up in this step are not accepted when trying to visit the page, you may need to [forward the authorization header](https://docs.cloud.service.gov.uk/deploying_services/use_a_custom_domain/#forwarding-headers)
+
 * To enable and add basic auth to the health check endpoint at `/health/all`:
 
     cf cups cosmetics-health-env -p '{


### PR DESCRIPTION
After setting the auth for the service in Staging, I found myself blocked from visiting the page as the credentials weren't accepted.
@slawosz provided the solution as this happened before.

Adding it to the Readme so next person struggling with it will have a clue about what to do when this happens.