### PR TITLE
Change phone validations: Allow international phones. Apply validations everywhere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Inviting Search Users
 
 1. SSH to rails console (described below)
-2. Run `InviteUser.call name: 'Joe Doe', email: 'email@example.org', role: :poison_centre`
+2. Run `InviteSearchUser.call name: 'Joe Doe', email: 'email@example.org', role: :poison_centre`
 3. Role could be `poison_centre` or `msa`
 
 ## Getting Setup

--- a/cosmetics-web/app/forms/concerns/email_form_validation.rb
+++ b/cosmetics-web/app/forms/concerns/email_form_validation.rb
@@ -6,9 +6,9 @@ module EmailFormValidation
 
     validates :email,
               email: {
-                message: I18n.t(:wrong_format, scope: "sign_in_form.email"),
+                message: I18n.t(:wrong_format, scope: :email_form_validation),
                 if: ->(sign_in_form) { sign_in_form.email.present? },
               }
-    validates_presence_of :email, message: I18n.t(:blank, scope: "sign_in_form.email")
+    validates_presence_of :email, message: I18n.t(:blank, scope: :email_form_validation)
   end
 end

--- a/cosmetics-web/app/forms/registration/account_security_form.rb
+++ b/cosmetics-web/app/forms/registration/account_security_form.rb
@@ -14,7 +14,10 @@ module Registration
 
     validates_presence_of :full_name, message: error_message(:full_name, :blank), if: :name_required?
     validates :mobile_number, presence: true
-    validates :mobile_number, phone: { message: I18n.t(:invalid, scope: %i[activerecord errors models user attributes mobile_number]) }, if: -> { mobile_number.present? }
+    validates :mobile_number,
+              phone: { message: I18n.t(:invalid, scope: %i[activerecord errors models user attributes mobile_number]),
+                       allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },
+              if: -> { mobile_number.present? }
     validates :password, length: { minimum: 8 }, if: -> { password.present? }
     validates :password, presence: true
 

--- a/cosmetics-web/app/forms/registration/account_security_form.rb
+++ b/cosmetics-web/app/forms/registration/account_security_form.rb
@@ -11,8 +11,11 @@ module Registration
     validates_presence_of :full_name, if: :name_required?
     validates :mobile_number, presence: true
     validates :mobile_number,
-              phone: { message: :invalid, allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },
-              if: -> { mobile_number.present? }
+              phone: { message: :invalid, allow_international: true },
+              if: :validate_international_mobile_number?
+    validates :mobile_number,
+              phone: { message: :invalid, allow_international: false },
+              if: :validate_uk_mobile_number?
     validates :password, length: { minimum: 8 }, if: -> { password.present? }
     validates :password, presence: true
 
@@ -36,6 +39,14 @@ module Registration
 
     def name_required?
       user.name.blank?
+    end
+
+    def validate_uk_mobile_number?
+      mobile_number.present? && user && !user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER
+    end
+
+    def validate_international_mobile_number?
+      mobile_number.present? && user && user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER
     end
   end
 end

--- a/cosmetics-web/app/forms/registration/account_security_form.rb
+++ b/cosmetics-web/app/forms/registration/account_security_form.rb
@@ -15,8 +15,7 @@ module Registration
     validates_presence_of :full_name, message: error_message(:full_name, :blank), if: :name_required?
     validates :mobile_number, presence: true
     validates :mobile_number,
-              phone: { message: I18n.t(:invalid, scope: %i[activerecord errors models user attributes mobile_number]),
-                       allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },
+              phone: { message: :invalid, allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },
               if: -> { mobile_number.present? }
     validates :password, length: { minimum: 8 }, if: -> { password.present? }
     validates :password, presence: true

--- a/cosmetics-web/app/forms/registration/account_security_form.rb
+++ b/cosmetics-web/app/forms/registration/account_security_form.rb
@@ -8,11 +8,7 @@ module Registration
     attribute :user
     attribute :full_name
 
-    private_class_method def self.error_message(attr, key)
-      I18n.t(key, scope: "account_security.#{attr}")
-    end
-
-    validates_presence_of :full_name, message: error_message(:full_name, :blank), if: :name_required?
+    validates_presence_of :full_name, if: :name_required?
     validates :mobile_number, presence: true
     validates :mobile_number,
               phone: { message: :invalid, allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },

--- a/cosmetics-web/app/forms/registration/new_account_form.rb
+++ b/cosmetics-web/app/forms/registration/new_account_form.rb
@@ -5,11 +5,7 @@ module Registration
 
     attribute :full_name
 
-    private_class_method def self.error_message(attr, key)
-      I18n.t(key, scope: "new_account.#{attr}")
-    end
-
-    validates_presence_of :full_name, message: error_message(:full_name, :blank)
+    validates_presence_of :full_name
     include EmailFormValidation
 
     def save

--- a/cosmetics-web/app/forms/resend_secondary_authentication_code_form.rb
+++ b/cosmetics-web/app/forms/resend_secondary_authentication_code_form.rb
@@ -6,7 +6,7 @@ class ResendSecondaryAuthenticationCodeForm
   attribute :user
 
   validates_presence_of :mobile_number,
-                        message: I18n.t(:blank, scope: %i[resend_secondary_authentication_code_form mobile_number]),
+                        message: :blank,
                         if: -> { user.mobile_number_change_allowed? }
   validates :mobile_number,
             phone: { message: :invalid, allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },

--- a/cosmetics-web/app/forms/resend_secondary_authentication_code_form.rb
+++ b/cosmetics-web/app/forms/resend_secondary_authentication_code_form.rb
@@ -9,7 +9,6 @@ class ResendSecondaryAuthenticationCodeForm
                         message: I18n.t(:blank, scope: %i[resend_secondary_authentication_code_form mobile_number]),
                         if: -> { user.mobile_number_change_allowed? }
   validates :mobile_number,
-            phone: { message: I18n.t(:invalid, scope: %i[resend_secondary_authentication_code_form mobile_number]),
-                     allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },
+            phone: { message: :invalid, allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },
             if: -> { user.mobile_number_change_allowed? && mobile_number.present? }
 end

--- a/cosmetics-web/app/forms/resend_secondary_authentication_code_form.rb
+++ b/cosmetics-web/app/forms/resend_secondary_authentication_code_form.rb
@@ -6,9 +6,25 @@ class ResendSecondaryAuthenticationCodeForm
   attribute :user
 
   validates_presence_of :mobile_number,
-                        message: :blank,
                         if: -> { user.mobile_number_change_allowed? }
   validates :mobile_number,
-            phone: { message: :invalid, allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },
-            if: -> { user.mobile_number_change_allowed? && mobile_number.present? }
+            phone: { message: :invalid, allow_international: true },
+            if: :validate_international_mobile_number?
+  validates :mobile_number,
+            phone: { message: :invalid, allow_international: false },
+            if: :validate_uk_mobile_number?
+
+private
+
+  def validate_mobile_number?
+    user&.mobile_number_change_allowed? && mobile_number.present?
+  end
+
+  def validate_uk_mobile_number?
+    validate_mobile_number? && !user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER
+  end
+
+  def validate_international_mobile_number?
+    validate_mobile_number? && user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER
+  end
 end

--- a/cosmetics-web/app/forms/resend_secondary_authentication_code_form.rb
+++ b/cosmetics-web/app/forms/resend_secondary_authentication_code_form.rb
@@ -9,6 +9,7 @@ class ResendSecondaryAuthenticationCodeForm
                         message: I18n.t(:blank, scope: %i[resend_secondary_authentication_code_form mobile_number]),
                         if: -> { user.mobile_number_change_allowed? }
   validates :mobile_number,
-            phone: { message: I18n.t(:invalid, scope: %i[resend_secondary_authentication_code_form mobile_number]) },
+            phone: { message: I18n.t(:invalid, scope: %i[resend_secondary_authentication_code_form mobile_number]),
+                     allow_international: -> { user.class::ALLOW_INTERNATIONAL_PHONE_NUMBER } },
             if: -> { user.mobile_number_change_allowed? && mobile_number.present? }
 end

--- a/cosmetics-web/app/forms/responsible_person_details_form.rb
+++ b/cosmetics-web/app/forms/responsible_person_details_form.rb
@@ -17,10 +17,6 @@ class ResponsiblePersonDetailsForm
   validate :user_not_member_of_rp_with_same_name
   validate :user_not_invited_to_rp_with_same_name
 
-  private_class_method def self.error_message(attr, key)
-    I18n.t(key, scope: "responsible_person.#{attr}")
-  end
-
   def user_not_member_of_rp_with_same_name
     return if errors[:name].present?
 

--- a/cosmetics-web/app/forms/secondary_authentication_form.rb
+++ b/cosmetics-web/app/forms/secondary_authentication_form.rb
@@ -9,16 +9,14 @@ class SecondaryAuthenticationForm
 
   attr_accessor :user_klass
 
-  validates_presence_of :otp_code, message: I18n.t(".otp_code.blank")
+  validates_presence_of :otp_code
   validates :otp_code,
-            format: { with: INTEGER_REGEX, message: I18n.t(".otp_code.numericality") },
+            format: { with: INTEGER_REGEX, message: :numericality },
             allow_blank: true
   validates :otp_code,
             length: {
               maximum: SecondaryAuthentication::OTP_LENGTH,
-              too_long: I18n.t(".otp_code.too_long"),
               minimum: SecondaryAuthentication::OTP_LENGTH,
-              too_short: I18n.t(".otp_code.too_short"),
             },
             allow_blank: true,
             if: -> { INTEGER_REGEX.match?(otp_code) }
@@ -36,7 +34,7 @@ class SecondaryAuthenticationForm
     return if errors.present?
 
     unless secondary_authentication.valid_otp? otp_code
-      errors.add(:otp_code, I18n.t(".otp_code.incorrect"))
+      errors.add(:otp_code, :incorrect)
     end
   end
 
@@ -44,7 +42,7 @@ class SecondaryAuthenticationForm
     return if errors.present?
 
     if secondary_authentication.otp_locked?
-      errors.add(:otp_code, I18n.t(".otp_code.incorrect"))
+      errors.add(:otp_code, :incorrect)
     end
   end
 
@@ -52,7 +50,7 @@ class SecondaryAuthenticationForm
     return if errors.present?
 
     if secondary_authentication.otp_expired?
-      errors.add(:otp_code, I18n.t(".otp_code.expired"))
+      errors.add(:otp_code, :expired)
     end
   end
 

--- a/cosmetics-web/app/forms/sign_in_form.rb
+++ b/cosmetics-web/app/forms/sign_in_form.rb
@@ -4,5 +4,5 @@ class SignInForm
   include EmailFormValidation
 
   attribute :password
-  validates_presence_of :password, message: I18n.t(:blank, scope: "sign_in_form.password")
+  validates_presence_of :password
 end

--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -18,7 +18,7 @@ class SearchUser < User
   }
 
   validates :mobile_number,
-            phone: { message: I18n.t(:invalid),
+            phone: { message: :invalid,
                      allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
             if: -> { mobile_number.present? }
 

--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -18,8 +18,7 @@ class SearchUser < User
   }
 
   validates :mobile_number,
-            phone: { message: :invalid,
-                     allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
+            phone: { message: :invalid, allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
             if: -> { mobile_number.present? }
 
   def poison_centre_user?

--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -1,5 +1,6 @@
 class SearchUser < User
   INVITATION_EXPIRATION_DAYS = 14
+  ALLOW_INTERNATIONAL_PHONE_NUMBER = false
 
   # Include default devise modules. Others available are:
   devise :database_authenticatable,
@@ -15,6 +16,11 @@ class SearchUser < User
     poison_centre: "poison_centre",
     msa: "market_surveilance_authority",
   }
+
+  validates :mobile_number,
+            phone: { message: I18n.t(:invalid),
+                     allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
+            if: -> { mobile_number.present? }
 
   def poison_centre_user?
     poison_centre?

--- a/cosmetics-web/app/models/submit_user.rb
+++ b/cosmetics-web/app/models/submit_user.rb
@@ -16,7 +16,7 @@ class SubmitUser < User
   has_one :user_attributes, dependent: :destroy
   validates :mobile_number, presence: true
   validates :mobile_number,
-            phone: { message: I18n.t(:invalid),
+            phone: { message: :invalid,
                      allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
             if: -> { mobile_number.present? }
 

--- a/cosmetics-web/app/models/submit_user.rb
+++ b/cosmetics-web/app/models/submit_user.rb
@@ -1,4 +1,6 @@
 class SubmitUser < User
+  ALLOW_INTERNATIONAL_PHONE_NUMBER = true
+
   # Include default devise modules. Others available are:
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
@@ -13,6 +15,10 @@ class SubmitUser < User
 
   has_one :user_attributes, dependent: :destroy
   validates :mobile_number, presence: true
+  validates :mobile_number,
+            phone: { message: I18n.t(:invalid),
+                     allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
+            if: -> { mobile_number.present? }
 
   def self.confirm_by_token(token)
     user = super(token)

--- a/cosmetics-web/app/models/submit_user.rb
+++ b/cosmetics-web/app/models/submit_user.rb
@@ -16,8 +16,7 @@ class SubmitUser < User
   has_one :user_attributes, dependent: :destroy
   validates :mobile_number, presence: true
   validates :mobile_number,
-            phone: { message: :invalid,
-                     allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
+            phone: { message: :invalid, allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
             if: -> { mobile_number.present? }
 
   def self.confirm_by_token(token)

--- a/cosmetics-web/app/services/invite_search_user.rb
+++ b/cosmetics-web/app/services/invite_search_user.rb
@@ -1,4 +1,4 @@
-class InviteUser
+class InviteSearchUser
   include Interactor
 
   delegate :user, :role, :name, to: :context

--- a/cosmetics-web/app/validators/phone_validator.rb
+++ b/cosmetics-web/app/validators/phone_validator.rb
@@ -57,7 +57,7 @@ class PhoneValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     validate_phone_number(value, (options[:allow_international] || false))
   rescue InvalidPhoneError => e
-    record.errors[attribute] << (options[:message] || e.message)
+    record.errors.add(attribute, options[:message] || e.message)
   end
 
 private

--- a/cosmetics-web/app/validators/phone_validator.rb
+++ b/cosmetics-web/app/validators/phone_validator.rb
@@ -1,20 +1,109 @@
+# Validates the phone numbers following the validation rules stablished by
+# GOV.UK Notifications API in:
+# https://github.com/alphagov/notifications-utils/blob/master/notifications_utils/recipients.py
+#
+# The reasoning behind aligning the validations against gov uk API is that we want
+# to avoid allowing phone numbers that later are rejected by the Gov.uk API when
+# attempting to send them a 2FA code.
 class PhoneValidator < ActiveModel::EachValidator
-  ACCEPTED_PREFIXES = %w[7 07 447 4407 00447].freeze
-  DEFAULT_ERROR = "is not a valid phone number".freeze
-  ACCEPTED_LENGTH = 10
+  class InvalidPhoneError < StandardError; end
+  class PhoneTooShortError < InvalidPhoneError
+    def message
+      "Not enough digits"
+    end
+  end
+  class PhoneTooLongError < InvalidPhoneError
+    def message
+      "Too many digits"
+    end
+  end
+  class InvalidCountryError < InvalidPhoneError
+    def message
+      "Not a valid country prefix"
+    end
+  end
+  class NotUKPhoneError < InvalidPhoneError
+    def message
+      "Not a valid country prefix"
+    end
+  end
+  class BadFormatError < InvalidPhoneError
+    def message
+      "Must not contain letters or symbols"
+    end
+  end
+
+  WHITESPACES = [
+    " ",       # Standard whitespace
+    "\u180E",  # Mongolian vowel separator
+    "\u200B",  # zero width space
+    "\u200C",  # zero width non-joiner
+    "\u200D",  # zero width joiner
+    "\u2060",  # word joiner
+    "\u00A0",  # non breaking space
+    "\uFEFF",  # zero width non-breaking space
+  ].freeze
+  DOUBLE_ZERO = "00".freeze
+  INTERNATIONAL_MAX_LENGTH = 15
+  INTERNATIONAL_MIN_LENGTH = 8
+  INTERNATIONAL_CODES_FILE_PATH = "config/constants/international_phone_codes.yml".freeze
+  PHONE_NUMBER_SYMBOLS = %w[( ) + -].freeze
+  STRINGS_TO_CLEAN = WHITESPACES + PHONE_NUMBER_SYMBOLS
+  UK_MOBILE_LENGTH = 10
+  UK_MOBILE_PREFIX = "7".freeze
+  UK_PREFIX = "44".freeze
+  ZERO = "0".freeze
 
   def validate_each(record, attribute, value)
-    digits = value.delete("^0-9")
-
-    if !digits.start_with?(*ACCEPTED_PREFIXES) || normalised_number(digits).length != ACCEPTED_LENGTH
-      record.errors[attribute] << (options[:message] || DEFAULT_ERROR)
-    end
+    validate_phone_number(value, (options[:allow_international] || false))
+  rescue InvalidPhoneError => e
+    record.errors[attribute] << (options[:message] || e.message)
   end
 
 private
 
-  def normalised_number(phone_number)
-    _prefix, match, after = phone_number.partition("7")
-    match + after
+  def validate_phone_number(number, allow_international)
+    return validate_uk_phone_number(number) if uk_phone_number?(number)
+
+    raise NotUKPhoneError unless allow_international
+
+    number = normalise_phone_number(number)
+    raise PhoneTooShortError if number.length < INTERNATIONAL_MIN_LENGTH
+    raise PhoneTooLongError if number.length > INTERNATIONAL_MAX_LENGTH
+    raise InvalidCountryError if international_prefix(number).blank?
+
+    number
+  end
+
+  def uk_phone_number?(phone_number)
+    return true if phone_number.start_with?(ZERO) && !phone_number.start_with?(DOUBLE_ZERO)
+
+    number = normalise_phone_number(phone_number)
+    number.start_with?(UK_PREFIX) ||
+      (number.start_with?(UK_MOBILE_PREFIX) && number.length < 11)
+  end
+
+  def normalise_phone_number(number)
+    STRINGS_TO_CLEAN.each { |str| number.gsub!(str, "") }
+    if number.match?(/^\d+$/) # All characters are digits (and has at least one digit)
+      number.delete_prefix!(ZERO) while number.start_with?(ZERO)
+      number
+    else
+      raise BadFormatError
+    end
+  end
+
+  def validate_uk_phone_number(number)
+    number = normalise_phone_number(number).delete_prefix(UK_PREFIX).delete_prefix(ZERO)
+    raise NotUKPhoneError unless number.start_with?(UK_MOBILE_PREFIX)
+    raise PhoneTooLongError if number.length > UK_MOBILE_LENGTH
+    raise PhoneTooShortError if number.length < UK_MOBILE_LENGTH
+
+    UK_PREFIX + number
+  end
+
+  def international_prefix(number)
+    int_codes = YAML.load_file(Rails.root.join(INTERNATIONAL_CODES_FILE_PATH)).keys
+    int_codes.find { |code| number.start_with?(code) }
   end
 end

--- a/cosmetics-web/config/constants/international_phone_codes.yml
+++ b/cosmetics-web/config/constants/international_phone_codes.yml
@@ -1,0 +1,657 @@
+# List obtained from Gov Digital Service list of international billing rates.
+# https://github.com/alphagov/notifications-utils/blob/master/notifications_utils/international_billing_rates.yml
+#
+# This list is used by the GOV.UK Notify API (https://github.com/alphagov/notifications-api) to validate phone
+# numbers prior to send SMS through the service.
+# We use this API in order to send 2FA codes to Cosmetics users.
+---
+'1':
+  names:
+  - Canada
+  - United States
+  - Dominican Republic
+'7':
+  names:
+  - South Ossetia
+  - Kazakhstan
+  - Abkhazia
+  - Russian Federation
+'20':
+  names:
+  - Egypt
+'27':
+  names:
+  - South Africa
+'30':
+  names:
+  - Greece
+'31':
+  names:
+  - Netherlands
+'32':
+  names:
+  - Belgium
+'33':
+  names:
+  - France
+'34':
+  names:
+  - Spain
+'36':
+  names:
+  - Hungary
+'39':
+  names:
+  - Italy
+'40':
+  names:
+  - Romania
+'41':
+  names:
+  - Switzerland
+'43':
+  names:
+  - Austria
+'44':
+  names:
+  - Guernsey
+  - Isle of Man
+  - Jersey
+'45':
+  names:
+  - Denmark
+'46':
+  names:
+  - Sweden
+'47':
+  names:
+  - Norway
+'48':
+  names:
+  - Poland
+'49':
+  names:
+  - Germany
+'51':
+  names:
+  - Peru
+'52':
+  names:
+  - Mexico
+'53':
+  names:
+  - Cuba
+'54':
+  names:
+  - Argentina
+'55':
+  names:
+  - Brazil
+'56':
+  names:
+  - Chile
+'57':
+  names:
+  - Colombia
+'58':
+  names:
+  - Venezuela
+'60':
+  names:
+  - Malaysia
+'61':
+  names:
+  - Australia
+'62':
+  names:
+  - Indonesia
+'63':
+  names:
+  - Philippines
+'64':
+  names:
+  - New Zealand
+'65':
+  names:
+  - Singapore
+'66':
+  names:
+  - Thailand
+'81':
+  names:
+  - Japan
+'82':
+  names:
+  - Korea, Republic of
+'84':
+  names:
+  - Vietnam
+'86':
+  names:
+  - China
+'90':
+  names:
+  - Turkey
+  - Northern Cyprus
+'91':
+  names:
+  - India
+'92':
+  names:
+  - Pakistan
+'93':
+  names:
+  - Afghanistan
+'94':
+  names:
+  - Sri Lanka
+'95':
+  names:
+  - Myanmar
+'98':
+  names:
+  - Iran
+'211':
+  names:
+  - South Sudan
+'212':
+  names:
+  - Morocco
+'213':
+  names:
+  - Algeria
+'216':
+  names:
+  - Tunisia
+'218':
+  names:
+  - Libya
+'220':
+  names:
+  - Gambia
+'221':
+  names:
+  - Senegal
+'222':
+  names:
+  - Mauritania
+'223':
+  names:
+  - Mali
+'224':
+  names:
+  - Guinea
+'225':
+  names:
+  - Cote d'Ivoire
+'226':
+  names:
+  - Burkina Faso
+'227':
+  names:
+  - Niger
+'228':
+  names:
+  - Togo
+'229':
+  names:
+  - Benin
+'230':
+  names:
+  - Mauritius
+'231':
+  names:
+  - Liberia
+'232':
+  names:
+  - Sierra Leone
+'233':
+  names:
+  - Ghana
+'234':
+  names:
+  - Nigeria
+'235':
+  names:
+  - Chad
+'236':
+  names:
+  - Central African Republic
+'237':
+  names:
+  - Cameroon
+'238':
+  names:
+  - Cape Verde
+'239':
+  names:
+  - Sao Tome and Principe
+'240':
+  names:
+  - Equatorial Guinea
+'241':
+  names:
+  - Gabon
+'242':
+  names:
+  - Congo
+'243':
+  names:
+  - Congo, Democratic Republic of
+'244':
+  names:
+  - Angola
+'245':
+  names:
+  - Guinea-Bissau
+'246':
+  names:
+  - British Indian Ocean Territory
+'248':
+  names:
+  - Seychelles
+'249':
+  names:
+  - Sudan
+'250':
+  names:
+  - Rwanda, Republic of
+'251':
+  names:
+  - Ethiopia
+'252':
+  names:
+  - Somalia
+'253':
+  names:
+  - Djibouti, Republic of
+'254':
+  names:
+  - Kenya
+'255':
+  names:
+  - Tanzania
+'256':
+  names:
+  - Uganda
+'257':
+  names:
+  - Burundi
+'258':
+  names:
+  - Mozambique
+'260':
+  names:
+  - Zambia
+'261':
+  names:
+  - Madagascar
+'262':
+  names:
+  - Reunion
+'263':
+  names:
+  - Zimbabwe
+'264':
+  names:
+  - Namibia
+'265':
+  names:
+  - Malawi
+'266':
+  names:
+  - Lesotho
+'267':
+  names:
+  - Botswana
+'268':
+  names:
+  - Swaziland
+'269':
+  names:
+  - Comoros
+'297':
+  names:
+  - Aruba
+'298':
+  names:
+  - Faroe Islands
+'299':
+  names:
+  - Greenland
+'350':
+  names:
+  - Gibraltar
+'351':
+  names:
+  - Portugal
+'352':
+  names:
+  - Luxembourg
+'353':
+  names:
+  - Ireland
+'354':
+  names:
+  - Iceland
+'355':
+  names:
+  - Albania
+'356':
+  names:
+  - Malta
+'357':
+  names:
+  - Cyprus
+'358':
+  names:
+  - Finland
+'359':
+  names:
+  - Bulgaria
+'370':
+  names:
+  - Lithuania
+'371':
+  names:
+  - Latvia
+'372':
+  names:
+  - Estonia
+'373':
+  names:
+  - Moldova
+'374':
+  names:
+  - Armenia
+'375':
+  names:
+  - Belarus
+'376':
+  names:
+  - Andorra
+'377':
+  names:
+  - Monaco
+'378':
+  names:
+  - San Marino, Republic of
+'380':
+  names:
+  - Ukraine
+'381':
+  names:
+  - Serbia
+'382':
+  names:
+  - Montenegro
+'385':
+  names:
+  - Croatia
+'386':
+  names:
+  - Slovenia
+'387':
+  names:
+  - Bosnia and Herzegovina
+'389':
+  names:
+  - Macedonia
+'420':
+  names:
+  - Czech Republic
+'421':
+  names:
+  - Slovakia
+'423':
+  names:
+  - Liechtenstein
+'500':
+  names:
+  - Falkland Islands
+'501':
+  names:
+  - Belize
+'502':
+  names:
+  - Guatemala
+'503':
+  names:
+  - El Salvador
+'504':
+  names:
+  - Honduras
+'505':
+  names:
+  - Nicaragua
+'506':
+  names:
+  - Costa Rica
+'507':
+  names:
+  - Panama
+'508':
+  names:
+  - Saint Pierre and Miquelon
+'509':
+  names:
+  - Haiti
+'590':
+  names:
+  - Guadeloupe
+'591':
+  names:
+  - Bolivia
+'592':
+  names:
+  - Guyana
+'593':
+  names:
+  - Ecuador
+'594':
+  names:
+  - French Guiana
+'595':
+  names:
+  - Paraguay
+'596':
+  names:
+  - Martinique
+'597':
+  names:
+  - Suriname
+'598':
+  names:
+  - Uruguay
+'599':
+  names:
+  - Curacao (former Netherlands Antilles)
+'670':
+  names:
+  - Timor L'este
+'672':
+  names:
+  - Norfolk Island
+'673':
+  names:
+  - Brunei Darussalam
+'674':
+  names:
+  - Nauru
+'675':
+  names:
+  - Papua New Guinea
+'676':
+  names:
+  - Tonga
+'677':
+  names:
+  - Solomon Islands
+'678':
+  names:
+  - Vanuatu
+'679':
+  names:
+  - Fiji
+'680':
+  names:
+  - Palau
+'682':
+  names:
+  - Cook Islands
+'685':
+  names:
+  - Samoa
+'687':
+  names:
+  - New Caledonia
+'689':
+  names:
+  - French Polynesia
+'691':
+  names:
+  - Micronesia, Federated States of
+'692':
+  names:
+  - Marshall Islands
+'852':
+  names:
+  - Hong Kong
+'853':
+  names:
+  - Macau
+'855':
+  names:
+  - Cambodia
+'856':
+  names:
+  - Laos
+'880':
+  names:
+  - Bangladesh
+'886':
+  names:
+  - Taiwan
+'960':
+  names:
+  - Maldives
+'961':
+  names:
+  - Lebanon
+'962':
+  names:
+  - Jordan
+'963':
+  names:
+  - Syria
+'964':
+  names:
+  - Iraq
+'965':
+  names:
+  - Kuwait
+'966':
+  names:
+  - Saudi Arabia
+'967':
+  names:
+  - Yemen
+'968':
+  names:
+  - Oman
+'970':
+  names:
+  - Palestinian Territory
+'971':
+  names:
+  - United Arab Emirates
+'972':
+  names:
+  - Israel
+'973':
+  names:
+  - Bahrain
+'974':
+  names:
+  - Qatar
+'975':
+  names:
+  - Bhutan
+'976':
+  names:
+  - Mongolia
+'977':
+  names:
+  - Nepal
+'992':
+  names:
+  - Tajikistan
+'993':
+  names:
+  - Turkmenistan
+'994':
+  names:
+  - Azerbaijan
+'995':
+  names:
+  - Georgia
+'996':
+  names:
+  - Kyrgyzstan
+'998':
+  names:
+  - Uzbekistan
+'1242':
+  names:
+  - Bahamas
+'1246':
+  names:
+  - Barbados
+'1264':
+  names:
+  - Anguilla
+'1268':
+  names:
+  - Antigua and Barbuda
+'1284':
+  names:
+  - Virgin Islands, British
+'1345':
+  names:
+  - Cayman Islands
+'1441':
+  names:
+  - Bermuda
+'1473':
+  names:
+  - Grenada
+'1649':
+  names:
+  - Turks and Caicos Islands
+'1664':
+  names:
+  - Montserrat
+'1684':
+  names:
+  - American Samoa
+'1721':
+  names:
+  - Sint Maarten
+'1758':
+  names:
+  - Saint Lucia
+'1767':
+  names:
+  - Dominica, Commonwealth of
+'1784':
+  names:
+  - Saint Vincent and The Grenadines
+'1868':
+  names:
+  - Trinidad and Tobago
+'1869':
+  names:
+  - Saint Kitts and Nevis
+'1876':
+  names:
+  - Jamaica

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -155,6 +155,11 @@ en:
               too_short: "Password must be at least 8 characters"
             full_name:
               blank: "Enter your full name"
+        resend_secondary_authentication_code_form:
+          attributes:
+            mobile_number:
+              blank: "Enter your mobile number"
+              invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
         responsible_person_details_form:
           attributes:
             name:
@@ -211,10 +216,6 @@ en:
     incorrect: "Incorrect security code"
     expired: "The security code has expired. New code sent."
     numericality: "The code must be 5 numbers"
-  resend_secondary_authentication_code_form:
-    mobile_number:
-      blank: "Enter your mobile number"
-      invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
   sign_in_form:
     email:
       wrong_email_or_password: "Enter your email address in the correct format, like name@example.com"

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -128,7 +128,7 @@ en:
         user:
           attributes:
             mobile_number:
-              invalid: "Enter your mobile number in the correct format, like 07700 900 982"
+              invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
             password:
               too_short: "Password must be at least 8 characters"
         responsible_person:
@@ -148,7 +148,7 @@ en:
         registration/account_security_form:
           attributes:
             mobile_number:
-              invalid: "Enter your mobile number in the correct format, like 07700 900 982"
+              invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
               blank: "Please enter mobile number"
             password:
               blank: "Please enter password"
@@ -214,7 +214,7 @@ en:
   resend_secondary_authentication_code_form:
     mobile_number:
       blank: "Enter your mobile number"
-      invalid: "Enter your mobile number in the correct format, like 07700 900 982"
+      invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
   sign_in_form:
     email:
       wrong_email_or_password: "Enter your email address in the correct format, like name@example.com"
@@ -224,7 +224,7 @@ en:
       blank: "Enter your password"
   sign_up_form:
     mobile_number:
-      wrong_format: "Enter your mobile number in the correct format, like 07700 900 982"
+      wrong_format: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
       blank: "Enter your mobile number"
     name:
       blank: "Enter your name"
@@ -241,7 +241,7 @@ en:
       blank: "Enter your full name"
   account_security_form:
     mobile_number:
-      invalid: "Enter your mobile number in the correct format, like 07700 900 982"
+      invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
       blank: "Please enter mobile number"
   contact_person:
     email_address:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -145,6 +145,10 @@ en:
         postal_code: "Postcode"
     errors:
       models:
+        registration/new_account_form:
+          attributes:
+            full_name:
+              blank: "Enter your full name"
         registration/account_security_form:
           attributes:
             mobile_number:
@@ -165,6 +169,19 @@ en:
             name:
               member_of_rp_with_same_name: "You are already associated with %{attribute}"
               invited_to_rp_with_same_name: "You have already been invited to join %{attribute}. Check your email inbox for your invite"
+        secondary_authentication_form:
+          attributes:
+            otp_code:
+              blank: "Enter the security code"
+              too_short: "You haven’t entered enough numbers"
+              too_long: "You’ve entered too many numbers"
+              incorrect: "Incorrect security code"
+              expired: "The security code has expired. New code sent."
+              numericality: "The code must be 5 numbers"
+        sign_in_form:
+          attributes:
+            password:
+              blank: "Enter your password"
   enquiries_email: "opss.enquiries@beis.gov.uk"
   errors:
     format: "%{message}"
@@ -206,45 +223,18 @@ en:
       above_10: "Above 10"
       not_applicable: "No pH"
       not_given: "Not given"
-  users:
-    check_your_email:
-      body: A message with a confirmation link has been sent to your email address. Please follow the link to continue.
-  otp_code:
-    blank: "Enter the security code"
-    too_short: "You haven’t entered enough numbers"
-    too_long: "You’ve entered too many numbers"
-    incorrect: "Incorrect security code"
-    expired: "The security code has expired. New code sent."
-    numericality: "The code must be 5 numbers"
-  sign_in_form:
-    email:
-      wrong_email_or_password: "Enter your email address in the correct format, like name@example.com"
-      wrong_format: "Enter your email address in the correct format, like name@example.com"
-      blank: "Enter your email address"
-    password:
-      blank: "Enter your password"
-  sign_up_form:
-    mobile_number:
-      wrong_format: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
-      blank: "Enter your mobile number"
-    name:
-      blank: "Enter your name"
-    password:
-      blank: "Enter your password"
-    password_confirmation:
-      blank: "Enter your password confirmation"
-      missmatch: "Should match password"
-  sign_user_in:
-    email:
-      wrong_email_or_password: "Enter correct email address and password"
-  new_account:
-    full_name:
-      blank: "Enter your full name"
-  account_security_form:
-    mobile_number:
-      invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
-      blank: "Please enter mobile number"
   contact_person:
     email_address:
       wrong_format: "Enter your email address in the correct format, like name@example.com"
       blank: "Enter your email address"
+  email_form_validation:
+    wrong_email_or_password: "Enter your email address in the correct format, like name@example.com"
+    wrong_format: "Enter your email address in the correct format, like name@example.com"
+    blank: "Enter your email address"
+  users:
+    check_your_email:
+      body: A message with a confirmation link has been sent to your email address. Please follow the link to continue.
+  sign_user_in:
+    email:
+      wrong_email_or_password: "Enter correct email address and password"
+

--- a/cosmetics-web/spec/features/account/change_mobile_number_spec.rb
+++ b/cosmetics-web/spec/features/account/change_mobile_number_spec.rb
@@ -52,16 +52,22 @@ RSpec.describe "Changing mobile number", :with_2fa, :with_stubbed_mailer, :with_
       expect(page).to have_link("Password is incorrect", href: "#password")
     end
 
-    # Mobile number validation is tricky,
-    # but due to a nature of requirement of mobile verification,
-    # for now it can stay so
-    xit "does not get updated when new mobile number is empty" do
+    it "does not get updated when new mobile number is empty" do
       fill_in "Password", with: user.password
       fill_in "New mobile number", with: ""
       click_on "Continue"
 
       expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
       expect(page).to have_link("Mobile number can not be blank", href: "#mobile_number")
+    end
+
+    it "does not get updated when new mobile number has an incorrect format" do
+      fill_in "Password", with: user.password
+      fill_in "New mobile number", with: "12345678(wrong)9101112"
+      click_on "Continue"
+
+      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+      expect(page).to have_link("Enter a mobile number, like 07700 900 982 or +44 7700 900 982", href: "#mobile_number")
     end
   end
 end

--- a/cosmetics-web/spec/features/account/change_mobile_number_spec.rb
+++ b/cosmetics-web/spec/features/account/change_mobile_number_spec.rb
@@ -27,47 +27,44 @@ RSpec.describe "Changing mobile number", :with_2fa, :with_stubbed_mailer, :with_
     click_on "Continue"
   end
 
-  context "when the password change is fine" do
-    it "changes password properly" do
-      fill_in "Password", with: user.password
-      fill_in "New mobile number", with: "07234234234"
-      click_on "Continue"
+  it "updates the mobile number" do
+    fill_in "Password", with: user.password
+    fill_in "New mobile number", with: "07234234234"
+    click_on "Continue"
 
-      expect(page).to have_css("h1", text: "Check your phone")
-      fill_in "Enter security code", with: "#{otp_code} "
-      click_on "Continue"
+    expect(page).to have_css("h1", text: "Check your phone")
+    fill_in "Enter security code", with: "#{otp_code} "
+    click_on "Continue"
 
-      expect_to_be_on_my_account_page
-      expect(page).to have_text(/Mobile number changed successfully/)
-    end
+    expect_to_be_on_my_account_page
+    expect(page).to have_text(/Mobile number changed successfully/)
+    expect(page).to have_css("dd.govuk-summary-list__value", text: "07234234234")
   end
 
-  context "when the update cant be done" do
-    it "does not get updated when password is wrong" do
-      fill_in "Password", with: "user.password"
-      fill_in "New mobile number", with: "07500111000"
-      click_on "Continue"
+  it "does not get updated when password is wrong" do
+    fill_in "Password", with: "user.password"
+    fill_in "New mobile number", with: "07500111000"
+    click_on "Continue"
 
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Password is incorrect", href: "#password")
-    end
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Password is incorrect", href: "#password")
+  end
 
-    it "does not get updated when new mobile number is empty" do
-      fill_in "Password", with: user.password
-      fill_in "New mobile number", with: ""
-      click_on "Continue"
+  it "does not get updated when new mobile number is empty" do
+    fill_in "Password", with: user.password
+    fill_in "New mobile number", with: ""
+    click_on "Continue"
 
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Mobile number can not be blank", href: "#mobile_number")
-    end
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Mobile number can not be blank", href: "#mobile_number")
+  end
 
-    it "does not get updated when new mobile number has an incorrect format" do
-      fill_in "Password", with: user.password
-      fill_in "New mobile number", with: "12345678(wrong)9101112"
-      click_on "Continue"
+  it "does not get updated when new mobile number has an incorrect format" do
+    fill_in "Password", with: user.password
+    fill_in "New mobile number", with: "12345678(wrong)9101112"
+    click_on "Continue"
 
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Enter a mobile number, like 07700 900 982 or +44 7700 900 982", href: "#mobile_number")
-    end
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Enter a mobile number, like 07700 900 982 or +44 7700 900 982", href: "#mobile_number")
   end
 end

--- a/cosmetics-web/spec/features/account/creating_a_search_account_from_an_invitation_spec.rb
+++ b/cosmetics-web/spec/features/account/creating_a_search_account_from_an_invitation_spec.rb
@@ -9,15 +9,24 @@ RSpec.feature "Creating a Search account from an invitation", :with_stubbed_mail
     configure_requests_for_search_domain
   end
 
-  scenario "Creating an account from an invitation" do
+  scenario "Creating a Search account from an invitation" do
     email = delivered_emails.last
     invite_url = email.personalization[:invitation_url]
     visit invite_url
 
     expect_to_be_on_complete_registration_page
 
-    fill_in_account_details_with full_name: "Bob Jones", mobile_number: "07731123345", password: "testpassword123@"
+    # Attempts to complete registration with validation errors
+    # International numbers are not accepted for Search users.
+    fill_in_account_details_with full_name: "Bob Jones", mobile_number: "+34629010101", password: "testpassword123@"
+    click_button "Continue"
 
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Enter a mobile number, like 07700 900 982 or +44 7700 900 982", href: "#mobile_number")
+    expect(page).to have_css("span#mobile_number-error", text: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982")
+
+    # Second attempt with no validation issues
+    fill_in_account_details_with full_name: "Bob Jones", mobile_number: "07731123345", password: "testpassword123@"
     click_button "Continue"
 
     expect_to_be_on_secondary_authentication_page

--- a/cosmetics-web/spec/features/account/creating_a_search_account_from_an_invitation_spec.rb
+++ b/cosmetics-web/spec/features/account/creating_a_search_account_from_an_invitation_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 require "support/feature_helpers"
 
-RSpec.feature "Creating an account from an invitation", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, type: :feature do
-  let!(:invited_user) { InviteUser.call(email: "john.doe@example.com", name: "John Doe", role: :poison_centre).user }
+RSpec.feature "Creating a Search account from an invitation", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, type: :feature do
+  let!(:invited_user) { InviteSearchUser.call(email: "john.doe@example.com", name: "John Doe", role: :poison_centre).user }
   let(:existing_user) { create(:poison_centre_user) }
 
   before do

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_stubbed_notify, :w
     visit "/"
     click_on "Create an account"
     expect(page).to have_current_path("/create-an-account")
+
     # First attempt with validation errors
     fill_in "Full name", with: ""
     fill_in "Email address", with: "signing_up.example.com"
@@ -22,6 +23,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_stubbed_notify, :w
     expect(page).to have_link("Enter your email address", href: "#email")
     expect(page).to have_css("span#email-error", text: "Enter your email address")
 
+    # Second attempt with no validation issues
     fill_in "Full name", with: "Joe Doe"
     fill_in "Email address", with: "signing_up@example.com"
     click_button "Continue"
@@ -35,6 +37,18 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_stubbed_notify, :w
     verify_url = email.personalization[:verify_email_url]
     visit verify_url
 
+    # Attempts to submit security page with validation errors
+    expect(page).to have_current_path("/account-security")
+    fill_in "Mobile number", with: "07000 invalid 000000"
+    fill_in "Password", with: "userpassword", match: :prefer_exact
+    click_button "Continue"
+
+    expect(page).to have_current_path("/account-security")
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Enter a mobile number, like 07700 900 982 or +44 7700 900 982", href: "#mobile_number")
+    expect(page).to have_css("span#mobile_number-error", text: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982")
+
+    # Second attempt with no validation issues
     fill_in "Mobile number", with: "07000000000"
     fill_in "Password", with: "userpassword", match: :prefer_exact
     click_button "Continue"

--- a/cosmetics-web/spec/forms/registration/account_security_form_spec.rb
+++ b/cosmetics-web/spec/forms/registration/account_security_form_spec.rb
@@ -110,14 +110,14 @@ RSpec.describe Registration::AccountSecurityForm do
     context "when mobile number has letters" do
       include_examples "mobile number" do
         let(:mobile_number) { "070000assd" }
-        let(:message) { "Enter your mobile number in the correct format, like 07700 900 982" }
+        let(:message) { "Enter a mobile number, like 07700 900 982 or +44 7700 900 982" }
       end
     end
 
     context "when mobile number has not enough characters" do
       include_examples "mobile number" do
         let(:mobile_number) { "0700710120" }
-        let(:message) { "Enter your mobile number in the correct format, like 07700 900 982" }
+        let(:message) { "Enter a mobile number, like 07700 900 982 or +44 7700 900 982" }
       end
     end
   end

--- a/cosmetics-web/spec/forms/resend_secondary_authentication_code_form_spec.rb
+++ b/cosmetics-web/spec/forms/resend_secondary_authentication_code_form_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ResendSecondaryAuthenticationCodeForm, :with_stubbed_mailer, :wit
 
         it "contains errors" do
           form.valid?
-          expect(form.errors.full_messages_for(:mobile_number)).to eq ["Enter your mobile number in the correct format, like 07700 900 982"]
+          expect(form.errors.full_messages_for(:mobile_number)).to eq ["Enter a mobile number, like 07700 900 982 or +44 7700 900 982"]
         end
       end
 

--- a/cosmetics-web/spec/requests/user_requests_new_secondary_authentication_code_spec.rb
+++ b/cosmetics-web/spec/requests/user_requests_new_secondary_authentication_code_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "User requests new secondary authentication code", type: :request
       end
 
       context "when a mobile number is provided" do
-        let(:mobile_number) { "7123456789" }
+        let(:mobile_number) { "+(44)7123456789" }
 
         it "generates a new secondary authentication code for the user" do
           expect {

--- a/cosmetics-web/spec/requests/user_requests_new_secondary_authentication_code_spec.rb
+++ b/cosmetics-web/spec/requests/user_requests_new_secondary_authentication_code_spec.rb
@@ -108,6 +108,29 @@ RSpec.describe "User requests new secondary authentication code", type: :request
         end
       end
 
+      context "when an incorrect mobile number is provied" do
+        let(:mobile_number) { "00thisIsWrong" }
+
+        it "shows the submission form" do
+          request_code
+
+          expect(response).to render_template("secondary_authentications/resend_code/new")
+        end
+
+        it "does not change the user secondary authentication code" do
+          expect {
+            request_code
+            user.reload
+          }.not_to change(user, :direct_otp)
+        end
+
+        it "does not send any sms to the user" do
+          request_code
+
+          expect(notify_stub).not_to have_received(:send_sms)
+        end
+      end
+
       context "when a mobile number is provided" do
         let(:mobile_number) { "7123456789" }
 

--- a/cosmetics-web/spec/requests/user_requests_new_secondary_authentication_code_spec.rb
+++ b/cosmetics-web/spec/requests/user_requests_new_secondary_authentication_code_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "User requests new secondary authentication code", type: :request
       end
 
       context "when a mobile number is provided" do
-        let(:mobile_number) { "07123456789" }
+        let(:mobile_number) { "7123456789" }
 
         it "generates a new secondary authentication code for the user" do
           expect {

--- a/cosmetics-web/spec/validators/phone_validator_spec.rb
+++ b/cosmetics-web/spec/validators/phone_validator_spec.rb
@@ -1,71 +1,128 @@
 require "rails_helper"
 
 RSpec.describe PhoneValidator do
-  subject(:validator) do
-    Class.new {
+  subject(:validator) { validator_class.new(phone, allow_international) }
+
+  let(:error_msg) { "Enter a mobile number, like 07700 900 982 or +44 7700 900 982" }
+
+  let(:validator_class) do
+    Class.new do
       include ActiveModel::Validations
       attr_accessor :phone
+      attr_reader :allow_int
       validates :phone,
-                phone: {
-                  message: "Enter your mobile number in the correct format, like 07700 900 982",
-                }
-    }.new
-  end
+                phone: { message: ERROR_MSG, allow_international: true },
+                if: :allow_int
+      validates :phone,
+                phone: { message: ERROR_MSG, allow_international: false },
+                unless: :allow_int
 
-  valid_uk_phone_numbers = [
-    "7123456789",
-    "07123456789",
-    "07123 456789",
-    "07123-456-789",
-    "00447123456789",
-    "00 44 7123456789",
-    "+447123456789",
-    "+44 7123 456 789",
-    "+44 (0)7123 456 789",
-    "\u200B\t\t+44 (0)7123 \uFEFF 456 789 \r\n",
-  ]
-
-  valid_uk_phone_numbers.each do |phone_number|
-    context "with valid phone number #{phone_number}" do
-      before do
-        validator.phone = phone_number
-        validator.validate
+      def initialize(phone, allow_int)
+        @phone = phone
+        @allow_int = allow_int
       end
 
-      it "is valid" do
-        expect(validator).to be_valid
-      end
-
-      it "does not populate an error message" do
-        expect(validator.errors.messages[:phone]).to be_empty
+      def self.name
+        "ValidatorClass"
       end
     end
   end
 
-  invalid_phone_numbers = [
-    "712345671",
-    "71234567123",
-    "00123456789",
-    "+111123 456789",
-    "564544554455544",
-  ]
+  before { stub_const("ERROR_MSG", error_msg) }
 
-  invalid_phone_numbers.each do |phone_number|
-    context "with invalid phone number #{phone_number}" do
-      before do
-        validator.phone = phone_number
-        validator.validate
-      end
+  RSpec.shared_examples_for "valid phone numbers" do |valid_phone_numbers|
+    valid_phone_numbers.each do |phone_number|
+      context "with valid phone number #{phone_number}" do
+        let(:phone) { phone_number }
 
-      it "is not valid" do
-        expect(validator).not_to be_valid
-      end
+        before { validator.validate }
 
-      it "populates an error message" do
-        expect(validator.errors.messages[:phone]).to eq [
-          "Enter your mobile number in the correct format, like 07700 900 982",
-        ]
+        it "is valid" do
+          expect(validator).to be_valid
+        end
+
+        it "does not populate an error message" do
+          expect(validator.errors.messages[:phone]).to be_empty
+        end
       end
     end
+  end
+
+  RSpec.shared_examples_for "invalid phone numbers" do |invalid_phone_numbers|
+    invalid_phone_numbers.each do |phone_number|
+      context "with invalid phone number #{phone_number}" do
+        let(:phone) { phone_number }
+
+        before { validator.validate }
+
+        it "is not valid" do
+          expect(validator).not_to be_valid
+        end
+
+        it "populates an error message" do
+          expect(validator.errors.messages[:phone]).to eq [error_msg]
+        end
+      end
+    end
+  end
+
+  context "when international numbers are allowed" do
+    let(:allow_international) { true }
+
+    valid_phone_numbers = [
+      "7123456789",
+      "07123456789",
+      "07123 456789",
+      "07123-456-789",
+      "00447123456789",
+      "00 44 7123456789",
+      "+447123456789",
+      "+44 7123 456 789",
+      "+44 (0)7123 456 789",
+      "\u200B+44 (0)7123 \uFEFF 456 789", # Allowed whitespaces & characters
+      "+34629012345", # Spanish mobile number,
+      "71234567123",  # Too long UK number is valid as Russian phone.
+    ]
+
+    invalid_phone_numbers = [
+      "712345671",             # Too short
+      "7123LM6789",            # Not allowed characters
+      "+48123 45",             # Too short international phone
+      "+48123456789123456789", # Too long international phone
+      "+99029012345",          # '990' Country code not allowed
+      "009904567891",          # '990' Country code not allowed
+    ]
+
+    include_examples "valid phone numbers", valid_phone_numbers
+    include_examples "invalid phone numbers", invalid_phone_numbers
+  end
+
+  context "when international numbers are not allowed" do
+    let(:allow_international) { false }
+
+    valid_phone_numbers = [
+      "7123456789",
+      "07123456789",
+      "07123 456789",
+      "07123-456-789",
+      "00447123456789",
+      "00 44 7123456789",
+      "+447123456789",
+      "+44 7123 456 789",
+      "+44 (0)7123 456 789",
+      "\u200B+44 (0)7123 \uFEFF 456 789", # Allowed whitespaces & characters
+    ]
+
+    invalid_phone_numbers = [
+      "712345671",      # Too short
+      "71234567123",    # Too long
+      "7123LM6789",     # Not allowed characters
+      "00123456789",    # Not UK Phone
+      "+111123 456789", # Not UK Phone
+      "+34629012345",   # Not UK Phone
+    ]
+
+    include_examples "valid phone numbers", valid_phone_numbers
+    include_examples "invalid phone numbers", invalid_phone_numbers
   end
 end


### PR DESCRIPTION
[Jira Ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-896)


These changes include:
1. Allow international phone numbers for Submit Users.
2. Only allow UK phone numbers for Search Users.
3. Bring validations to the models, not only on the forms.
4. Align validations with GovUK API phone validations.
5. **Extra**: Refactor locales & form validation errors.

We want to allow Submit users to use international phone numbers.
As we want to avoid allowing users to set a phone number that will be rejected later by GovUK Notify API when trying to send a 2FA SMS, we decided to align our service phone number validations with GovUK Notify ones.

By duplicating the validations in both the forms and model we avoid situations where an user that got its phone number set outside one of the validated forms, ends with an invalid phone that later is rejected by GovUK Notify API (this is currently happening for users who registered through "Complete Registration" page following an invitation)

## Phone validations rules: 
- Phone is identified as UK phone if either:
  - Starts with "0" (but not "00"). 
  - Ignoring starting "0"s and removing special symbols (`+, spaces, -, (, )`):
    - Starts with UK prefix (44).
    - Starts with UK Mobile prefix(7) and its length is less than 11 digits.

- UK Phone numbers must: 
  - Start with UK Mobile prefix ("7") 
  - Be 10 digits long.

- Any phone number not identified as UK number is assumed to be an international phone number.

- International phone numbers must: 
  - Be between 8 and 15 digits length
  - Start with a prefix listed in the yaml file with the list of approved prefixes we introduced in the PR.

## Extra work
During the development of this ticket noticed that in multiple forms we had to specify the scope/route for the validation errors from the translations in the YAML locales files. 
This could be avoided by moving those errors into the correct YAML route/tree so the location can be automatically inferred by Rails and the error declaration becomes more succinct. 
As I was already doing it for the forms with the 2FA mobile phone validations, decided to refactor this on the rest of the forms and keep them consistent with the refactor.
