### PR TITLE
Bugfix: Antivirus flagging not communicated to users

### DIFF
--- a/cosmetics-web/app/analyzers/anti_virus_analyzer.rb
+++ b/cosmetics-web/app/analyzers/anti_virus_analyzer.rb
@@ -13,7 +13,7 @@ class AntiVirusAnalyzer < ActiveStorage::Analyzer
       { safe: body["safe"] }
     end
 
-    if metadata["safe"] == false && notification_file.present?
+    if metadata[:safe] == false && notification_file.present?
       notification_file.update(upload_error: :file_flagged_as_virus)
     end
 

--- a/cosmetics-web/spec/analyzers/anti_virus_analyzer_spec.rb
+++ b/cosmetics-web/spec/analyzers/anti_virus_analyzer_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe AntiVirusAnalyzer, type: :analyzer do
+  describe "#metadata" do
+    let(:analyzer) { described_class.new(blob) }
+    let(:notification_file) { create(:notification_file) }
+    let(:blob) do
+      ActiveStorage::Blob.create_after_upload!(
+        io: File.open(Rails.root.join("spec/fixtures/testImage.png"), "rb"),
+        filename: "testImage.png",
+        content_type: "image/png",
+      )
+    end
+
+    before do
+      allow(analyzer).to receive(:get_notification_file_from_blob).and_return(notification_file)
+    end
+
+    context "when the antivirus does not detect a virus", :with_stubbed_antivirus do
+      it "sets as not safe on the metadata" do
+        expect(analyzer.metadata).to eq({ safe: true })
+      end
+    end
+
+    context "when the antivirus detects a virus", :with_stubbed_antivirus_returning_false do
+      it "sets as safe on the metadata" do
+        expect(analyzer.metadata).to eq({ safe: false })
+      end
+
+      it "adds an upload error on the notification file" do
+        expect { analyzer.metadata }.to change(notification_file, :upload_error)
+                                    .from(nil)
+                                    .to("file_flagged_as_virus")
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
+++ b/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "ZIP file upload notifications", :with_stubbed_antivirus, type: :feature do
+RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :feature do
   let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
 
   before do
@@ -406,5 +406,25 @@ RSpec.describe "ZIP file upload notifications", :with_stubbed_antivirus, type: :
     click_button "Accept and submit the cosmetic product notification"
     expect_to_be_on__your_cosmetic_products_page
     expect_to_see_message "Multi-Item-Rangevalues_Exactvalues_Nano"
+  end
+
+  feature "detecting virus in attachments", :with_stubbed_antivirus_returning_false do
+    scenario "Using a zip file that contains a virus" do
+      visit new_responsible_person_add_notification_path(responsible_person)
+
+      expect_to_be_on__was_eu_notified_about_products_page
+      answer_was_eu_notified_with "Yes"
+
+      expect_to_be_on__do_you_have_the_zip_files_page
+      answer_do_you_have_zip_files_with "Yes"
+
+      expect_to_be_on__upload_eu_notification_files_page
+      upload_zip_file "testExportFile.zip"
+
+      visit responsible_person_notifications_path(responsible_person)
+
+      expect(page).to have_link("Errors (1)", href: "#errors")
+      expect_to_see_notification_error("The uploaded file has been flagged as a virus")
+    end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1001)

## Description
While working on refactoring bits of the antivirus-related code in other ticket, noticed that:
1) We don't have specs covering neither the antivirus analyzer nor the end to end flow when detecting a virus in an user uploaded file.
2) The tagging of files with virus error was not happening even when virus are detected. So the end-to-end flow of displaying a notification as "Error" when a virus is detected during the submission was broken.

## Low level description
The analyzer metadata generates a hash with symbols as keys, while the check against the metadata output was using strings as keys.

Because of the non existent key being queried, the check on metadata safety was always returning null value, not false. Hence the Notification File was never getting flagged with the "file flagged as virus" upload error, even when the metadata indicated so.

Added both unit specs for the AV analyzer and a feature spec to cover the virus detection flow end to end.
