### PR TITLE
Fix image upload page for flow with ZIP file containing a multi-component notification

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
@@ -13,7 +13,7 @@ class ResponsiblePersons::AdditionalInformationController < SubmitApplicationCon
       @notification.formulation_file_uploaded!
     end
 
-    if @notification.images_required_and_missing?
+    if @notification.required_images_missing_or_with_virus?
       return redirect_to new_responsible_person_notification_product_image_upload_path(@notification.responsible_person, @notification)
     end
 

--- a/cosmetics-web/app/controllers/responsible_persons/product_image_upload_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/product_image_upload_controller.rb
@@ -4,28 +4,38 @@ class ResponsiblePersons::ProductImageUploadController < SubmitApplicationContro
   def new; end
 
   def create
-    if params[:image_upload].present?
-      params[:image_upload].each do |image|
-        image_upload = @notification.image_uploads.build
-        image_upload.file.attach(image)
-        image_upload.filename = image.original_filename
-      end
+    return render_missing_file_error if params[:image_upload].blank?
 
-      if @notification.save
-        redirect_to responsible_person_notification_additional_information_index_path(@notification.responsible_person, @notification)
-      else
-        @notification.image_uploads.each do |image_upload|
-          image_upload.errors.messages[:file].map(&method(:add_error))
-        end
-        render :new
-      end
+    params[:image_upload].each { |img| add_image_to_notification(img) }
+    if @notification.save
+      redirect_to responsible_person_notification_additional_information_index_path(
+        @notification.responsible_person,
+        @notification,
+      )
     else
-      add_error "No file selected"
-      render :new
+      render_image_upload_errors
     end
   end
 
 private
+
+  def render_missing_file_error
+    add_error "No file selected"
+    render :new
+  end
+
+  def add_image_to_notification(image)
+    image_upload = @notification.image_uploads.build
+    image_upload.file.attach(image)
+    image_upload.filename = image.original_filename
+  end
+
+  def render_image_upload_errors
+    @notification.image_uploads.each do |image_upload|
+      image_upload.errors.messages[:file].map(&method(:add_error))
+    end
+    render :new
+  end
 
   def add_error(error_message)
     @error_list.push(text: error_message, href: "#image_upload")

--- a/cosmetics-web/app/controllers/responsible_persons/product_image_upload_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/product_image_upload_controller.rb
@@ -6,7 +6,7 @@ class ResponsiblePersons::ProductImageUploadController < SubmitApplicationContro
   def create
     return render_missing_file_error if params[:image_upload].blank?
 
-    params[:image_upload].each { |img| add_image_to_notification(img) }
+    params[:image_upload].each { |img| @notification.add_image(img) }
     if @notification.save
       redirect_to responsible_person_notification_additional_information_index_path(
         @notification.responsible_person,
@@ -22,12 +22,6 @@ private
   def render_missing_file_error
     add_error "No file selected"
     render :new
-  end
-
-  def add_image_to_notification(image)
-    image_upload = @notification.image_uploads.build
-    image_upload.file.attach(image)
-    image_upload.filename = image.original_filename
   end
 
   def render_image_upload_errors

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -163,11 +163,7 @@ private
 
   def render_add_product_image_step
     if params[:image_upload].present?
-      params[:image_upload].each do |image|
-        image_upload = @notification.image_uploads.build
-        image_upload.file.attach(image)
-        image_upload.filename = image.original_filename
-      end
+      params[:image_upload].each { |img| @notification.add_image(img) }
       @notification.save
       if @notification.is_multicomponent?
         render_wizard @notification

--- a/cosmetics-web/app/models/image_upload.rb
+++ b/cosmetics-web/app/models/image_upload.rb
@@ -12,15 +12,24 @@ class ImageUpload < ApplicationRecord
     file.attachment.present?
   end
 
-  def file_missing?
-    !file_exists?
+  def failed_antivirus_check?
+    # File is deleted when antivirus check flags it as a virus.
+    !file_exists? && virus_safe == false
   end
 
-  def marked_as_safe?
-    file_exists? && metadata_safe
+  def passed_antivirus_check?
+    # We want to return 'false' (not nil) when the virus_safe is 'nil'
+    file_exists? && virus_safe == true
   end
 
-  def metadata_safe
+  def pending_antivirus_check?
+    # If is 'false' is not pending.
+    file_exists? && virus_safe.nil?
+  end
+
+private
+
+  def virus_safe
     return true if ENV["ANTIVIRUS_ENABLED"] == "false"
 
     file.metadata["safe"]

--- a/cosmetics-web/app/models/image_upload.rb
+++ b/cosmetics-web/app/models/image_upload.rb
@@ -13,8 +13,7 @@ class ImageUpload < ApplicationRecord
   end
 
   def failed_antivirus_check?
-    # File is deleted when antivirus check flags it as a virus.
-    !file_exists? && virus_safe == false
+    file_exists? && virus_safe == false
   end
 
   def passed_antivirus_check?
@@ -23,7 +22,6 @@ class ImageUpload < ApplicationRecord
   end
 
   def pending_antivirus_check?
-    # If is 'false' is not pending.
     file_exists? && virus_safe.nil?
   end
 

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -97,6 +97,13 @@ class Notification < ApplicationRecord
     sprintf("UKCP-%08d", reference_number)
   end
 
+  def add_image(image)
+    image_uploads.build.tap do |upload|
+      upload.file.attach(image)
+      upload.filename = image.original_filename
+    end
+  end
+
   def images_are_present_and_safe?
     !image_uploads.empty? && image_uploads.all?(&:marked_as_safe?)
   end

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -105,17 +105,15 @@ class Notification < ApplicationRecord
   end
 
   def images_are_present_and_safe?
-    !image_uploads.empty? && image_uploads.all?(&:marked_as_safe?)
+    !image_uploads.empty? && image_uploads.all?(&:passed_antivirus_check?)
   end
 
   def images_failed_anti_virus_check?
-    image_uploads.any?(&:file_missing?)
+    image_uploads.any?(&:failed_antivirus_check?)
   end
 
   def images_pending_anti_virus_check?
-    image_uploads.any? do |image|
-      image.file_exists? && !image.marked_as_safe?
-    end
+    image_uploads.any?(&:pending_antivirus_check?)
   end
 
   def to_param

--- a/cosmetics-web/app/views/notifications/_product_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_product_details.html.erb
@@ -37,11 +37,13 @@
               <% if image.passed_antivirus_check? %>
                 <li><%= link_to image.filename, url_for(image.file) %></li>
               <% elsif image.file_exists? %>
-                <%= "Processing image #{image.file.filename} ..." %>
-                <br>
-                <%= link_to "Refresh",
-                            edit_responsible_person_notification_path(@responsible_person, @notification),
-                            class: "govuk-link--no-visited-state" %>
+                <p>
+                  <%= "Processing image #{image.file.filename} ..." %>
+                  <br>
+                  <%= link_to "Refresh",
+                              edit_responsible_person_notification_path(@responsible_person, @notification),
+                              class: "govuk-link--no-visited-state" %>
+                </p>
               <% end %>
             <% end %>
           </ul>

--- a/cosmetics-web/app/views/notifications/_product_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_product_details.html.erb
@@ -36,6 +36,12 @@
             <% notification.image_uploads.each do |image| %>
               <% if image.passed_antivirus_check? %>
                 <li><%= link_to image.filename, url_for(image.file) %></li>
+              <% elsif image.file_exists? %>
+                <%= "Processing image #{image.file.filename} ..." %>
+                <br>
+                <%= link_to "Refresh",
+                            edit_responsible_person_notification_path(@responsible_person, @notification),
+                            class: "govuk-link--no-visited-state" %>
               <% end %>
             <% end %>
           </ul>

--- a/cosmetics-web/app/views/notifications/_product_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_product_details.html.erb
@@ -34,7 +34,7 @@
         <% if notification.image_uploads.present? %>
           <ul class="govuk-list">
             <% notification.image_uploads.each do |image| %>
-              <% if image.file_exists? && image.marked_as_safe? %>
+              <% if image.passed_antivirus_check? %>
                 <li><%= link_to image.filename, url_for(image.file) %></li>
               <% end %>
             <% end %>

--- a/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.erb
@@ -18,7 +18,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third product-images">
     <% @notification.image_uploads.each do |image| %>
-      <% if image.marked_as_safe? %>
+      <% if image.passed_antivirus_check? %>
         <% if image.file.variable? %>
           <%= link_to image_tag(image.file.variant(resize: "450x450")), url_for(image.file) %>
         <% elsif image.file.previewable? %>

--- a/cosmetics-web/app/views/responsible_persons/product_image_upload/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/product_image_upload/new.html.erb
@@ -1,27 +1,28 @@
-<% content_for :page_title, "Upload an image of the product label" %>
+<% page_title = @notification.is_multicomponent? ? "Upload images of the item labels" : "Upload an image of the product label" %>
+<% content_for :page_title, page_title %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: responsible_person_notifications_path(@responsible_person, anchor: "incomplete") %>
 <% end %>
 
-<%= form_with url: responsible_person_notification_product_image_upload_index_path, method: :post do |form| %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <% if @error_list.present? %>
+      <%= govukErrorSummary(titleText: "There is a problem", errorList: @error_list) %>
+    <% end %>
 
-      <% if @error_list.present? %>
-        <%= govukErrorSummary(titleText: "There is a problem", errorList: @error_list) %>
-      <% end %>
+    <h1 class="govuk-heading-l"><%= page_title %></h1>
 
-      <h1 class="govuk-heading-l">Upload an image of the product label</h1>
-
+    <% if @notification.is_multicomponent? %>
+      <%= render "shared/multiple_images_upload_description" %>
+    <% else %>
       <p>This can be an artwork file or a photo of the label.</p>
-
       <p>If you upload a photo text in the image must be legible.</p>
-
       <p>
         The file must be a ‘jpg’, ‘pdf’, or ‘png’ and no larger than <%= ImageUpload.max_file_size / 1.megabyte %> MB.
       </p>
-
+    <% end %>
+    <%= form_with(url: responsible_person_notification_product_image_upload_index_path, method: :post, multipart: true) do |form| %>
       <div class="govuk-form-group <%= "govuk-form-group--error" if @error_list.present? %>">
         <%= form.label :image_upload, "Choose file", class: "govuk-label" %>
 
@@ -32,13 +33,12 @@
         <% end %>
 
         <%= form.file_field :image_upload, multiple: true, accept: ImageUpload.allowed_types.join(", "), class: "govuk-file-upload" %>
-
       </div>
 
       <div class="govuk-form-group">
         <%= govukButton text: "Continue" %>
       </div>
-
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>
+

--- a/cosmetics-web/app/views/responsible_persons/wizard/notification_build/add_product_image.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/notification_build/add_product_image.html.erb
@@ -14,21 +14,7 @@
     <h1 class="govuk-heading-l"><%= page_title %></h1>
 
     <% if @notification.is_multicomponent? %>
-      <p class="govuk-body">
-        For National Poison Information Services to identify the item, you need to upload images of the item labels.
-      </p>
-      <p class="govuk-body">
-        To further help identify the items, you can also provide a photo of the kit and its items.
-      </p>
-      <p class="govuk-body">
-        You can upload up to 10 images. Each file can be up to 30MB and must be a JPG, PNG or PDF.
-      </p>
-      <p class="govuk-body">
-        Upload an image of the label for each item in the kit.
-      </p>
-      <p class="govuk-body">
-        The image must be in focus and all packaging text legible.
-      </p>
+      <%= render "shared/multiple_images_upload_description" %>
     <% else %>
       <p class="govuk-body">
         For National Poison Information Services to identify the product, you need to upload an image of the product label.

--- a/cosmetics-web/app/views/shared/_multiple_images_upload_description.html.erb
+++ b/cosmetics-web/app/views/shared/_multiple_images_upload_description.html.erb
@@ -1,0 +1,15 @@
+<p class="govuk-body">
+  For National Poison Information Services to identify the item, you need to upload images of the item labels.
+</p>
+<p class="govuk-body">
+  To further help identify the items, you can also provide a photo of the kit and its items.
+</p>
+<p class="govuk-body">
+  You can upload up to 10 images. Each file can be up to 30MB and must be a JPG, PNG or PDF.
+</p>
+<p class="govuk-body">
+  Upload an image of the label for each item in the kit.
+</p>
+<p class="govuk-body">
+  The image must be in focus and all packaging text legible.
+</p>

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
@@ -134,16 +134,13 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
       expect(assigns(:notification).errors[:image_uploads]).to include("waiting for files to pass anti virus check. Refresh to update")
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it "adds error if failed attempt to submit when images have failed antivirus check" do
-      draft_notification.image_uploads.build
-      draft_notification.save
+      attach_image_to_draft_with_metadata(safe: false)
       get :edit, params: { responsible_person_id: responsible_person.id,
                            reference_number: draft_notification.reference_number,
                            submit_failed: true }
       expect(assigns(:notification).errors[:image_uploads]).to include("failed anti virus check")
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it "does not allow the user to edit notification for a Responsible Person they not belong to" do
       other_responsible_person = create(:responsible_person)

--- a/cosmetics-web/spec/factories/image_upload.rb
+++ b/cosmetics-web/spec/factories/image_upload.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     trait :uploaded_and_virus_scanned do
       after :create do |image_upload|
-        image_upload.file.metadata["safe"] = "true"
+        image_upload.file.metadata["safe"] = true
       end
     end
   end

--- a/cosmetics-web/spec/factories/image_upload.rb
+++ b/cosmetics-web/spec/factories/image_upload.rb
@@ -4,8 +4,14 @@ FactoryBot.define do
     file { Rack::Test::UploadedFile.new("spec/fixtures/testPdf.pdf", "image/png") }
 
     trait :uploaded_and_virus_scanned do
-      after :create do |image_upload|
+      after(:stub, :create) do |image_upload|
         image_upload.file.metadata["safe"] = true
+      end
+    end
+
+    trait :uploaded_and_virus_identified do
+      after(:stub, :create) do |image_upload|
+        image_upload.file.metadata["safe"] = false
       end
     end
   end

--- a/cosmetics-web/spec/models/image_upload_spec.rb
+++ b/cosmetics-web/spec/models/image_upload_spec.rb
@@ -1,22 +1,168 @@
 require "rails_helper"
 
 RSpec.describe ImageUpload, type: :model do
-  let(:image_upload) { described_class.create }
-  let(:file) { fixture_file_upload("/testImage.png", "image/png") }
-
-  before do
-    allow(described_class).to receive(:max_file_size).and_return(10)
-  end
-
-  after do
-    allow(described_class).to receive(:max_file_size).and_call_original
-  end
+  let(:image_upload) { described_class.new }
+  let(:attachment) { fixture_file_upload("/testImage.png", "image/png") }
+  let(:file_metadata) { {} }
+  # rubocop:disable RSpec/VerifiedDoubles
+  # ActiveStorage associations between ActiveStorage::Attached::One and ActiveStorage::Blob make this quite complex to stub with a verified stub.
+  let(:file_stub) { double(attachment: attachment, metadata: file_metadata) }
+  # rubocop:enable RSpec/VerifiedDoubles
 
   describe "image validation", :with_stubbed_antivirus do
-    it "adds an error if the file is above the allowed filesize" do
-      image_upload.file.attach(file)
-      image_upload.save
-      expect(image_upload.errors[:file]).to include("must be smaller than 0MB")
+    context "when the file is above the allowed filesize" do
+      before do
+        allow(described_class).to receive(:max_file_size).and_return(10)
+      end
+
+      it "adds an error" do
+        image_upload.file.attach(attachment)
+        image_upload.validate
+        expect(image_upload.errors[:file]).to include("must be smaller than 0MB")
+      end
+    end
+  end
+
+  describe "#file_exists?" do
+    it "returns true when image upload contains an attachment" do
+      image_upload.file.attach(attachment)
+      expect(image_upload.file_exists?).to eq true
+    end
+
+    it "returns false when image upload does not contain an attachment" do
+      expect(image_upload.file_exists?).to eq false
+    end
+  end
+
+  describe "#passed_antivirus_check?" do
+    before do
+      allow(image_upload).to receive(:file).and_return(file_stub)
+    end
+
+    context "when image upload contains a file" do
+      let(:attachment) { fixture_file_upload("/testImage.png", "image/png") }
+
+      context "when the antivirus is disabled" do
+        before { stub_const("ENV", { "ANTIVIRUS_ENABLED" => "false" }) }
+
+        it { expect(image_upload.passed_antivirus_check?).to eq true }
+      end
+
+      context "with the antivirus enabled" do
+        before { stub_const("ENV", { "ANTIVIRUS_ENABLED" => "true" }) }
+
+        context "with the file metadata is marked as safe" do
+          let(:file_metadata) { { "safe" => true } }
+
+          it { expect(image_upload.passed_antivirus_check?).to eq true }
+        end
+
+        context "with the file metadata is marked as not safe" do
+          let(:file_metadata) { { "safe" => false } }
+
+          it { expect(image_upload.passed_antivirus_check?).to eq false }
+        end
+
+        context "with the file metadata does not have safety information" do
+          let(:file_metadata) { {} }
+
+          it { expect(image_upload.passed_antivirus_check?).to eq false }
+        end
+      end
+    end
+
+    context "when image upload does not contain a file" do
+      let(:attachment) {}
+
+      it { expect(image_upload.passed_antivirus_check?).to eq false }
+    end
+  end
+
+  describe "#pending_antivirus_check?" do
+    before do
+      allow(image_upload).to receive(:file).and_return(file_stub)
+    end
+
+    context "when image upload contains a file" do
+      let(:attachment) { fixture_file_upload("/testImage.png", "image/png") }
+
+      context "when the antivirus is disabled" do
+        before { stub_const("ENV", { "ANTIVIRUS_ENABLED" => "false" }) }
+
+        it { expect(image_upload.pending_antivirus_check?).to eq false }
+      end
+
+      context "with the antivirus enabled" do
+        before { stub_const("ENV", { "ANTIVIRUS_ENABLED" => "true" }) }
+
+        context "with the file metadata is marked as safe" do
+          let(:file_metadata) { { "safe" => true } }
+
+          it { expect(image_upload.pending_antivirus_check?).to eq false }
+        end
+
+        context "with the file metadata is marked as not safe" do
+          let(:file_metadata) { { "safe" => false } }
+
+          it { expect(image_upload.pending_antivirus_check?).to eq false }
+        end
+
+        context "with the file metadata does not have safety information" do
+          let(:file_metadata) { {} }
+
+          it { expect(image_upload.pending_antivirus_check?).to eq true }
+        end
+      end
+    end
+
+    context "when image upload does not contain a file" do
+      let(:attachment) {}
+
+      it { expect(image_upload.passed_antivirus_check?).to eq false }
+    end
+  end
+
+  describe "#failed_antivirus_check?" do
+    before do
+      allow(image_upload).to receive(:file).and_return(file_stub)
+    end
+
+    context "when image upload contains a file" do
+      let(:attachment) { fixture_file_upload("/testImage.png", "image/png") }
+
+      it { expect(image_upload.failed_antivirus_check?).to eq false }
+    end
+
+    context "when image upload does not contain a file" do
+      let(:attachment) {}
+
+      context "when the antivirus is disabled" do
+        before { stub_const("ENV", { "ANTIVIRUS_ENABLED" => "false" }) }
+
+        it { expect(image_upload.failed_antivirus_check?).to eq false }
+      end
+
+      context "with the antivirus enabled" do
+        before { stub_const("ENV", { "ANTIVIRUS_ENABLED" => "true" }) }
+
+        context "with the file metadata is marked as safe" do
+          let(:file_metadata) { { "safe" => true } }
+
+          it { expect(image_upload.failed_antivirus_check?).to eq false }
+        end
+
+        context "with the file metadata is marked as not safe" do
+          let(:file_metadata) { { "safe" => false } }
+
+          it { expect(image_upload.failed_antivirus_check?).to eq true }
+        end
+
+        context "with the file metadata does not have safety information" do
+          let(:file_metadata) { {} }
+
+          it { expect(image_upload.failed_antivirus_check?).to eq false }
+        end
+      end
     end
   end
 end

--- a/cosmetics-web/spec/models/image_upload_spec.rb
+++ b/cosmetics-web/spec/models/image_upload_spec.rb
@@ -130,12 +130,6 @@ RSpec.describe ImageUpload, type: :model do
     context "when image upload contains a file" do
       let(:attachment) { fixture_file_upload("/testImage.png", "image/png") }
 
-      it { expect(image_upload.failed_antivirus_check?).to eq false }
-    end
-
-    context "when image upload does not contain a file" do
-      let(:attachment) {}
-
       context "when the antivirus is disabled" do
         before { stub_const("ENV", { "ANTIVIRUS_ENABLED" => "false" }) }
 
@@ -163,6 +157,12 @@ RSpec.describe ImageUpload, type: :model do
           it { expect(image_upload.failed_antivirus_check?).to eq false }
         end
       end
+    end
+
+    context "when image upload does not contain a file" do
+      let(:attachment) {}
+
+      it { expect(image_upload.failed_antivirus_check?).to eq false }
     end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-972)

## Description of first issue
There was a bug where the image upload page in post-brexit multi-component journey gets into an infinite loop requesting image submission and never moves to the next stage of the flow.

This was caused by:
1) Antivirus over the uploaded file running asynchronously in the background.
2) Business logic enforcing the file to have been checked as "safe from virus" in order to load the next page.

Because at submission point the file is still waiting for the AV check, the virus safety enforcement was never accomplished and the user was being redirected back to the image upload page.

### Solution
Allow to load the next page when the antivirus check is pending over the image.

## Description of second issue
Even when the ZIP file contains a multi-component notification, the image upload page when completing the missing information page was displaying information for a single component notification.

 ### Solution
 Display multiple image uploads information (and title) when loading the image upload page for a multi-component notification.
 
 ## Screenshots of new behaviour
 
**Upload images page for multi-components**
![image](https://user-images.githubusercontent.com/1227578/102894858-a40d9b80-445b-11eb-8ede-55b1623074a1.png)

**Notification details after image submission**
![Screenshot from 2020-12-21 16-08-32](https://user-images.githubusercontent.com/1227578/102797922-41a79300-43a8-11eb-841a-fac7aee2ff17.png)

**Notification details after multiple image submission**
![image](https://user-images.githubusercontent.com/1227578/102895345-6cebba00-445c-11eb-91c7-da725aff168e.png)

