### PR TITLE
Fix orphan blobs left after file deletion

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notification_files_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notification_files_controller.rb
@@ -44,12 +44,12 @@ class ResponsiblePersons::NotificationFilesController < SubmitApplicationControl
   end
 
   def destroy
-    NotificationFile.delete(params[:id])
+    NotificationFile.destroy(params[:id])
     redirect_to responsible_person_notifications_path(@responsible_person)
   end
 
   def destroy_all
-    @responsible_person.notification_files.where(user_id: current_user.id).where.not(upload_error: nil).delete_all
+    @responsible_person.notification_files.where(user_id: current_user.id).where.not(upload_error: nil).destroy_all
     redirect_to responsible_person_notifications_path(@responsible_person)
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -249,7 +249,7 @@ private
     end
 
     if @component.predefined?
-      @component.formulation_file.delete if @component.formulation_file.attached?
+      @component.formulation_file.purge if @component.formulation_file.attached?
       jump_to(next_step(:upload_formulation)) # Intended target page is select_frame_formulation - assuming the step order declared above doesn't change!
     else
       @component.update(frame_formulation: nil) unless @component.frame_formulation.nil?
@@ -294,7 +294,7 @@ private
       if @component.valid?
         redirect_to finish_wizard_path
       else
-        @component.formulation_file.delete if @component.formulation_file.attached?
+        @component.formulation_file.purge if @component.formulation_file.attached?
         render step
       end
     else

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -146,7 +146,7 @@ private
     if params.key?(:remove_component)
       remove_component_id = params[:remove_component].to_i
       componet_to_remove = @notification.components.select { |component| component.id == remove_component_id }
-      @notification.components.delete(componet_to_remove)
+      @notification.components.destroy(componet_to_remove)
       @notification.components.create if @notification.components.length < 2
       render step
     elsif params.key?(:add_component) && params[:add_component]

--- a/cosmetics-web/spec/requests/notification_files_spec.rb
+++ b/cosmetics-web/spec/requests/notification_files_spec.rb
@@ -14,47 +14,99 @@ RSpec.describe "Notification files", :with_stubbed_antivirus, type: :request do
       sign_out(:submit_user)
     end
 
-    context "when deleting a notification file" do
-      let(:notification_file) { create(:notification_file, responsible_person: responsible_person, user: user) }
-
-      before do
-        delete responsible_person_notification_file_path(responsible_person, notification_file)
+    describe "deleting a notification file" do
+      let(:notification_file) do
+        create(:notification_file,
+               uploaded_file: create_file_blob("testExportFile.zip"),
+               responsible_person: responsible_person,
+               user: user)
       end
 
       it "redirects to the notifications dashboard" do
+        delete responsible_person_notification_file_path(responsible_person, notification_file)
         expect(response).to redirect_to(responsible_person_notifications_path(responsible_person))
       end
 
       it "deletes the notification file" do
+        expect(notification_file).not_to be_nil
+        delete responsible_person_notification_file_path(responsible_person, notification_file)
         expect { notification_file.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "deletes the notification file attachment" do
+        attachment = notification_file.uploaded_file
+        expect(attachment).not_to be_nil
+        delete responsible_person_notification_file_path(responsible_person, notification_file)
+        expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "deletes the notification file blob" do
+        blob = notification_file.uploaded_file.blob
+        expect(blob).not_to be_nil
+        delete responsible_person_notification_file_path(responsible_person, notification_file)
+        expect { blob.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
-    context "when deleting ALL notification files with errors" do
-      let!(:notification_file_with_error_1) { create(:notification_file, responsible_person: responsible_person, user: user, upload_error: "uploaded_file_not_a_zip") }
-      let!(:notification_file_with_error_2) { create(:notification_file, responsible_person: responsible_person, user: user, upload_error: "uploaded_file_not_a_zip") }
-      let!(:notification_file_with_no_error) { create(:notification_file, responsible_person: responsible_person, user: user, upload_error: nil) }
-      let!(:notification_file_with_error_belonging_to_colleague) { create(:notification_file, responsible_person: responsible_person, user: colleague, upload_error: "uploaded_file_not_a_zip") }
-
-      before do
-        delete destroy_all_responsible_person_notification_files_path(responsible_person)
+    describe "deleting ALL notification files with errors" do
+      let!(:notification_file_with_no_error) do
+        create(:notification_file,
+               responsible_person: responsible_person,
+               uploaded_file: create_file_blob("testExportFile.zip"),
+               user: user,
+               upload_error: nil)
+      end
+      let!(:notification_file_with_error) do
+        create(:notification_file,
+               responsible_person: responsible_person,
+               user: user,
+               uploaded_file: create_file_blob("testExportFile.zip"),
+               upload_error: "uploaded_file_not_a_zip")
+      end
+      let!(:notification_file2_with_error) do
+        create(:notification_file,
+               responsible_person: responsible_person,
+               user: user,
+               uploaded_file: create_file_blob("testExportFile.zip"),
+               upload_error: "uploaded_file_not_a_zip")
+      end
+      let!(:notification_file_with_error_belonging_to_colleague) do
+        create(:notification_file,
+               responsible_person: responsible_person,
+               uploaded_file: create_file_blob("testExportFile.zip"),
+               user: colleague,
+               upload_error: "uploaded_file_not_a_zip")
       end
 
       it "redirects to the notifications dashboard" do
+        delete destroy_all_responsible_person_notification_files_path(responsible_person)
         expect(response).to redirect_to(responsible_person_notifications_path(responsible_person))
       end
 
-      it "deletes the notification files with errors" do
-        expect { notification_file_with_error_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect { notification_file_with_error_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      it "deletes the notification files with errors belonging to the user" do
+        delete destroy_all_responsible_person_notification_files_path(responsible_person)
+        expect(responsible_person.notification_files).to contain_exactly(
+          notification_file_with_no_error,
+          notification_file_with_error_belonging_to_colleague,
+        )
       end
 
-      it "does not delete the notification file with no error" do
-        expect { notification_file_with_no_error.reload }.not_to raise_error
+      it "deletes the attachments from the deleted notification files" do
+        attachment = notification_file_with_error.uploaded_file.attachment
+        attachment2 = notification_file2_with_error.uploaded_file.attachment
+
+        delete destroy_all_responsible_person_notification_files_path(responsible_person)
+        expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { attachment2.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      it "does not delete the notification file belonging to a colleague" do
-        expect { notification_file_with_error_belonging_to_colleague.reload }.not_to raise_error
+      it "deletes the attachment blobs from the deleted notification files" do
+        blob = notification_file_with_error.uploaded_file.blob
+        blob2 = notification_file2_with_error.uploaded_file.blob
+
+        delete destroy_all_responsible_person_notification_files_path(responsible_person)
+        expect { blob.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { blob2.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1004)

## Description
We detected through our error management/notification system the presence of "blob" files that are detached from any object.
We believe this is caused by the incorrect deletion of attachments and objects with attachments where:
1. Objects with attachments are deleted via `delete` instead of `destroy` calls. Leaving their attachments non deleted.
2. Calls to attachment removal are done via `delete` instead of `purge` or `purge_later`, effectively detaching the associated object from the file blob and, again, not removing the blob.

When we delete a Notification/Component/Any object we want to wipe it, including its associated attachments.

This is achieved by calling `destroy` over the objects (so it triggers callbacks deleting the dependent objects associated to the deleted one) and `purge` over the attachments (so also deletes the blobs).
