### PR TITLE
WIP: Don't process Notification file unless virus free

### DIFF
--- a/cosmetics-web/spec/jobs/notification_file_processor_job_spec.rb
+++ b/cosmetics-web/spec/jobs/notification_file_processor_job_spec.rb
@@ -10,91 +10,175 @@ RSpec.describe NotificationFileProcessorJob, :with_stubbed_antivirus do
   let(:responsible_person) { create(:responsible_person) }
 
   describe "#perform" do
-    before do
-      described_class.new.perform(notification_file.id)
+    subject(:job) { described_class.new }
+
+    context "when the attached file is safe from virus" do
+      let(:notification_file) do
+        create(:notification_file, uploaded_file: uploaded_file)
+      end
+
+      before do
+        allow(uploaded_file).to receive(:metadata).and_return({ "safe" => true })
+      end
+
+      context "with a valid zip file" do
+        let(:uploaded_file) { create_file_blob("testExportFile.zip") }
+
+        it "removes the notification file" do
+          job.perform(notification_file.id)
+          expect {
+            notification_file.reload
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "creates a notification populated with relevant name" do
+          expect { job.perform(notification_file.id) }.to change(Notification, :count).by(1)
+          notification = Notification.order(created_at: :asc).last
+          expect(notification.product_name).equal?("CTPA moisture conditioner")
+        end
+      end
+
+      context "when the file is the wrong file type" do
+        let(:uploaded_file) { create_file_blob("testImage.png") }
+
+        it "adds an error to the file" do
+          job.perform(notification_file.id)
+          expect(notification_file.reload.upload_error).to eq("uploaded_file_not_a_zip")
+        end
+      end
+
+      context "when the zip files contains PDFs" do
+        let(:uploaded_file) { create_file_blob("testZippedPDF.zip") }
+
+        it "adds an error to the file" do
+          job.perform(notification_file.id)
+          expect(notification_file.reload.upload_error).to eq("unzipped_files_are_pdf")
+        end
+      end
+
+      context "when the zip file does not contain a product XML file" do
+        let(:uploaded_file) { create_file_blob("testNoProductFile.zip") }
+
+        it "adds an error to the file" do
+          job.perform(notification_file.id)
+          expect(notification_file.reload.upload_error).to eq("product_file_not_found")
+        end
+      end
+
+      context "when the zip file cannot be validated" do
+        let(:uploaded_file) { create_file_blob("testExportWithMissingData.zip") }
+
+        it "adds an error to the file" do
+          job.perform(notification_file.id)
+          expect(notification_file.reload.upload_error).to eq("notification_validation_error")
+        end
+      end
+
+      context "when the zip file contains a draft notification" do
+        let(:uploaded_file) { create_file_blob("testDraftNotification.zip") }
+
+        it "adds an error to the file" do
+          job.perform(notification_file.id)
+          expect(notification_file.reload.upload_error).to eq("draft_notification_error")
+        end
+      end
+
+      context "when a notification for that product already exists" do
+        let(:uploaded_file) { create_file_blob("testExportFile.zip") }
+        let(:notification_file) do
+          create(:notification_file, uploaded_file: uploaded_file, responsible_person: responsible_person)
+        end
+
+        before do
+          # create pre-existing duplicate notification
+          create(:registered_notification, responsible_person: responsible_person, cpnp_reference: "1000094")
+        end
+
+        it "adds an error to the file" do
+          job.perform(notification_file.id)
+          expect(notification_file.reload.upload_error).to eq("notification_duplicated")
+        end
+      end
+
+      context "when the zip files exceeds the file size limit" do
+        let(:uploaded_file) { create_file_blob("testExportFile.zip") }
+
+        before do
+          stub_const("NotificationFile::MAX_FILE_SIZE_BYTES", 10)
+        end
+
+        it "adds an error to the file" do
+          job.perform(notification_file.id)
+          expect(notification_file.reload.upload_error).to eq("file_size_too_big")
+        end
+      end
     end
 
-    context "with a valid zip file" do
-      let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testExportFile.zip")) }
+    context "when a virus has been detected in the attached file" do
+      let(:uploaded_file) { create_file_blob("testExportFile.zip") }
+      let(:notification_file) { create(:notification_file, uploaded_file: uploaded_file) }
 
-      it "removes the notification file" do
+      before do
+        allow(uploaded_file).to receive(:metadata).and_return({ "safe" => false })
+        # To be able to stub the metadata without being overriden on storage
+        allow(NotificationFile).to receive(:find).and_return(notification_file)
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it "does not create a notification" do
         expect {
-          notification_file.reload
-        }.to raise_error(ActiveRecord::RecordNotFound)
+          begin
+            job.perform(notification_file.id)
+          rescue described_class::AntivirusCheckFailedError
+            nil
+          end
+        }.not_to change(Notification, :count)
       end
 
-      it "creates a notification populated with relevant name" do
-        notification = Notification.order(created_at: :asc).last
-        expect(notification.product_name).equal?("CTPA moisture conditioner")
+      it "does not enqueue the job again" do
+        ActiveJob::Base.queue_adapter = :test
+        begin
+          job.perform(notification_file.id)
+        rescue described_class::AntivirusCheckFailedError
+          nil
+        end
+        expect(described_class).not_to have_been_enqueued
       end
+      # rubocop:enable RSpec/ExampleLength
     end
 
-    context "when the file is the wrong file type" do
-      let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testImage.png")) }
+    context "when the antivirus check has not run for the attached file" do
+      let(:uploaded_file) { create_file_blob("testExportFile.zip") }
+      let(:notification_file) { create(:notification_file, uploaded_file: uploaded_file) }
 
-      it "adds an error to the file" do
-        expect(notification_file.reload.upload_error).to eq("uploaded_file_not_a_zip")
+      before do
+        allow(uploaded_file).to receive(:metadata).and_return({})
+        # To be able to stub the metadata without being overriden on storage
+        allow(NotificationFile).to receive(:find).and_return(notification_file)
       end
-    end
 
-    context "when the zip files contains PDFs" do
-      let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testZippedPDF.zip")) }
-
-      it "adds an error to the file" do
-        expect(notification_file.reload.upload_error).to eq("unzipped_files_are_pdf")
+      # rubocop:disable RSpec/ExampleLength
+      it "does not create a notification" do
+        expect {
+          begin
+            job.perform(notification_file.id)
+          rescue described_class::AntivirusCheckPendingError
+            nil
+          end
+        }.not_to change(Notification, :count)
       end
-    end
 
-    context "when the zip file does not contain a product XML file" do
-      let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testNoProductFile.zip")) }
-
-      it "adds an error to the file" do
-        expect(notification_file.reload.upload_error).to eq("product_file_not_found")
+      # Struggling to get this bit tested, as the "retry_on" magic does not seem to be happening on specs
+      xit "enqueues the job again" do
+        ActiveJob::Base.queue_adapter = :test
+        begin
+          job.perform(notification_file.id)
+        rescue described_class::AntivirusCheckPendingError
+          nil
+        end
+        expect(described_class).to have_been_enqueued
       end
-    end
-
-    context "when the zip file cannot be validated" do
-      let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testExportWithMissingData.zip")) }
-
-      it "adds an error to the file" do
-        expect(notification_file.reload.upload_error).to eq("notification_validation_error")
-      end
-    end
-
-    context "when the zip file contains a draft notification" do
-      let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testDraftNotification.zip")) }
-
-      it "adds an error to the file" do
-        expect(notification_file.reload.upload_error).to eq("draft_notification_error")
-      end
-    end
-  end
-
-  context "when a notification for that product already exists" do
-    let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testExportFile.zip"), responsible_person: responsible_person) }
-
-    before do
-      # create pre-existing duplicate notification
-      create(:registered_notification, responsible_person: responsible_person, cpnp_reference: "1000094")
-
-      described_class.new.perform(notification_file.id)
-    end
-
-    it "adds an error to the file" do
-      expect(notification_file.reload.upload_error).to eq("notification_duplicated")
-    end
-  end
-
-  context "when the zip files exceeds the file size limit" do
-    let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testExportFile.zip")) }
-
-    before do
-      stub_const("NotificationFile::MAX_FILE_SIZE_BYTES", 10)
-      described_class.new.perform(notification_file.id)
-    end
-
-    it "adds an error to the file" do
-      expect(notification_file.reload.upload_error).to eq("file_size_too_big")
+      # rubocop:enable RSpec/ExampleLength
     end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1003)
The antivirus job and the notification file processing are both run as async jobs in parallel.

This allows the file to be processed while is still being analyzed for virus or, even worse, when it actually contains a virus file in the zip.

In order to avoid that we guard the process execution behind a check on
the antivirus output:
- If the antivirus process finished and the file is marked as safe,
  process the notification as usual.
- If the antivirus process hasn't run on the file, reschedule the
  processing of the notification to be run again later.
- If the antivirus process finished and detects a virus on the
  attachment, do not process the file.
