### PR TITLE
Bugfix: incomplete accounts trying to reset password

### DIFF
--- a/cosmetics-web/app/controllers/users/passwords_controller.rb
+++ b/cosmetics-web/app/controllers/users/passwords_controller.rb
@@ -65,6 +65,9 @@ module Users
     end
 
     def resend_account_setup_link_for(user)
+      user.confirmed_at = nil
+      user.account_security_completed = false
+      user.save(validate: false)
       user.resend_account_setup_link
       redirect_to check_your_email_path
     end

--- a/cosmetics-web/app/controllers/users/passwords_controller.rb
+++ b/cosmetics-web/app/controllers/users/passwords_controller.rb
@@ -28,6 +28,9 @@ module Users
     end
 
     def create
+      user = user_class.find_by(email: params[user_param_key][:email])
+      return resend_account_setup_link_for(user) if user && !user.has_completed_registration?
+
       super do |resource|
         suppress_email_not_found_error
 
@@ -61,8 +64,8 @@ module Users
       user_signed_in? && is_fully_authenticated?
     end
 
-    def resend_invitation_link_for(user)
-      SendUserInvitationJob.perform_later(user.id, nil)
+    def resend_account_setup_link_for(user)
+      user.resend_account_setup_link
       redirect_to check_your_email_path
     end
 

--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -33,9 +33,8 @@ class SearchUser < User
     !msa_user?
   end
 
-  # TODO: is this used?
-  def send_confirmation_instructions
-    SearchNotifyMailer.send_account_confirmation_email(self).deliver_later
+  def resend_account_setup_link
+    SearchNotifyMailer.invitation_email(self).deliver_later
   end
 
   def send_reset_password_instructions_notification(token)
@@ -57,10 +56,6 @@ class SearchUser < User
 
   def invitation_expired?
     invited_at <= INVITATION_EXPIRATION_DAYS.days.ago
-  end
-
-  def has_completed_registration?
-    encrypted_password.present? && name.present? && mobile_number.present? && mobile_number_verified
   end
 
 private

--- a/cosmetics-web/app/models/submit_user.rb
+++ b/cosmetics-web/app/models/submit_user.rb
@@ -56,6 +56,10 @@ class SubmitUser < User
     @dont_send_confirmation_instructions = true
   end
 
+  def resend_account_setup_link
+    resend_confirmation_instructions
+  end
+
   def send_confirmation_instructions
     return if @dont_send_confirmation_instructions
 

--- a/cosmetics-web/app/models/user.rb
+++ b/cosmetics-web/app/models/user.rb
@@ -25,4 +25,8 @@ class User < ApplicationRecord
   def mobile_number_change_allowed?
     !mobile_number_verified?
   end
+
+  def has_completed_registration?
+    encrypted_password.present? && name.present? && mobile_number.present? && mobile_number_verified
+  end
 end

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -19,9 +19,17 @@ FactoryBot.define do
         end
       end
 
+      trait :confirmed_not_verified do
+        confirmed_at { 1.hour.ago }
+        confirmation_sent_at { Time.zone.now }
+        confirmation_token { Devise.friendly_token }
+        mobile_number_verified { false }
+      end
+
       trait :unconfirmed do
         password { nil }
         mobile_number { nil }
+        mobile_number_verified { false }
         confirmed_at { nil }
         confirmation_sent_at { Time.zone.now }
         direct_otp_sent_at { nil }

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     sequence(:email) { |n| "john.doe#{n}@example.org" }
     mobile_number { "07500 000 000" }
     password { "testpassword123" }
-    confirmed_at { 1.hour.ago }
     has_accepted_declaration { true }
     direct_otp_sent_at { Time.zone.now }
     direct_otp { "12345" }
@@ -12,6 +11,8 @@ FactoryBot.define do
     account_security_completed { true }
 
     factory :submit_user, class: "SubmitUser" do
+      confirmed_at { 1.hour.ago }
+
       trait :with_responsible_person do
         after(:create) do |user|
           create_list(:responsible_person_user, 1, user: user)
@@ -48,6 +49,17 @@ FactoryBot.define do
 
       after :create do |user, options|
         create(:user_attributes, user: user, declaration_accepted: !options.first_login)
+      end
+
+      trait :registration_incomplete do
+        password { nil }
+        mobile_number { nil }
+        invitation_token { Devise.friendly_token }
+        invited_at { Time.zone.now }
+        direct_otp_sent_at { nil }
+        direct_otp { nil }
+        to_create { |user| user.save(validate: false) }
+        account_security_completed { false }
       end
     end
   end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1014)
[Bugtracker exception](https://sentry.io/organizations/beis/issues/2123481455)

When an user with an incomplete account (missing their mobile number, name or password) attempts a password recovery the service is throwing an error.

Sadly seems some users get confused after introducing their email in the first step of the Submit user registration and, instead
of checking their email for the confirmation link (as prompted), they directly attempt to login, and not having set their password they attempt to reset it.

The cause of the exception is the 2FA attempt prior to the password reset, while the user actually doesn't have a mobile number to send the 2FA code to.

As this bit of the code is shared between Submit and Search users, we are changing this behaviour to:

- SUBMIT USERS:
  When a submit user that didn't complete its registration attempts to reset its password (that is not set up), will be resent the 
  account confirmation instructions instead.

- SEARCH USERS:
  When a search user that didn't complete its registration after having received an invitation link attempts to reset its password, 
  will be resent the invitation link instead.
