### PR TITLE
Fix errors when user attempts to navigate away when on the account security setup page

### DIFF
--- a/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
@@ -11,6 +11,11 @@ module SecondaryAuthenticationConcern
     return unless Rails.configuration.secondary_authentication_enabled
 
     if user && (!user.mobile_number_verified || !secondary_authentication_present?)
+
+      if !user.account_security_completed? || !user.mobile_number
+        return redirect_to(registration_new_account_security_path)
+      end
+
       session[:secondary_authentication_redirect_to] = redirect_to
       session[:secondary_authentication_user_id] = user_id_for_secondary_authentication
       session[:secondary_authentication_notice] = notice

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -37,6 +37,19 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_stubbed_notify, :w
     verify_url = email.personalization[:verify_email_url]
     visit verify_url
 
+    # Attempting to access other pages should redirect back to form
+    click_link "Your account"
+    expect(page).to have_current_path("/account-security")
+
+    click_link "Submit cosmetic product notifications"
+    expect(page).to have_current_path("/account-security")
+
+    click_link "How to prepare images for notification"
+    expect(page).to have_current_path("/account-security")
+
+    click_link "Privacy policy"
+    expect(page).to have_current_path("/account-security")
+
     # Attempts to submit security page with validation errors
     expect(page).to have_current_path("/account-security")
     fill_in "Mobile number", with: "07000 invalid 000000"


### PR DESCRIPTION
## Example Sentry errors
https://sentry.io/organizations/beis/issues/2123432557/?project=1398436
https://sentry.io/organizations/beis/issues/2124293995/?project=1398436
https://sentry.io/organizations/beis/issues/2123432557/?project=1398436

## Description
When the user has clicked the email link to set up their account, they are able to click various links as shown on the screenshot below:

<img width="975" alt="Screenshot 2021-01-02 at 12 21 28" src="https://user-images.githubusercontent.com/408371/103457222-0fc1f500-4cf5-11eb-84a1-ff77fff05027.png">

The main title 'Submit cosmetic product notifications' redirects back to the form, but other links throw an uncaught exception. These should also redirect back to the form.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
