### PR TITLE
Bump worker memory and apply number of instances correctly

### DIFF
--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -22,7 +22,5 @@ cp -a ./infrastructure/env/. ./cosmetics-web/env/
 # Deploy the submit app and set the hostname
 cf push $APP_NAME -f $MANIFEST_FILE --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --strategy rolling
 
-cf scale $APP_NAME --process worker -i 1
-
 # Remove the copied infrastructure env files to clean up
 rm -R cosmetics-web/env/

--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -36,5 +36,5 @@ applications:
       command: export $(./env/get-env-from-vcap.sh) && bin/yarn install && bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: 4
-      memory: 1G
+      memory: 2G
       disk_quota: 2G


### PR DESCRIPTION
Fixes the worker instances always being scaled to 1, and increases memory to avoid errors such as https://sentry.io/organizations/beis/issues/2126255547/