### PR TITLE
Capture errors when extracting zip file

### DIFF
--- a/cosmetics-web/app/jobs/notification_file_processor_job.rb
+++ b/cosmetics-web/app/jobs/notification_file_processor_job.rb
@@ -30,6 +30,9 @@ private
 
       Sidekiq.logger.info "Successful File Upload"
     end
+  rescue Zip::Error => e
+    Sidekiq.logger.error e.message
+    @notification_file.update(upload_error: :uploaded_file_not_a_zip)
   rescue UnexpectedPdfFileError => e
     Sidekiq.logger.error e.message
     @notification_file.update(upload_error: :unzipped_files_are_pdf)

--- a/cosmetics-web/spec/factories/notification_file.rb
+++ b/cosmetics-web/spec/factories/notification_file.rb
@@ -2,6 +2,11 @@ FactoryBot.define do
   factory :notification_file do
     responsible_person
     user factory: :submit_user
+
+    trait :skip_validations do
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     after :create do |notification_file, options|
       notification_file.name = options.uploaded_file.filename if notification_file.uploaded_file.attached?
     end

--- a/cosmetics-web/spec/jobs/notification_file_processor_job_spec.rb
+++ b/cosmetics-web/spec/jobs/notification_file_processor_job_spec.rb
@@ -107,6 +107,16 @@ RSpec.describe NotificationFileProcessorJob, :with_stubbed_antivirus do
     end
   end
 
+  context "when the zip file is invalid" do
+    let(:notification_file) { create(:notification_file, :skip_validations, uploaded_file: create_file_blob("testText.txt")) }
+
+    before { described_class.new.perform(notification_file.id) }
+
+    it "adds an error to the file" do
+      expect(notification_file.reload.upload_error).to eq("uploaded_file_not_a_zip")
+    end
+  end
+
   context "when there is an unexpected error parsing the files" do
     let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testExportFile.zip")) }
     let(:exception) { StandardError.new }


### PR DESCRIPTION
So far we have had 24 instances since Sunday of corrupt or invalid zip files being uploaded and failing processing:

https://sentry.io/organizations/beis/issues/2127458135/?project=1398436&query=is%3Aunresolved

This change captures these errors and feeds back to the user so they may correct it.