### PR TITLE
Increase app start timeouts on deployments

### DIFF
--- a/cosmetics-web/deploy-review.sh
+++ b/cosmetics-web/deploy-review.sh
@@ -42,7 +42,7 @@ until cf service $REDIS_NAME > /tmp/redis_exists && grep "create succeeded" /tmp
 cp -a ./infrastructure/env/. ./cosmetics-web/env/
 
 # Deploy the submit app and set the hostname
-cf push $APP -f $MANIFEST_FILE --var cosmetics-instance-name=$INSTANCE_NAME --var cosmetics-web-database=$DB_NAME --var submit-host=$SUBMIT_APP.$DOMAIN --var search-host=$SEARCH_APP.$DOMAIN --var cosmetics-host=$SUBMIT_APP.$DOMAIN --var cosmetics-redis-service=$REDIS_NAME --var sentry-current-env=$REVIEW_INSTANCE_NAME --strategy rolling
+cf push $APP -f $MANIFEST_FILE --app-start-timeout 180 --var cosmetics-instance-name=$INSTANCE_NAME --var cosmetics-web-database=$DB_NAME --var submit-host=$SUBMIT_APP.$DOMAIN --var search-host=$SEARCH_APP.$DOMAIN --var cosmetics-host=$SUBMIT_APP.$DOMAIN --var cosmetics-redis-service=$REDIS_NAME --var sentry-current-env=$REVIEW_INSTANCE_NAME --strategy rolling
 
 cf scale $APP --process worker -i 1
 

--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -19,8 +19,15 @@ MANIFEST_FILE=./cosmetics-web/manifest.yml
 # Copy the environment helper script
 cp -a ./infrastructure/env/. ./cosmetics-web/env/
 
+# Set the amount of time in minutes that the CLI will wait for all instances to start.
+# Because of the rolling deployment strategy, this should be set to at least the amount of
+# time each app takes to start multiplied by the number of instances.
+#
+# See https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html
+export CF_STARTUP_TIMEOUT=20
+
 # Deploy the submit app and set the hostname
-cf push $APP_NAME -f $MANIFEST_FILE --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --strategy rolling
+cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --strategy rolling
 
 # Remove the copied infrastructure env files to clean up
 rm -R cosmetics-web/env/


### PR DESCRIPTION
The last two merges have failed to deploy due to timeouts:

https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/runs/1644540742?check_suite_focus=true
https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/runs/1643344223?check_suite_focus=true

This increases the timeout thresholds [as per PSD](https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/master/deploy.sh). I have set `CF_STARTUP_TIMEOUT` higher due to the higher number of instances.