### PR TITLE
Avoid duplicated emails with different capitalisation

### DIFF
--- a/cosmetics-web/app/forms/registration/new_account_form.rb
+++ b/cosmetics-web/app/forms/registration/new_account_form.rb
@@ -24,7 +24,7 @@ module Registration
   private
 
     def user_exists?
-      if (user = SubmitUser.find_by(email: email))
+      if (user = SubmitUser.where("lower(email) = ?", email&.downcase).first)
         if user.confirmed?
           SubmitNotifyMailer.send_account_already_exists(user).deliver_later
         else

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -162,7 +162,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_stubbed_notify, :w
       expect(page).to have_current_path("/create-an-account")
 
       fill_in "Full name", with: "Joe Doe"
-      fill_in "Email address", with: user.email
+      fill_in "Email address", with: user.email.upcase
       click_button "Continue"
 
       expect_to_be_on_check_your_email_page


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1017)
[Error tracking](https://sentry.io/organizations/beis/issues/2128065615/?project=1398436)

Users were able to register a new account with an email already belonging to another user but with different capitalisation.

This was happening because when saving the user in the new account form we were bypassing the validations for creating a partially completed user. While the business logic to check if the user already exists is using a case sensitive call (find_by) and not detecting that there is already an user with that email.

This caused the user becoming invalid in a later stage when trying to submit their security information to complete the registration.
At that point the email does not pass the validation and the form submission triggers an unexpected error.
