### PR TITLE
Redirect to notification page if already submitted when attempting to access wizard pages

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/formulation_upload_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/formulation_upload_controller.rb
@@ -32,6 +32,9 @@ private
     @component = Component.find(params[:component_id])
     @notification = @component.notification
     @responsible_person = @notification.responsible_person
+
+    return redirect_to responsible_person_notification_path(@responsible_person, @notification) if @notification&.notification_complete?
+
     authorize @component.notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 end

--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -3,7 +3,7 @@ require "will_paginate/array"
 class ResponsiblePersons::NotificationsController < SubmitApplicationController
   before_action :set_responsible_person
   before_action :validate_responsible_person
-  before_action :set_notification, only: %i[show edit confirm delete destroy]
+  before_action :set_notification, only: %i[show confirm delete destroy]
 
   def index
     @pending_notification_files_count = 0
@@ -39,6 +39,12 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
 
   # Check your answers page
   def edit
+    @notification = Notification.find_by reference_number: params[:reference_number]
+
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification.notification_complete?
+
+    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
+
     @previous_page_path = previous_path_before_check_your_answers(@notification)
 
     if params[:submit_failed]

--- a/cosmetics-web/app/controllers/responsible_persons/product_image_upload_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/product_image_upload_controller.rb
@@ -39,6 +39,9 @@ private
     @error_list = []
     @notification = Notification.find_by reference_number: params[:notification_reference_number]
     @responsible_person = @notification.responsible_person
+
+    return redirect_to responsible_person_notification_path(@responsible_person, @notification) if @notification&.notification_complete?
+
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 end

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -94,6 +94,9 @@ private
 
   def set_component
     @component = Component.find(params[:component_id])
+
+    return redirect_to responsible_person_notification_path(@component.notification.responsible_person, @component.notification) if @component&.notification&.notification_complete?
+
     authorize @component.notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
     @component_name = @component.notification.is_multicomponent? ? @component.name : "the product"
   end

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -95,6 +95,9 @@ private
 
   def set_component
     @component = Component.find(params[:component_id])
+
+    return redirect_to responsible_person_notification_path(@component.notification.responsible_person, @component.notification) if @component&.notification&.notification_complete?
+
     authorize @component.notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -95,6 +95,9 @@ private
 
   def set_notification
     @notification = Notification.find_by reference_number: params[:notification_reference_number]
+
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/trigger_questions_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/trigger_questions_controller.rb
@@ -37,7 +37,10 @@ private
 
   def set_component
     @component = Component.find(params[:component_id])
-    authorize @component.notification, policy_class: ResponsiblePersonNotificationPolicy
+
+    return redirect_to responsible_person_notification_path(@component.notification.responsible_person, @component.notification) if @component&.notification&.notification_complete?
+
+    authorize @component.notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
     @component_name = @component.notification.is_multicomponent? ? @component.name : "the cosmetic product"
   end
 

--- a/cosmetics-web/spec/controllers/formulation_upload_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/formulation_upload_controller_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe ResponsiblePersons::FormulationUploadController, :with_stubbed_an
         get(:new, params: other_responsible_person_params)
       }.to raise_error(Pundit::NotAuthorizedError)
     end
+
+    context "when the notification is already submitted" do
+      subject(:request) { get(:new, params: params) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
+    end
   end
 
   describe "POST #create" do
@@ -84,11 +94,14 @@ RSpec.describe ResponsiblePersons::FormulationUploadController, :with_stubbed_an
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "does not let the user submit the form for a component for a completed notification" do
-      notification.update state: "notification_complete"
-      expect {
-        post(:create, params: params.merge(formulation_file: pdf_file))
-      }.to raise_error(Pundit::NotAuthorizedError)
+    context "when the notification is already submitted" do
+      subject(:request) { post(:create, params: params.merge(formulation_file: pdf_file)) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
     end
   end
 end

--- a/cosmetics-web/spec/controllers/nanomaterial_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/nanomaterial_build_controller_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :controller do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
-  let(:notification) { create(:notification, components: [create(:component)], responsible_person: responsible_person) }
-  let(:component) { notification.components.first }
+  let(:notification) { create(:notification, responsible_person: responsible_person) }
+  let(:component) { create(:component, notification: notification) }
 
   let(:nanomaterial) do
     create(:nano_material,
@@ -41,6 +41,16 @@ RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :c
   end
 
   describe "GET #show" do
+    context "when the notification is already submitted" do
+      subject(:request) { get(:show, params: params.merge({ id: "confirm_usage" })) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
+    end
+
     it "assigns the correct component" do
       get(:show, params: params.merge(id: :select_purposes))
       expect(assigns(:component)).to eq(component)

--- a/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
@@ -58,11 +58,14 @@ RSpec.describe ResponsiblePersons::Wizard::NotificationBuildController, :with_st
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "does not allow the user to update a notification that has already been submitted" do
-      notification.update state: "notification_complete"
-      expect {
-        get(:show, params: params.merge(id: :add_product_name))
-      }.to raise_error(Pundit::NotAuthorizedError)
+    context "when the notification is already submitted" do
+      subject(:request) { get(:show, params: params.merge({ id: "add_internal_reference" })) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
     end
   end
 
@@ -142,11 +145,14 @@ RSpec.describe ResponsiblePersons::Wizard::NotificationBuildController, :with_st
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "does not allow the user to update a notification that has already been submitted" do
-      notification.update state: "notification_complete"
-      expect {
-        post(:update, params: params.merge(id: :add_product_name, notification: { product_name: "Super Shampoo" }))
-      }.to raise_error(Pundit::NotAuthorizedError)
+    context "when the notification is already submitted" do
+      subject(:request) { post(:update, params: params.merge(id: :add_product_name, notification: { product_name: "Super Shampoo" })) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
     end
 
     context "when pressing 'Continue' from the List of components page" do

--- a/cosmetics-web/spec/controllers/product_image_upload_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/product_image_upload_controller_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe ResponsiblePersons::ProductImageUploadController, :with_stubbed_a
         get(:new, params: other_responsible_person_params)
       }.to raise_error(Pundit::NotAuthorizedError)
     end
+
+    context "when the notification is already submitted" do
+      subject(:request) { get(:new, params: params) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
+    end
   end
 
   describe "POST #create" do
@@ -84,11 +94,14 @@ RSpec.describe ResponsiblePersons::ProductImageUploadController, :with_stubbed_a
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "does not let the user submit the form for a component for a completed notification" do
-      notification.update state: "notification_complete"
-      expect {
-        post(:create, params: params.merge(image_upload: [image_file]))
-      }.to raise_error(Pundit::NotAuthorizedError)
+    context "when the notification is already submitted" do
+      subject(:request) { post(:create, params: params.merge(image_upload: [image_file])) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "does not let the user submit the form" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
     end
   end
 end

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
@@ -149,6 +149,16 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
         get :edit, params: { responsible_person_id: other_responsible_person.id, reference_number: other_notification.reference_number }
       }.to raise_error(Pundit::NotAuthorizedError)
     end
+
+    context "when the notification is already submitted" do
+      subject(:request) { get(:edit, params: { responsible_person_id: responsible_person.id, reference_number: notification.reference_number }) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
+    end
   end
 
   describe "POST /confirm" do

--- a/cosmetics-web/spec/controllers/responsible_persons/trigger_questions_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/trigger_questions_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ResponsiblePersons::Wizard::TriggerQuestionsController, :with_stubbed_antivirus, type: :controller do
+  let(:user) { build(:submit_user) }
+  let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+  let(:component) { create(:component, notification: notification) }
+
+  before do
+    sign_in_as_member_of_responsible_person(responsible_person, user)
+  end
+
+  after do
+    sign_out(:submit_user)
+  end
+
+  describe "GET #show" do
+    context "when the notification is already submitted" do
+      subject(:request) { get(:show, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number, component_id: component.id, id: "select_ph_range" }) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-1036

## Description
When the user has completed a notification they may subsequently use the browser's history to navigate back to a wizard page for that notification. Rather than throwing an uncaught exception this change redirects the user to the summary page for that notification.

So far we have seen 89 instances of this error in production so this will eliminate future occurrences.

Fixes these issues which can be marked as resolved once deployed:

https://sentry.io/organizations/beis/issues/2123870623/?environment=prod&project=1398436
https://sentry.io/organizations/beis/issues/2124963423/?environment=prod&project=1398436
https://sentry.io/organizations/beis/issues/2124963343/?environment=prod&project=1398436
https://sentry.io/organizations/beis/issues/2124722739/?environment=prod&project=1398436
https://sentry.io/organizations/beis/issues/2126674565/?environment=prod&project=1398436
https://sentry.io/organizations/beis/issues/2126152205/?environment=prod&project=1398436
https://sentry.io/organizations/beis/issues/2125879994/?environment=prod&project=1398436
https://sentry.io/organizations/beis/issues/2125878751/?environment=prod&project=1398436

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
