### PR TITLE
Redirect on additional info pages when notification complete

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
@@ -24,6 +24,9 @@ private
 
   def set_notification
     @notification = Notification.find_by reference_number: params[:notification_reference_number]
+
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 end

--- a/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
@@ -46,11 +46,14 @@ RSpec.describe ResponsiblePersons::AdditionalInformationController, :with_stubbe
       expect(response).to redirect_to(new_responsible_person_notification_product_image_upload_path(responsible_person, notification))
     end
 
-    it "raised a NotAuthorizedError if the notification has already been submitted" do
-      notification = Notification.create(responsible_person_id: responsible_person.id, components: [predefined_component], state: "notification_complete")
-      expect {
-        get :index, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }
-      }.to raise_error(Pundit::NotAuthorizedError)
+    context "when the notification is already submitted" do
+      subject(:request) { get(:index, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person, components: [predefined_component]) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
     end
 
     context "when a notification has multiple components" do


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-1036

## Description
When the user creates a manual notification they may navigate through the history back to the additional information pages of the notification wizard. Instead of throwing an uncaught exception this change will redirect the user to the notification's summary page.

This will resolve https://sentry.io/organizations/beis/issues/2135407690/?project=1398436.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
