### PR TITLE
Fix additional info when notification complete

### DIFF
--- a/cosmetics-web/app/analyzers/master_analyzer.rb
+++ b/cosmetics-web/app/analyzers/master_analyzer.rb
@@ -1,16 +1,28 @@
 class MasterAnalyzer < ActiveStorage::Analyzer
+  include AnalyzerHelper
+
   def self.accept?(_blob)
     true
   end
 
   # Collect metadata from all of the other analyzers to add to the blob
   def metadata
-    Rails.application.config.document_analyzers.each do |analyzer_class|
-      if analyzer_class.accept? @blob
-        analyzer = analyzer_class.new @blob
-        @blob.metadata.merge!(analyzer.metadata)
+    notification_file = get_notification_file_from_blob(@blob)
+
+    begin
+      Rails.application.config.document_analyzers.each do |analyzer_class|
+        if analyzer_class.accept? @blob
+          analyzer = analyzer_class.new @blob
+          @blob.metadata.merge!(analyzer.metadata)
+        end
       end
+    rescue Aws::S3::Errors::NotFound
+      notification_file.update(upload_error: :file_upload_failed) if notification_file.present?
     end
+
+    # Process notification file only after analysing is complete
+    NotificationFileProcessorJob.perform_later(notification_file.id) if notification_file.present?
+
     @blob.metadata
   end
 end

--- a/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
@@ -24,6 +24,9 @@ private
 
   def set_notification
     @notification = Notification.find_by reference_number: params[:notification_reference_number]
+
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 end

--- a/cosmetics-web/app/controllers/responsible_persons/notification_files_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notification_files_controller.rb
@@ -42,8 +42,6 @@ class ResponsiblePersons::NotificationFilesController < SubmitApplicationControl
         return render :new
       end
       Rails.logger.info "[#{uuid}][NotificationFileUpload][d=#{Time.zone.now.to_f - t1}] notification file saved"
-
-      NotificationFileProcessorJob.perform_later(notification_file.id)
     end
     Rails.logger.info "[#{uuid}][NotificationFileUpload][d=#{Time.zone.now.to_f - t1}] after adding notification files"
 

--- a/cosmetics-web/app/jobs/notification_file_processor_job.rb
+++ b/cosmetics-web/app/jobs/notification_file_processor_job.rb
@@ -11,6 +11,9 @@ class NotificationFileProcessorJob < ApplicationJob
 
   def perform(notification_file_id)
     @notification_file = NotificationFile.find(notification_file_id)
+
+    return if @notification_file.upload_error.present?
+
     create_notification_from_file
     delete_notification_file if @notification_file.upload_error.blank?
   end

--- a/cosmetics-web/app/models/notification_file.rb
+++ b/cosmetics-web/app/models/notification_file.rb
@@ -20,6 +20,7 @@ class NotificationFile < ApplicationRecord
     notification_duplicated: "notification_duplicated",
     notification_validation_error: "notification_validation_error",
     draft_notification_error: "draft_notification_error",
+    file_upload_failed: "file_upload_failed",
     unknown_error: "unknown_error",
   }
 

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
           notification_duplicated: "A notification for this product already exists for this responsible person"
           notification_validation_error: "Try again or manually enter the production notification data"
           draft_notification_error: "The uploaded file is for a draft notification"
+          file_upload_failed: "The file upload failed. Please try again"
           unknown_error: "Try again or manually enter the production notification data"
       notification:
         ph_min_value: "pH"

--- a/cosmetics-web/spec/analyzers/master_analyzer_spec.rb
+++ b/cosmetics-web/spec/analyzers/master_analyzer_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe MasterAnalyzer, type: :analyzer, without_default_file_analyzers: true do
+  subject(:analyzer) { described_class.new(blob) }
+
+  describe "#metadata" do
+    context "with a notification file" do
+      let(:notification_file) { create(:notification_file, uploaded_file: create_file_blob("testExportFile.zip")) }
+      let(:blob) { notification_file.uploaded_file }
+
+      context "when there is an error downloading the file", :with_stubbed_s3_returning_not_found do
+        before { Rails.application.config.document_analyzers.append AntiVirusAnalyzer }
+
+        it "sets an error on the notification file record" do
+          expect { analyzer.metadata }.to change { notification_file.reload.upload_error }.from(nil).to("file_upload_failed")
+        end
+      end
+
+      it "schedules NotificationFileProcessorJob" do
+        allow(NotificationFileProcessorJob).to receive(:perform_later)
+        analyzer.metadata
+        expect(NotificationFileProcessorJob).to have_received(:perform_later).with(notification_file.id)
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
@@ -46,11 +46,14 @@ RSpec.describe ResponsiblePersons::AdditionalInformationController, :with_stubbe
       expect(response).to redirect_to(new_responsible_person_notification_product_image_upload_path(responsible_person, notification))
     end
 
-    it "raised a NotAuthorizedError if the notification has already been submitted" do
-      notification = Notification.create(responsible_person_id: responsible_person.id, components: [predefined_component], state: "notification_complete")
-      expect {
-        get :index, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }
-      }.to raise_error(Pundit::NotAuthorizedError)
+    context "when the notification is already submitted" do
+      subject(:request) { get(:index, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }) }
+
+      let(:notification) { create(:registered_notification, responsible_person: responsible_person, components: [predefined_component]) }
+
+      it "redirects to the notifications page" do
+        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
     end
 
     context "when a notification has multiple components" do

--- a/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
+++ b/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
@@ -458,4 +458,24 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
       expect_to_see_notification_error("The uploaded file has been flagged as a virus")
     end
   end
+
+  feature "handling file uplaod errors", :with_stubbed_s3_returning_not_found do
+    scenario "When the upload to AWS S3 fails" do
+      visit new_responsible_person_add_notification_path(responsible_person)
+
+      expect_to_be_on__was_eu_notified_about_products_page
+      answer_was_eu_notified_with "Yes"
+
+      expect_to_be_on__do_you_have_the_zip_files_page
+      answer_do_you_have_zip_files_with "Yes"
+
+      expect_to_be_on__upload_eu_notification_files_page
+      upload_zip_file "testExportFile.zip"
+
+      visit responsible_person_notifications_path(responsible_person)
+
+      expect(page).to have_link("Errors (1)", href: "#errors")
+      expect_to_see_notification_error("The file upload failed. Please try again")
+    end
+  end
 end

--- a/cosmetics-web/spec/support/analyzers.rb
+++ b/cosmetics-web/spec/support/analyzers.rb
@@ -1,0 +1,32 @@
+RSpec.shared_context "without default file analyzers", shared_context: :metadata do
+  # rubocop:disable RSpec/InstanceVariable
+  before do
+    @default_analyzers = Rails.application.config.active_storage.analyzers
+    @default_analyzers.each { |analyzer| Rails.application.config.active_storage.analyzers.delete(analyzer) }
+
+    @default_document_analyzers = Rails.application.config.document_analyzers
+    @default_document_analyzers.each { |analyzer| Rails.application.config.document_analyzers.delete(analyzer) }
+  end
+
+  after do
+    Rails.application.config.active_storage.analyzers = @default_analyzers
+    Rails.application.config.document_analyzers = @default_document_analyzers
+  end
+  # rubocop:enable RSpec/InstanceVariable
+end
+
+RSpec.configure do |rspec|
+  rspec.include_context "without default file analyzers", without_default_file_analyzers: true
+end
+
+RSpec.shared_context "with AWS S3 returning a 404 error", shared_context: :metadata do
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(AntiVirusAnalyzer).to receive(:download_blob_to_tempfile).and_raise(Aws::S3::Errors::NotFound.new("test", "test"))
+    # rubocop:enable RSpec/AnyInstance
+  end
+end
+
+RSpec.configure do |rspec|
+  rspec.include_context "with AWS S3 returning a 404 error", with_stubbed_s3_returning_not_found: true
+end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-1003

## Description
Fixes the following issues:

* `Aws::S3::Errors::NotFound` exceptions not caught when attempting to analyse an uploaded file (most likely due to a request timeout). Now an error message will appear on the notification files list to inform the user of a problem and to try again.
* Notification file processing could be started before the anti virus check has been completed. This is due to a race condition caused by the controller scheduling the job at the same time as the file is uploaded. Since both jobs are asynchronous, there's no guarantee that the analyser job is completed first. Now the analyser job will schedule the processing job only once it is completed.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
