### PR TITLE
Remove download link to predefined frame formulations

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/wizard/component_build/select_frame_formulation.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/component_build/select_frame_formulation.html.erb
@@ -14,8 +14,6 @@
 
       <h1 class="govuk-fieldset__heading govuk-label--l"><%= title %></h1>
 
-      <p class="govuk-body">Download list of <%= link_to("predefined frame formulations (PDF)", "#") %></p>
-
       <%= render "form_components/govuk_select", form: form, key: :frame_formulation,
                 show_all_values: true, is_autocomplete: true,
                 label: { text: question, classes: "govuk-label--m", isPageHeading: true },


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-1018

## Description
Predefined frame formulation on frame formulation page not working - this commit removes it as per the jira ticket
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
