### PR TITLE
Fix back link from new RP type selection

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/account_wizard/select_type.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/select_type.html.erb
@@ -2,8 +2,10 @@
 <% content_for :after_header do %>
   <% default_back_path =  if current_user.responsible_persons.none?
                             wizard_path(:create_or_join_existing)
-                          else
+                          elsif current_responsible_person.present?
                             responsible_person_path(current_responsible_person)
+                          else
+                            select_responsible_persons_path
                           end
   %>
   <%= link_to "Back", request.referer.present? ? request.referer : default_back_path, class: "govuk-back-link" %>


### PR DESCRIPTION
[Sentry related error](https://sentry.io/organizations/beis/issues/2052277308)
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1047)
When a user belonging to multiple RP reached this page before having selected their current RP, the backlink route was throwing an exception.

Fixed by pointing the backlink to the RP selection when the user has multiple RPs, none of them is defined as their current one.
