### PR TITLE
Show correct error text for notification before brexit

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/wizard/add_notification_wizard_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/add_notification_wizard_controller.rb
@@ -16,7 +16,6 @@ class ResponsiblePersons::Wizard::AddNotificationWizardController < SubmitApplic
   def update
     answer = params[:answer]
     if answer != "yes" && answer != "no"
-
       @error_text = case step
                     when :do_you_have_files_from_eu_notification
                       "Select yes if you have EU notification files"
@@ -24,6 +23,8 @@ class ResponsiblePersons::Wizard::AddNotificationWizardController < SubmitApplic
                       "Select yes if you’re likely to notify the EU about these products"
                     when :have_products_been_notified_in_eu
                       "Select yes if the EU has been notified about these products using CPNP"
+                    when :was_product_on_sale_before_eu_exit
+                      "Select yes if the EU was notified about the nanomaterial before 1 January 2021"
                     else
                       "Select an option"
                     end

--- a/cosmetics-web/spec/controllers/responsible_persons/add_notification_wizard_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/add_notification_wizard_controller_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe ResponsiblePersons::Wizard::AddNotificationWizardController, type
         put(:update, params: { responsible_person_id: responsible_person.id, id: "have_products_been_notified_in_eu" })
         expect(assigns(:error_text)).to eq("Select yes if the EU has been notified about these products using CPNP")
       end
+
+      it "adds error message if no option selected for `was_product_on_sale_before_eu_exit`" do
+        put(:update, params: { responsible_person_id: responsible_person.id, id: "was_product_on_sale_before_eu_exit" })
+        expect(assigns(:error_text)).to eq("Select yes if the EU was notified about the nanomaterial before 1 January 2021")
+      end
     end
 
     describe "GET #new" do


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-1027

## Description
Prior to this PR when a user did not enter an answer to the `was_product_on_sale_before_eu_exit` the app showed a generic error message. This was because the relevant step wasn't in the case statement in the `AddNotificationWizardController`. This PR fixes this issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
