### PR TITLE
Don't allow users to have the option to select how they want to give a cosmetic product formulation

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -292,7 +292,10 @@ private
   def render_upload_formulation
     formulation_file = params.dig(:component, :formulation_file)
 
-    if formulation_file.present?
+    if @component.notification.was_notified_before_eu_exit?
+      @component.formulation_file.attach(formulation_file) if formulation_file.present?
+      redirect_to edit_responsible_person_notification_path(@component.notification.responsible_person, @component.notification)
+    elsif formulation_file.present?
       @component.formulation_file.attach(formulation_file)
       if @component.valid?
         redirect_to finish_wizard_path
@@ -300,9 +303,6 @@ private
         @component.formulation_file.purge if @component.formulation_file.attached?
         render step
       end
-    elsif @component.notification.was_notified_before_eu_exit?
-      @component.formulation_file.attach(formulation_file) if formulation_file.present?
-      redirect_to finish_wizard_path
     else
       @component.errors.add :formulation_file, "Upload a list of ingredients"
       render step

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -37,6 +37,11 @@ class ResponsiblePersons::Wizard::ComponentBuildController < SubmitApplicationCo
       create_required_cmrs
     when :list_nanomaterials
       setup_nano_elements
+    when :select_formulation_type
+      if @component.notification.was_notified_before_eu_exit?
+        @component.update(notification_type: "predefined")
+        jump_to(:select_frame_formulation)
+      end
     end
     render_wizard
   end

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -282,7 +282,7 @@ private
     end
 
     @component.update!(contains_poisonous_ingredients: params[:component][:contains_poisonous_ingredients])
-    if @component.contains_poisonous_ingredients?
+    if @component.contains_poisonous_ingredients? && !@component.notification.was_notified_before_eu_exit?
       redirect_to responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :upload_formulation)
     else
       redirect_to finish_wizard_path

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -268,12 +268,7 @@ private
 
   def update_frame_formulation
     if @component.update_with_context(component_params, :select_frame_formulation)
-
-      if @component.notification.was_notified_after_eu_exit?
-        redirect_to responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :contains_poisonous_ingredients)
-      else
-        redirect_to responsible_person_notification_component_trigger_question_path(@component.notification.responsible_person, @component.notification, @component, :select_ph_range)
-      end
+      redirect_to responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :contains_poisonous_ingredients)
     else
       render :select_frame_formulation
     end
@@ -305,6 +300,9 @@ private
         @component.formulation_file.purge if @component.formulation_file.attached?
         render step
       end
+    elsif @component.notification.was_notified_before_eu_exit?
+      @component.formulation_file.attach(formulation_file) if formulation_file.present?
+      redirect_to finish_wizard_path
     else
       @component.errors.add :formulation_file, "Upload a list of ingredients"
       render step

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -282,7 +282,7 @@ private
     end
 
     @component.update!(contains_poisonous_ingredients: params[:component][:contains_poisonous_ingredients])
-    if @component.contains_poisonous_ingredients? && !@component.notification.was_notified_before_eu_exit?
+    if @component.contains_poisonous_ingredients? && @component.notification.was_notified_after_eu_exit?
       redirect_to responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :upload_formulation)
     else
       redirect_to finish_wizard_path

--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -16,6 +16,8 @@ module ComponentBuildHelper
       wizard_path(:select_category, category: Component.get_parent_category(@category))
     elsif step == :upload_formulation && @component.predefined?
       wizard_path(:contains_poisonous_ingredients)
+    elsif step == :select_frame_formulation && @component.notification.was_notified_before_eu_exit?
+      wizard_path(:select_category)
     elsif previous_step.present?
       responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, previous_step)
     else

--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -16,8 +16,6 @@ module ComponentBuildHelper
       wizard_path(:select_category, category: Component.get_parent_category(@category))
     elsif step == :upload_formulation && @component.predefined?
       wizard_path(:contains_poisonous_ingredients)
-    elsif step == :select_frame_formulation && @component.notification.was_notified_before_eu_exit?
-      wizard_path(:select_category)
     elsif previous_step.present?
       responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, previous_step)
     else

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -143,7 +143,7 @@
         <%= component.contains_poisonous_ingredients.present? ? "Yes" : "No" %>
       </td>
     </tr>
-    <% if component.notification.was_notified_before_eu_exit? && component.contains_poisonous_ingredients.present? %>
+    <% if component.contains_poisonous_ingredients.present? %>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row">Poisonous ingredients</th>
         <td class="govuk-table__cell">

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -147,9 +147,21 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row">Poisonous ingredients</th>
         <td class="govuk-table__cell">
-          <%= link_to "Add poisonous ingredients document",
-                  responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :upload_formulation),
-                  class: "govuk-link--no-visited-state" %>
+          <% if component.formulation_file.attached? %>
+            <% if component.formulation_file.metadata["safe"] %>
+              <%= link_to component.formulation_file.filename, url_for(component.formulation_file) %>
+            <% else %>
+              <%= "Processing file #{component.formulation_file.filename} ..." %>
+              <br>
+              <%= link_to "Refresh",
+                      edit_responsible_person_notification_path(@responsible_person, @notification),
+                      class: "govuk-link--no-visited-state" %>
+            <% end %>
+          <% else %>
+            <%= link_to "Add poisonous ingredients document",
+                    responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :upload_formulation),
+                    class: "govuk-link--no-visited-state" %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -143,6 +143,16 @@
         <%= component.contains_poisonous_ingredients.present? ? "Yes" : "No" %>
       </td>
     </tr>
+    <% if component.notification.was_notified_before_eu_exit? && component.contains_poisonous_ingredients.present? %>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="row">Poisonous ingredients</th>
+        <td class="govuk-table__cell">
+          <%= link_to "Add poisonous ingredients document",
+                  responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :upload_formulation),
+                  class: "govuk-link--no-visited-state" %>
+        </td>
+      </tr>
+    <% end %>
   <% end %>
   <% if component.trigger_questions %>
     <%= render "notifications/ph", component: component %>

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -86,12 +86,14 @@
         <% elsif component.formulation_file.attached? %>
           <% if component.formulation_file.metadata["safe"] %>
             <%= link_to component.formulation_file.filename, url_for(component.formulation_file) %>
-          <% else %>
+          <% elsif component.formulation_file.metadata["safe"].nil? %>
             <%= "Processing file #{component.formulation_file.filename} ..." %>
             <br>
             <%= link_to "Refresh",
                     edit_responsible_person_notification_path(@responsible_person, @notification),
                     class: "govuk-link--no-visited-state" %>
+          <% else %>
+            <%= "The uploaded file has been flagged as a virus" %>
           <% end %>
         <% elsif allow_edits %>
           <%= link_to "Add formulation document",
@@ -150,12 +152,14 @@
           <% if component.formulation_file.attached? %>
             <% if component.formulation_file.metadata["safe"] %>
               <%= link_to component.formulation_file.filename, url_for(component.formulation_file) %>
-            <% else %>
+            <% elsif component.formulation_file.metadata["safe"].nil? %>
               <%= "Processing file #{component.formulation_file.filename} ..." %>
               <br>
               <%= link_to "Refresh",
                       edit_responsible_person_notification_path(@responsible_person, @notification),
                       class: "govuk-link--no-visited-state" %>
+            <% else %>
+              <%= "The uploaded file has been flagged as a virus" %>
             <% end %>
           <% else %>
             <%= link_to "Add poisonous ingredients document",

--- a/cosmetics-web/spec/controllers/component_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/component_build_controller_spec.rb
@@ -277,12 +277,6 @@ RSpec.describe ResponsiblePersons::Wizard::ComponentBuildController, type: :cont
         post(:update, params: params.merge(id: :add_physical_form, component: { physical_form: "loose powder" }))
         expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, pre_eu_exit_notification, component, :contains_nanomaterials))
       end
-
-      it "skips contains poisonous ingredients question and redirects to PH question" do
-        post(:update, params: params.merge(id: :select_frame_formulation, component: { frame_formulation: "skin_care_cream_lotion_gel" }))
-
-        expect(response).to redirect_to(responsible_person_notification_component_trigger_question_path(responsible_person, pre_eu_exit_notification, component, :select_ph_range))
-      end
     end
   end
 

--- a/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
@@ -7,144 +7,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     sign_in_as_member_of_responsible_person(responsible_person)
   end
 
-  scenario "Manual, pre-Brexit, exact ingredients, single item, no nanomaterials", :with_stubbed_antivirus do
-    visit new_responsible_person_add_notification_path(responsible_person)
-
-    expect_to_be_on__was_eu_notified_about_products_page
-    answer_was_eu_notified_with "Yes"
-
-    expect_to_be_on__do_you_have_the_zip_files_page
-    answer_do_you_have_zip_files_with "No, I’ll enter information manually"
-
-    expect_to_be_on__was_product_notified_before_brexit_page
-    answer_was_product_notified_before_brexit_with "Yes"
-
-    expect_to_be_on__what_is_product_called_page
-    answer_product_name_with "SkinSoft tangerine shampoo"
-
-    expect_to_be_on__internal_reference_page
-    answer_do_you_want_to_give_an_internal_reference_with "No"
-
-    expect_to_be_on__multi_item_kits_page
-    answer_is_product_multi_item_kit_with "No, this is a single product"
-
-    expect_to_be_on__is_item_available_in_shades_page
-    answer_is_item_available_in_shades_with "No"
-
-    expect_to_be_on__physical_form_of_item_page
-    answer_what_is_physical_form_of_item_with "Liquid"
-
-    expect_to_be_on__does_item_contain_nanomaterial_page
-    answer_does_item_contain_nanomaterials_with "No"
-
-    expect_to_be_on__item_category_page
-    answer_item_category_with "Hair and scalp products"
-
-    expect_to_be_on__item_subcategoy_page(category: "hair and scalp products")
-    answer_item_subcategory_with "Hair and scalp care and cleansing products"
-
-    expect_to_be_on__item_sub_subcategory_page(subcategory: "hair and scalp care and cleansing products")
-    answer_item_sub_subcategory_with "Shampoo"
-
-    expect_to_be_on__formulation_method_page
-    answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration"
-
-    expect_to_be_on__upload_ingredients_page "Exact concentrations of the ingredients"
-    upload_ingredients_pdf
-
-    expect_to_be_on__what_is_ph_range_of_product_page
-    answer_what_is_ph_range_of_product_with "The minimum pH is 3 or higher, and the maximum pH is 10 or lower"
-
-    expect_to_be_on__check_your_answers_page(product_name: "SkinSoft tangerine shampoo")
-
-    expect_check_your_answers_page_to_contain(
-      product_name: "SkinSoft tangerine shampoo",
-      number_of_components: "1",
-      shades: "None",
-      contains_cmrs: "No",
-      nanomaterials: "None",
-      category: "Hair and scalp products",
-      subcategory: "Hair and scalp care and cleansing products",
-      sub_subcategory: "Shampoo",
-      formulation_given_as: "Exact concentration",
-      physical_form: "Liquid",
-      ph: "Between 3 and 10",
-    )
-    click_button "Accept and submit the cosmetic product notification"
-
-    expect_to_be_on__your_cosmetic_products_page
-    expect_to_see_message "SkinSoft tangerine shampoo notification submitted"
-  end
-
-  scenario "Manual, pre-Brexit, ingredient ranges, single item, no nanomaterials", :with_stubbed_antivirus do
-    visit new_responsible_person_add_notification_path(responsible_person)
-
-    expect_to_be_on__was_eu_notified_about_products_page
-    answer_was_eu_notified_with "Yes"
-
-    expect_to_be_on__do_you_have_the_zip_files_page
-    answer_do_you_have_zip_files_with "No, I’ll enter information manually"
-
-    expect_to_be_on__was_product_notified_before_brexit_page
-    answer_was_product_notified_before_brexit_with "Yes"
-
-    expect_to_be_on__what_is_product_called_page
-    answer_product_name_with "SkinSoft tangerine shampoo"
-
-    expect_to_be_on__internal_reference_page
-    answer_do_you_want_to_give_an_internal_reference_with "No"
-
-    expect_to_be_on__multi_item_kits_page
-    answer_is_product_multi_item_kit_with "No, this is a single product"
-
-    expect_to_be_on__is_item_available_in_shades_page
-    answer_is_item_available_in_shades_with "No"
-
-    expect_to_be_on__physical_form_of_item_page
-    answer_what_is_physical_form_of_item_with "Liquid"
-
-    expect_to_be_on__does_item_contain_nanomaterial_page
-    answer_does_item_contain_nanomaterials_with "No"
-
-    expect_to_be_on__item_category_page
-    answer_item_category_with "Hair and scalp products"
-
-    expect_to_be_on__item_subcategoy_page(category: "hair and scalp products")
-    answer_item_subcategory_with "Hair and scalp care and cleansing products"
-
-    expect_to_be_on__item_sub_subcategory_page(subcategory: "hair and scalp care and cleansing products")
-    answer_item_sub_subcategory_with "Shampoo"
-
-    expect_to_be_on__formulation_method_page
-    answer_how_do_you_want_to_give_formulation_with "List ingredients and their concentration range"
-
-    expect_to_be_on__upload_ingredients_page "Concentration ranges of the ingredients"
-    upload_ingredients_pdf
-
-    expect_to_be_on__what_is_ph_range_of_product_page
-    answer_what_is_ph_range_of_product_with "The minimum pH is 3 or higher, and the maximum pH is 10 or lower"
-
-    expect_to_be_on__check_your_answers_page(product_name: "SkinSoft tangerine shampoo")
-
-    expect_check_your_answers_page_to_contain(
-      product_name: "SkinSoft tangerine shampoo",
-      number_of_components: "1",
-      shades: "None",
-      contains_cmrs: "No",
-      nanomaterials: "None",
-      category: "Hair and scalp products",
-      subcategory: "Hair and scalp care and cleansing products",
-      sub_subcategory: "Shampoo",
-      formulation_given_as: "Concentration ranges",
-      physical_form: "Liquid",
-      ph: "Between 3 and 10",
-    )
-    click_button "Accept and submit the cosmetic product notification"
-
-    expect_to_be_on__your_cosmetic_products_page
-    expect_to_see_message "SkinSoft tangerine shampoo notification submitted"
-  end
-
   scenario "Manual, pre-Brexit, frame formulation, single item, no nanomaterials", :with_stubbed_antivirus do
     visit new_responsible_person_add_notification_path(responsible_person)
 
@@ -183,9 +45,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "mouth wash / breath spray")
     answer_item_sub_subcategory_with "Mouth wash"
-
-    expect_to_be_on__formulation_method_page
-    answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation"
 
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Mouthwash"
@@ -262,9 +121,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair colouring products", item_name: "SkinSoft strawberry blonde hair colourant")
     answer_item_sub_subcategory_with "Oxidative hair colour products"
 
-    expect_to_be_on__formulation_method_page item_name: "SkinSoft strawberry blonde hair colourant"
-    answer_how_do_you_want_to_give_formulation_with("Choose a predefined frame formulation", item_name: "SkinSoft strawberry blonde hair colourant")
-
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"
 
@@ -294,9 +150,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair colouring products", item_name: "SkinSoft strawberry blonde hair fixer")
     answer_item_sub_subcategory_with "Oxidative hair colour products"
-
-    expect_to_be_on__formulation_method_page item_name: "SkinSoft strawberry blonde hair fixer"
-    answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation", item_name: "SkinSoft strawberry blonde hair fixer"
 
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Or Three Components - Oxidative Part"
@@ -403,9 +256,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__item_sub_subcategory_page(subcategory: "make-up products")
     answer_item_sub_subcategory_with "Eye shadow"
 
-    expect_to_be_on__formulation_method_page
-    answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation"
-
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Eye Shadow, Blusher And Liner (Powder)"
 
@@ -501,9 +351,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair colouring products", item_name: "SkinSoft nano black hair dye kit colourant")
     answer_item_sub_subcategory_with "Oxidative hair colour products"
 
-    expect_to_be_on__formulation_method_page item_name: "SkinSoft nano black hair dye kit colourant"
-    answer_how_do_you_want_to_give_formulation_with("Choose a predefined frame formulation", item_name: "SkinSoft nano black hair dye kit colourant")
-
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"
 
@@ -551,9 +398,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair colouring products", item_name: "SkinSoft nano black hair dye kit fixer")
     answer_item_sub_subcategory_with "Oxidative hair colour products"
-
-    expect_to_be_on__formulation_method_page item_name: "SkinSoft nano black hair dye kit fixer"
-    answer_how_do_you_want_to_give_formulation_with("Choose a predefined frame formulation", item_name: "SkinSoft nano black hair dye kit fixer")
 
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"

--- a/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
@@ -122,9 +122,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__poisonous_ingredients_page
     answer_does_product_contain_poisonous_ingredients_with "Yes"
 
-    expect_to_be_on__upload_poisonous_ingredients_page
-    upload_ingredients_pdf
-
     expect_to_be_on__what_is_ph_range_of_product_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
@@ -144,10 +141,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
       ph: "No pH",
       poisonous_ingredients: "Yes",
     )
-    click_button "Accept and submit the cosmetic product notification"
-
-    expect_to_be_on__your_cosmetic_products_page
-    expect_to_see_message "SkinSoft deep blue mouthwash notification submitted"
 
     click_link "Add poisonous ingredients document"
 
@@ -158,6 +151,12 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft deep blue mouthwash")
+    expect(page).to have_summary_item(key: "Poisonous ingredients", value: "testPdf.pdf")
+
+    click_button "Accept and submit the cosmetic product notification"
+
+    expect_to_be_on__your_cosmetic_products_page
+    expect_to_see_message "SkinSoft deep blue mouthwash notification submitted"
   end
 
   scenario "Manual, pre-Brexit, frame formulation, multi-item, no nanomaterials, no poison", :with_stubbed_antivirus do
@@ -356,9 +355,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
 
     expect_to_be_on__poisonous_ingredients_page
     answer_does_product_contain_poisonous_ingredients_with "Yes"
-
-    expect_to_be_on__upload_poisonous_ingredients_page
-    upload_ingredients_pdf
 
     expect_to_be_on__what_is_ph_range_of_product_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"

--- a/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     sign_in_as_member_of_responsible_person(responsible_person)
   end
 
-  scenario "Manual, pre-Brexit, frame formulation, single item, no nanomaterials", :with_stubbed_antivirus do
+  scenario "Manual, pre-Brexit, frame formulation, single item, no nanomaterials, no poison", :with_stubbed_antivirus do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
@@ -49,6 +49,9 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Mouthwash"
 
+    expect_to_be_on__poisonous_ingredients_page
+    answer_does_product_contain_poisonous_ingredients_with "No"
+
     expect_to_be_on__what_is_ph_range_of_product_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
@@ -66,6 +69,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
       formulation_given_as: "Frame formulation",
       physical_form: "Liquid",
       ph: "No pH",
+      poisonous_ingredients: "No",
     )
     click_button "Accept and submit the cosmetic product notification"
 
@@ -73,7 +77,80 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_see_message "SkinSoft deep blue mouthwash notification submitted"
   end
 
-  scenario "Manual, pre-Brexit, frame formulation, multi-item, no nanomaterials", :with_stubbed_antivirus do
+  scenario "Manual, pre-Brexit, frame formulation, single item, no nanomaterials, with poison", :with_stubbed_antivirus do
+    visit new_responsible_person_add_notification_path(responsible_person)
+
+    expect_to_be_on__was_eu_notified_about_products_page
+    answer_was_eu_notified_with "Yes"
+
+    expect_to_be_on__do_you_have_the_zip_files_page
+    answer_do_you_have_zip_files_with "No, I’ll enter information manually"
+
+    expect_to_be_on__was_product_notified_before_brexit_page
+    answer_was_product_notified_before_brexit_with "Yes"
+
+    expect_to_be_on__what_is_product_called_page
+    answer_product_name_with "SkinSoft deep blue mouthwash"
+
+    expect_to_be_on__internal_reference_page
+    answer_do_you_want_to_give_an_internal_reference_with "No"
+
+    expect_to_be_on__multi_item_kits_page
+    answer_is_product_multi_item_kit_with "No, this is a single product"
+
+    expect_to_be_on__is_item_available_in_shades_page
+    answer_is_item_available_in_shades_with "No"
+
+    expect_to_be_on__physical_form_of_item_page
+    answer_what_is_physical_form_of_item_with "Liquid"
+
+    expect_to_be_on__does_item_contain_nanomaterial_page
+    answer_does_item_contain_nanomaterials_with "No"
+
+    expect_to_be_on__item_category_page
+    answer_item_category_with "Oral hygiene products"
+
+    expect_to_be_on__item_subcategoy_page(category: "oral hygiene products")
+    answer_item_subcategory_with "Mouth wash / breath spray"
+
+    expect_to_be_on__item_sub_subcategory_page(subcategory: "mouth wash / breath spray")
+    answer_item_sub_subcategory_with "Mouth wash"
+
+    expect_to_be_on__frame_formulation_select_page
+    give_frame_formulation_as "Mouthwash"
+
+    expect_to_be_on__poisonous_ingredients_page
+    answer_does_product_contain_poisonous_ingredients_with "Yes"
+
+    expect_to_be_on__upload_poisonous_ingredients_page
+    upload_ingredients_pdf
+
+    expect_to_be_on__what_is_ph_range_of_product_page
+    answer_what_is_ph_range_of_product_with "It does not have a pH"
+
+    expect_to_be_on__check_your_answers_page(product_name: "SkinSoft deep blue mouthwash")
+
+    expect_check_your_answers_page_to_contain(
+      product_name: "SkinSoft deep blue mouthwash",
+      number_of_components: "1",
+      shades: "None",
+      contains_cmrs: "No",
+      nanomaterials: "None",
+      category: "Oral hygiene products",
+      subcategory: "Mouth wash / breath spray",
+      sub_subcategory: "Mouth wash",
+      formulation_given_as: "Frame formulation",
+      physical_form: "Liquid",
+      ph: "No pH",
+      poisonous_ingredients: "Yes",
+    )
+    click_button "Accept and submit the cosmetic product notification"
+
+    expect_to_be_on__your_cosmetic_products_page
+    expect_to_see_message "SkinSoft deep blue mouthwash notification submitted"
+  end
+
+  scenario "Manual, pre-Brexit, frame formulation, multi-item, no nanomaterials, no poison", :with_stubbed_antivirus do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
@@ -124,6 +201,9 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"
 
+    expect_to_be_on__poisonous_ingredients_page
+    answer_does_product_contain_poisonous_ingredients_with "No"
+
     expect_to_be_on__what_is_ph_range_of_product_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
@@ -154,6 +234,9 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Or Three Components - Oxidative Part"
 
+    expect_to_be_on__poisonous_ingredients_page
+    answer_does_product_contain_poisonous_ingredients_with "No"
+
     expect_to_be_on__what_is_ph_range_of_product_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
@@ -178,6 +261,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
           formulation_given_as: "Frame formulation",
           physical_form: "Liquid",
           ph: "No pH",
+          poisonous_ingredients: "No",
         },
         {
           name: "SkinSoft strawberry blonde hair fixer",
@@ -190,6 +274,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
           formulation_given_as: "Frame formulation",
           physical_form: "Liquid",
           ph: "No pH",
+          poisonous_ingredients: "No",
         },
       ],
     )
@@ -199,7 +284,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_see_message "SkinSoft strawberry blonde hair dye notification submitted"
   end
 
-  scenario "Manual, pre-Brexit, frame formulation, single item, with nanomaterials", :with_stubbed_antivirus do
+  scenario "Manual, pre-Brexit, frame formulation, single item, with nanomaterials, with poison", :with_stubbed_antivirus do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
@@ -259,6 +344,12 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Eye Shadow, Blusher And Liner (Powder)"
 
+    expect_to_be_on__poisonous_ingredients_page
+    answer_does_product_contain_poisonous_ingredients_with "Yes"
+
+    expect_to_be_on__upload_poisonous_ingredients_page
+    upload_ingredients_pdf
+
     expect_to_be_on__what_is_ph_range_of_product_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
@@ -278,6 +369,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
       formulation_given_as: "Frame formulation",
       physical_form: "Solid or pressed powder",
       ph: "No pH",
+      poisonous_ingredients: "Yes",
     )
     click_button "Accept and submit the cosmetic product notification"
 
@@ -285,7 +377,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_see_message "SkinSoft carbon black eyeshadow notification submitted"
   end
 
-  scenario "Manual, pre-Brexit, frame formulation, multi-item, each with nanomaterials", :with_stubbed_antivirus do
+  scenario "Manual, pre-Brexit, frame formulation, multi-item, each with nanomaterials, no poison", :with_stubbed_antivirus do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
@@ -354,6 +446,9 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"
 
+    expect_to_be_on__poisonous_ingredients_page
+    answer_does_product_contain_poisonous_ingredients_with "No"
+
     expect_to_be_on__what_is_ph_range_of_product_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
@@ -402,6 +497,9 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__frame_formulation_select_page
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"
 
+    expect_to_be_on__poisonous_ingredients_page
+    answer_does_product_contain_poisonous_ingredients_with "No"
+
     expect_to_be_on__what_is_ph_range_of_product_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
@@ -428,6 +526,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
           formulation_given_as: "Frame formulation",
           physical_form: "Liquid",
           ph: "No pH",
+          poisonous_ingredients: "No",
         },
         {
           name: "SkinSoft nano black hair dye kit fixer",
@@ -442,6 +541,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
           formulation_given_as: "Frame formulation",
           physical_form: "Liquid",
           ph: "No pH",
+          poisonous_ingredients: "No",
         },
       ],
     )

--- a/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_see_message "SkinSoft deep blue mouthwash notification submitted"
   end
 
-  scenario "Manual, pre-Brexit, frame formulation, single item, no nanomaterials, with poison", :with_stubbed_antivirus do
+  scenario "Manual, pre-Brexit, frame formulation, single item, no nanomaterials, with poison, add poison document", :with_stubbed_antivirus do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
@@ -148,6 +148,16 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
 
     expect_to_be_on__your_cosmetic_products_page
     expect_to_see_message "SkinSoft deep blue mouthwash notification submitted"
+
+    click_link "Add poisonous ingredients document"
+
+    expect_to_be_on__upload_poisonous_ingredients_page
+    upload_ingredients_pdf
+
+    expect_to_be_on__what_is_ph_range_of_product_page
+    answer_what_is_ph_range_of_product_with "It does not have a pH"
+
+    expect_to_be_on__check_your_answers_page(product_name: "SkinSoft deep blue mouthwash")
   end
 
   scenario "Manual, pre-Brexit, frame formulation, multi-item, no nanomaterials, no poison", :with_stubbed_antivirus do

--- a/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
@@ -147,9 +147,6 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     expect_to_be_on__upload_poisonous_ingredients_page
     upload_ingredients_pdf
 
-    expect_to_be_on__what_is_ph_range_of_product_page
-    answer_what_is_ph_range_of_product_with "It does not have a pH"
-
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft deep blue mouthwash")
     expect(page).to have_summary_item(key: "Poisonous ingredients", value: "testPdf.pdf")
 

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -270,7 +270,7 @@ def expect_to_be_on__upload_formulation_document_page(header_text)
 end
 
 # rubocop:disable Naming/MethodParameterName
-def expect_check_your_answers_page_to_contain(product_name:, number_of_components:, shades:, contains_cmrs:, nanomaterials:, category:, subcategory:, sub_subcategory:, formulation_given_as:, frame_formulation: nil, physical_form:, ph: nil, application_instruction: nil, exposure_condition: nil, eu_notification_date: nil)
+def expect_check_your_answers_page_to_contain(product_name:, number_of_components:, shades:, contains_cmrs:, nanomaterials:, category:, subcategory:, sub_subcategory:, formulation_given_as:, frame_formulation: nil, physical_form:, ph: nil, application_instruction: nil, exposure_condition: nil, eu_notification_date: nil, poisonous_ingredients: nil)
   within("#product-table") do
     expect(page).to have_summary_item(key: "Name", value: product_name)
     expect(page).to have_summary_item(key: "Shades", value: shades)
@@ -292,6 +292,10 @@ def expect_check_your_answers_page_to_contain(product_name:, number_of_component
     end
 
     expect(page).to have_summary_item(key: "Physical form", value: physical_form)
+
+    if poisonous_ingredients
+      expect(page).to have_summary_item(key: "Contains poisonous ingredients", value: poisonous_ingredients)
+    end
 
     if ph
       expect(page).to have_summary_item(key: "pH", value: ph)


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-987

## Description
After this change:
- users will not have the option to select how they want to give a cosmetic product formulation if they have notified before Jan 1st 2021 - they will go straight to the choose frame formulation page.
- Show poisonous ingredients file in check your answers page if user has uploaded this file.
- Make poisonous ingredients upload file non-mandatory if user notified after jan 1st.
- Link to upload poisonous ingredients file if user selects `yes` to poisonous ingredients but does not upload the file and has notified after jan 1st.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
