### PR TITLE
Rescue 404 errors when downloading file from S3

### DIFF
--- a/cosmetics-web/app/analyzers/master_analyzer.rb
+++ b/cosmetics-web/app/analyzers/master_analyzer.rb
@@ -16,7 +16,7 @@ class MasterAnalyzer < ActiveStorage::Analyzer
           @blob.metadata.merge!(analyzer.metadata)
         end
       end
-    rescue Aws::S3::Errors::NotFound
+    rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
       notification_file.update(upload_error: :file_upload_failed) if notification_file.present?
     end
 


### PR DESCRIPTION
We are already rescuing the `Aws::S3::Errors::NotFound` exception. `Aws::S3::Errors::NoSuchKey` is also analogous to a 404 HTTP response so the same action should be taken.

I have checked a few of the most recent instances in production. In all cases the matching `ActiveStorage::Blob` record does not exist. Clearly it must have existed given it had an ID and the analyzer job was scheduled.

Most likely this occurs as a result of race conditions. There are a few places where we call `purge` on a blob if it fails validation. It is likely these analyzer jobs are trying to download these files.

Therefore I do not think this error is affecting users, but it is the most common exception being reported currently.

I did not modify the spec as it would just be a repeat of the existing one.