### PR TITLE
Validate phone numbers on contact details page

### DIFF
--- a/cosmetics-web/app/models/contact_person.rb
+++ b/cosmetics-web/app/models/contact_person.rb
@@ -8,4 +8,7 @@ class ContactPerson < ApplicationRecord
             }
   validates :email_address, presence: { message: I18n.t(:blank, scope: "contact_person.email_address") }
   validates :phone_number, presence: true
+  validates :phone_number,
+            phone: { message: I18n.t(:invalid, scope: "contact_person.phone_number"), allow_landline: true },
+            if: -> { phone_number.present? }
 end

--- a/cosmetics-web/app/models/contact_person.rb
+++ b/cosmetics-web/app/models/contact_person.rb
@@ -9,6 +9,6 @@ class ContactPerson < ApplicationRecord
   validates :email_address, presence: { message: I18n.t(:blank, scope: "contact_person.email_address") }
   validates :phone_number, presence: true
   validates :phone_number,
-            phone: { message: I18n.t(:invalid, scope: "contact_person.phone_number"), allow_landline: true },
+            phone: { message: I18n.t(:invalid, scope: "contact_person.phone_number"), allow_landline: true, allow_international: true },
             if: -> { phone_number.present? }
 end

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -228,6 +228,8 @@ en:
     email_address:
       wrong_format: "Enter your email address in the correct format, like name@example.com"
       blank: "Enter your email address"
+    phone_number:
+      invalid: "Enter a valid phone number, like 0344 411 1444 or +44 7700 900 982"
   email_form_validation:
     wrong_email_or_password: "Enter your email address in the correct format, like name@example.com"
     wrong_format: "Enter your email address in the correct format, like name@example.com"
@@ -238,4 +240,3 @@ en:
   sign_user_in:
     email:
       wrong_email_or_password: "Enter correct email address and password"
-

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -638,9 +638,10 @@ def fill_in_rp_contact_details
   expect(page).to have_h1(/Contact person for/)
   fill_in "Full name", with: "Auto-test contact person"
   fill_in "Email address", with: "auto-test@foo"
-  fill_in "Phone number", with: "07984563072"
+  fill_in "Phone number", with: "wowowow"
   click_on "Continue"
   expect(page).to have_text("Enter your email address in the correct format")
+  expect(page).to have_text("Enter a valid phone number, like 0344 411 1444 or +44 7700 900 982")
   fill_in "Full name", with: "Auto-test contact person"
   fill_in "Email address", with: "auto-test@exaple.com"
   fill_in "Phone number", with: "07984563072"

--- a/cosmetics-web/spec/validators/phone_validator_spec.rb
+++ b/cosmetics-web/spec/validators/phone_validator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PhoneValidator do
-  subject(:validator) { validator_class.new(phone, allow_international) }
+  subject(:validator) { validator_class.new(phone, allow_international, allow_landline) }
 
   let(:error_msg) { "Enter a mobile number, like 07700 900 982 or +44 7700 900 982" }
 
@@ -9,17 +9,31 @@ RSpec.describe PhoneValidator do
     Class.new do
       include ActiveModel::Validations
       attr_accessor :phone
-      attr_reader :allow_int
-      validates :phone,
-                phone: { message: ERROR_MSG, allow_international: true },
-                if: :allow_int
-      validates :phone,
-                phone: { message: ERROR_MSG, allow_international: false },
-                unless: :allow_int
+      attr_reader :allow_int_but_no_uk_landlines,
+                  :do_not_allow_int_or_uk_landlines,
+                  :allow_int_and_uk_landlines,
+                  :allow_uk_landlines_but_not_int
 
-      def initialize(phone, allow_int)
+      validates :phone,
+                phone: { message: ERROR_MSG, allow_international: true, allow_landline: false },
+                if: :allow_int_but_no_uk_landlines
+      validates :phone,
+                phone: { message: ERROR_MSG, allow_international: false, allow_landline: false },
+                if: :do_not_allow_int_or_uk_landlines
+      validates :phone,
+                phone: { message: ERROR_MSG, allow_international: true, allow_landline: true },
+                if: :allow_int_and_uk_landlines
+      validates :phone,
+                phone: { message: ERROR_MSG, allow_international: false, allow_landline: true },
+                if: :allow_uk_landlines_but_not_int
+
+      def initialize(phone, allow_int, allow_landline = false)
         @phone = phone
-        @allow_int = allow_int
+
+        @allow_int_but_no_uk_landlines = (allow_int && !allow_landline)
+        @do_not_allow_int_or_uk_landlines = (!allow_int && !allow_landline)
+        @allow_int_and_uk_landlines = (allow_int && allow_landline)
+        @allow_uk_landlines_but_not_int = (!allow_int && allow_landline)
       end
 
       def self.name
@@ -68,6 +82,7 @@ RSpec.describe PhoneValidator do
 
   context "when international numbers are allowed" do
     let(:allow_international) { true }
+    let(:allow_landline) { nil }
 
     valid_phone_numbers = [
       "7123456789",
@@ -99,6 +114,7 @@ RSpec.describe PhoneValidator do
 
   context "when international numbers are not allowed" do
     let(:allow_international) { false }
+    let(:allow_landline) { nil }
 
     valid_phone_numbers = [
       "7123456789",
@@ -115,6 +131,70 @@ RSpec.describe PhoneValidator do
 
     invalid_phone_numbers = [
       "712345671",      # Too short
+      "71234567123",    # Too long
+      "7123LM6789",     # Not allowed characters
+      "00123456789",    # Not UK Phone
+      "+111123 456789", # Not UK Phone
+      "+34629012345",   # Not UK Phone
+    ]
+
+    include_examples "valid phone numbers", valid_phone_numbers
+    include_examples "invalid phone numbers", invalid_phone_numbers
+  end
+
+  context "when uk landlines and international numbers are allowed" do
+    let(:allow_landline) { true }
+    let(:allow_international) { true }
+
+    valid_phone_numbers = [
+      "7123456789",
+      "07123456789",
+      "07123 456789",
+      "07123-456-789",
+      "00447123456789",
+      "00 44 7123456789",
+      "+447123456789",
+      "+44 7123 456 789",
+      "+44 (0)7123 456 789",
+      "\u200B+44 (0)7123 \uFEFF 456 789", # Allowed whitespaces & characters
+      "+34629012345", # Spanish mobile number,
+      "71234567123",  # Too long UK number is valid as Russian phone.
+      "01632 960123", # UK landline number is valid
+    ]
+
+    invalid_phone_numbers = [
+      "712345",                # Too short (even for landline)
+      "7123LM6789",            # Not allowed characters
+      "+48123 4",              # Too short international phone or landline
+      "+48123456789123456789", # Too long international phone
+      "+99029012345",          # '990' Country code not allowed
+      "009904567891",          # '990' Country code not allowed
+    ]
+
+    include_examples "valid phone numbers", valid_phone_numbers
+    include_examples "invalid phone numbers", invalid_phone_numbers
+  end
+
+  context "when uk landlines are allowed but international numbers are not" do
+    let(:allow_landline) { true }
+    let(:allow_international) { false }
+
+    valid_phone_numbers = [
+      "7123456789",
+      "07123456789",
+      "07123 456789",
+      "07123-456-789",
+      "00447123456789",
+      "00 44 7123456789",
+      "+447123456789",
+      "+44 7123 456 789",
+      "+44 (0)7123 456 789",
+      "\u200B+44 (0)7123 \uFEFF 456 789", # Allowed whitespaces & characters
+      "01632 960123", # UK landline number is valid
+    ]
+
+    invalid_phone_numbers = [
+      "712345",         # Too short (even for landline)
       "71234567123",    # Too long
       "7123LM6789",     # Not allowed characters
       "00123456789",    # Not UK Phone


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-1026

## Description
This PR adds validation to the phone number field on the contact details page.

I have made changes to the `phone_validator` class because we need to allow british landlines in this case, not strictly mobile phones (which is necessary validation for 2fa).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
