### PR TITLE
Fix back links through notification flows

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -80,27 +80,15 @@ private
   # through the various sets of questions.
   def previous_path_before_check_your_answers(notification)
     if notification.via_zip_file?
-
       # Incomplete notifications dashboard
       responsible_person_notifications_path(notification.responsible_person, anchor: "incomplete")
-
-    elsif notification.was_notified_after_eu_exit?
-
-      # Last question is image upload page
-      responsible_person_notification_build_path(notification.responsible_person, notification, :add_product_image)
-
     elsif notification.is_multicomponent?
-
       # Last page is the List of components
       responsible_person_notification_build_path(notification.responsible_person, notification, :add_new_component)
-
     else
-
       component = notification.components.first
-
       # Last question was either pH question or exact pH range for the component
       page = component.minimum_ph ? :ph : :select_ph_range
-
       responsible_person_notification_component_trigger_question_path(notification.responsible_person, notification, component, page)
     end
   end

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -42,7 +42,9 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
     case step
     when :select_purposes
       responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :list_nanomaterials)
-    when :confirm_usage, :non_standard_nanomaterial_notified
+    when :confirm_usage
+      wizard_path(:confirm_restrictions)
+    when :non_standard_nanomaterial_notified
       wizard_path(:select_purposes)
     when :when_products_containing_nanomaterial_can_be_placed_on_market, :notify_your_nanomaterial
       wizard_path(:non_standard_nanomaterial_notified)

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -41,7 +41,12 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
   def previous_wizard_path
     case step
     when :select_purposes
-      responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :list_nanomaterials)
+      notification = @component.notification
+      if notification.via_zip_file?
+        responsible_person_notifications_path(notification.responsible_person, anchor: "incomplete")
+      else
+        responsible_person_notification_component_build_path(notification.responsible_person, notification, @component, :list_nanomaterials)
+      end
     when :confirm_usage
       wizard_path(:confirm_restrictions)
     when :non_standard_nanomaterial_notified

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -71,6 +71,10 @@ class ResponsiblePersons::Wizard::NotificationBuildController < SubmitApplicatio
 
     if step == :add_product_name
       responsible_person_add_notification_path(@notification.responsible_person, :have_products_been_notified_in_eu)
+    elsif step == :add_new_component && @notification.state == "draft_complete"
+      last_component = @notification.components.last
+      last_step = last_component.ph_range_not_required? ? :select_ph_range : :ph
+      responsible_person_notification_component_trigger_question_path(@notification.responsible_person, @notification, last_component, last_step)
     elsif previous_step.present?
       responsible_person_notification_build_path(@notification.responsible_person, @notification, previous_step)
     else
@@ -204,6 +208,8 @@ private
     case step
     when :for_children_under_three
       :add_internal_reference
+    when :is_mixed
+      @notification.was_notified_before_eu_exit? ? :single_or_multi_component : :add_product_image
     when :ph_range
       :is_hair_dye
     when :add_new_component

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -217,7 +217,7 @@ private
         :is_mixed
       end
     when :add_product_image
-      @notification.is_multicomponent? ? :add_new_component : :single_or_multi_component
+      :single_or_multi_component
     end
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -70,7 +70,8 @@ class ResponsiblePersons::Wizard::NotificationBuildController < SubmitApplicatio
     previous_step = previous_step(previous_step) if skip_step?(previous_step)
 
     if step == :add_product_name
-      responsible_person_add_notification_path(@notification.responsible_person, :have_products_been_notified_in_eu)
+      last_eu_step = @notification.was_notified_before_eu_exit ? :was_product_on_sale_before_eu_exit : :will_products_be_notified_in_eu
+      responsible_person_add_notification_path(@notification.responsible_person, last_eu_step)
     elsif step == :add_new_component && @notification.state == "draft_complete"
       last_component = @notification.components.last
       last_step = last_component.ph_range_not_required? ? :select_ph_range : :ph

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/trigger_questions_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/trigger_questions_controller.rb
@@ -79,4 +79,15 @@ private
   def ph_param
     { ph: params.fetch(:component, {})[:ph] }
   end
+
+  def previous_wizard_path
+    notification = @component.notification
+    if step == :select_ph_range && notification.was_notified_before_eu_exit?
+      responsible_person_notification_component_build_path(
+        notification.responsible_person, notification, @component, :contains_poisonous_ingredients
+      )
+    else
+      super
+    end
+  end
 end

--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -14,6 +14,8 @@ module ComponentBuildHelper
       responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_product_image)
     elsif step == :select_category && @category.present?
       wizard_path(:select_category, category: Component.get_parent_category(@category))
+    elsif step == :select_formulation_type
+      wizard_path(:select_category, category: @component.sub_category)
     elsif step == :upload_formulation && @component.predefined?
       wizard_path(:contains_poisonous_ingredients)
     elsif step == :select_frame_formulation && @component.notification.was_notified_before_eu_exit?

--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -22,6 +22,8 @@ module ComponentBuildHelper
       responsible_person_notification_component_nanomaterial_build_path(notification.responsible_person, notification, @component, last_nanoelement, nanoelement_step)
     elsif step == :select_formulation_type
       wizard_path(:select_category, category: @component.sub_category)
+    elsif step == :upload_formulation && @component.notification.was_notified_before_eu_exit?
+      edit_responsible_person_notification_path(notification.responsible_person, notification)
     elsif step == :upload_formulation && @component.predefined?
       wizard_path(:contains_poisonous_ingredients)
     elsif step == :select_frame_formulation && @component.notification.was_notified_before_eu_exit?

--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -7,21 +7,27 @@ module ComponentBuildHelper
   def previous_wizard_path
     previous_step = get_previous_step
     previous_step = previous_step(previous_step) if skip_step?(previous_step)
+    notification = @component.notification
 
     if step == :add_component_name
-      responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_new_component)
-    elsif step == :number_of_shades && !@component.notification.is_multicomponent?
-      responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_product_image)
+      responsible_person_notification_build_path(notification.responsible_person, notification, :add_new_component)
+    elsif step == :number_of_shades && !notification.is_multicomponent?
+      last_step = notification.was_notified_before_eu_exit ? :single_or_multi_component : :add_product_image
+      responsible_person_notification_build_path(notification.responsible_person, notification, last_step)
     elsif step == :select_category && @category.present?
       wizard_path(:select_category, category: Component.get_parent_category(@category))
+    elsif step == :select_category && @component&.nano_material.present?
+      last_nanoelement = @component.nano_material.nano_elements.last
+      nanoelement_step = last_nanoelement.standard? ? :confirm_usage : :when_products_containing_nanomaterial_can_be_placed_on_market
+      responsible_person_notification_component_nanomaterial_build_path(notification.responsible_person, notification, @component, last_nanoelement, nanoelement_step)
     elsif step == :select_formulation_type
       wizard_path(:select_category, category: @component.sub_category)
     elsif step == :upload_formulation && @component.predefined?
       wizard_path(:contains_poisonous_ingredients)
     elsif step == :select_frame_formulation && @component.notification.was_notified_before_eu_exit?
-      wizard_path(:select_category)
+      wizard_path(:select_category, category: @component.sub_category)
     elsif previous_step.present?
-      responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, previous_step)
+      responsible_person_notification_component_build_path(notification.responsible_person, notification, @component, previous_step)
     else
       super
     end

--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -11,7 +11,7 @@ module ComponentBuildHelper
     if step == :add_component_name
       responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_new_component)
     elsif step == :number_of_shades && !@component.notification.is_multicomponent?
-      responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :single_or_multi_component)
+      responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_product_image)
     elsif step == :select_category && @category.present?
       wizard_path(:select_category, category: Component.get_parent_category(@category))
     elsif step == :upload_formulation && @component.predefined?

--- a/cosmetics-web/app/views/responsible_persons/notification_files/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notification_files/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Upload your EU notification files" %>
 <% content_for :after_header do %>
-  <%= link_to "Back", responsible_person_add_notification_path(@responsible_person, :have_products_been_notified_in_eu),
+  <%= link_to "Back", responsible_person_add_notification_path(@responsible_person, :do_you_have_files_from_eu_notification),
           class: "govuk-back-link" %>
 <% end %>
 

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
 
     factory :draft_notification do
       state { :draft_complete }
+
+      after(:create) do |notification|
+        create(:component, notification: notification)
+        notification.reload
+      end
     end
 
     factory :imported_notification do

--- a/cosmetics-web/spec/features/manual_post_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_post_brexit_notifications_spec.rb
@@ -12,63 +12,83 @@ RSpec.describe "Manual, pre-Brexit notifications", :with_stubbed_antivirus, type
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "No"
 
     expect_to_be_on__are_you_likely_to_notify_eu_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_are_you_likely_to_notify_eu_with "No"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_are_you_likely_to_notify_eu_page
     answer_product_name_with "SkinSoft tangerine shampoo"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__is_product_for_under_threes_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_for_under_threes_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_is_product_for_under_threes_page
     answer_is_product_multi_item_kit_with "No, this is a single product"
 
     exepct_to_be_on_upload_product_label_page
+    expect_back_link_to_multi_item_kits_page
     upload_product_label
 
     expect_to_be_on__is_item_available_in_shades_page
+    expect_back_link_to_upload_product_label_page
     answer_is_item_available_in_shades_with "No"
 
     expect_to_be_on__physical_form_of_item_page
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid"
 
     expect_to_be_on__what_is_product_contained_in_page
+    expect_back_link_to_physical_form_of_item_page
     answer_what_is_product_contained_in_with "A pressurised container, an impregnated sponge, wipe, patch or pad, or is encapsulated"
 
     expect_to_be_on__what_type_of_applicator_page
+    expect_back_link_to_what_is_product_contained_in_page
     answer_what_type_of_applicator_with "Pressurised spray"
 
     expect_to_be_on__does_item_contain_cmrs_page
+    expect_back_link_to_what_type_of_applicator_page
     answer_does_item_contain_cmrs_with "No"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_does_item_contain_cmrs_page
     answer_does_item_contain_nanomaterials_with "No"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_item_category_with "Hair and scalp products"
 
     expect_to_be_on__item_subcategoy_page(category: "hair and scalp products")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Hair and scalp care and cleansing products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair and scalp care and cleansing products")
+    expect_back_link_to_item_category_page("hair_and_scalp_products")
     answer_item_sub_subcategory_with "Shampoo"
 
     expect_to_be_on__formulation_method_page
+    expect_back_link_to_item_category_page("hair_and_scalp_care_and_cleansing_products")
     answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration"
 
     expect_to_be_on__upload_ingredients_page "Exact concentrations of the ingredients"
+    expect_back_link_to_formulation_method_page
     upload_ingredients_pdf
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_upload_ingredients_page
     answer_what_is_ph_range_of_product_with "The minimum pH is 3 or higher, and the maximum pH is 10 or lower"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft tangerine shampoo")
+    expect_back_link_to_what_is_ph_range_of_product_page
 
     expect_check_your_answers_page_to_contain(
       product_name: "SkinSoft tangerine shampoo",
@@ -93,63 +113,83 @@ RSpec.describe "Manual, pre-Brexit notifications", :with_stubbed_antivirus, type
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "No"
 
     expect_to_be_on__are_you_likely_to_notify_eu_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_are_you_likely_to_notify_eu_with "No"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_are_you_likely_to_notify_eu_page
     answer_product_name_with "SkinSoft tangerine shampoo"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__is_product_for_under_threes_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_for_under_threes_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_is_product_for_under_threes_page
     answer_is_product_multi_item_kit_with "No, this is a single product"
 
     exepct_to_be_on_upload_product_label_page
+    expect_back_link_to_multi_item_kits_page
     upload_product_label
 
     expect_to_be_on__is_item_available_in_shades_page
+    expect_back_link_to_upload_product_label_page
     answer_is_item_available_in_shades_with "No"
 
     expect_to_be_on__physical_form_of_item_page
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid"
 
     expect_to_be_on__what_is_product_contained_in_page
+    expect_back_link_to_physical_form_of_item_page
     answer_what_is_product_contained_in_with "A pressurised container, an impregnated sponge, wipe, patch or pad, or is encapsulated"
 
     expect_to_be_on__what_type_of_applicator_page
+    expect_back_link_to_what_is_product_contained_in_page
     answer_what_type_of_applicator_with "Pressurised spray"
 
     expect_to_be_on__does_item_contain_cmrs_page
+    expect_back_link_to_what_type_of_applicator_page
     answer_does_item_contain_cmrs_with "No"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_does_item_contain_cmrs_page
     answer_does_item_contain_nanomaterials_with "No"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_item_category_with "Hair and scalp products"
 
     expect_to_be_on__item_subcategoy_page(category: "hair and scalp products")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Hair and scalp care and cleansing products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair and scalp care and cleansing products")
+    expect_back_link_to_item_category_page("hair_and_scalp_products")
     answer_item_sub_subcategory_with "Shampoo"
 
     expect_to_be_on__formulation_method_page
+    expect_back_link_to_item_category_page("hair_and_scalp_care_and_cleansing_products")
     answer_how_do_you_want_to_give_formulation_with "List ingredients and their concentration range"
 
     expect_to_be_on__upload_ingredients_page "Concentration ranges of the ingredients"
+    expect_back_link_to_formulation_method_page
     upload_ingredients_pdf
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_upload_ingredients_page
     answer_what_is_ph_range_of_product_with "The minimum pH is 3 or higher, and the maximum pH is 10 or lower"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft tangerine shampoo")
+    expect_back_link_to_what_is_ph_range_of_product_page
 
     expect_check_your_answers_page_to_contain(
       product_name: "SkinSoft tangerine shampoo",
@@ -174,66 +214,87 @@ RSpec.describe "Manual, pre-Brexit notifications", :with_stubbed_antivirus, type
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "No"
 
     expect_to_be_on__are_you_likely_to_notify_eu_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_are_you_likely_to_notify_eu_with "No"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_are_you_likely_to_notify_eu_page
     answer_product_name_with "SkinSoft tangerine shampoo"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__is_product_for_under_threes_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_for_under_threes_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_is_product_for_under_threes_page
     answer_is_product_multi_item_kit_with "No, this is a single product"
 
     exepct_to_be_on_upload_product_label_page
+    expect_back_link_to_multi_item_kits_page
     upload_product_label
 
     expect_to_be_on__is_item_available_in_shades_page
+    expect_back_link_to_upload_product_label_page
     answer_is_item_available_in_shades_with "No"
 
     expect_to_be_on__physical_form_of_item_page
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid"
 
     expect_to_be_on__what_is_product_contained_in_page
+    expect_back_link_to_physical_form_of_item_page
     answer_what_is_product_contained_in_with "A pressurised container, an impregnated sponge, wipe, patch or pad, or is encapsulated"
 
     expect_to_be_on__what_type_of_applicator_page
+    expect_back_link_to_what_is_product_contained_in_page
     answer_what_type_of_applicator_with "Pressurised spray"
 
     expect_to_be_on__does_item_contain_cmrs_page
+    expect_back_link_to_what_type_of_applicator_page
     answer_does_item_contain_cmrs_with "No"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_does_item_contain_cmrs_page
     answer_does_item_contain_nanomaterials_with "No"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_item_category_with "Hair and scalp products"
 
     expect_to_be_on__item_subcategoy_page(category: "hair and scalp products")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Hair and scalp care and cleansing products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair and scalp care and cleansing products")
+    expect_back_link_to_item_category_page("hair_and_scalp_products")
     answer_item_sub_subcategory_with "Shampoo"
 
     expect_to_be_on__formulation_method_page
+    expect_back_link_to_item_category_page("hair_and_scalp_care_and_cleansing_products")
     answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_formulation_method_page
     give_frame_formulation_as "Soap Shampoo"
 
     expect_to_be_on__poisonous_ingredients_page
+    expect_back_link_to_frame_formulation_select_page
     answer_does_product_contain_poisonous_ingredients_with "No"
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "The minimum pH is 3 or higher, and the maximum pH is 10 or lower"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft tangerine shampoo")
+    expect_back_link_to_what_is_ph_range_of_product_page
 
     expect_check_your_answers_page_to_contain(
       product_name: "SkinSoft tangerine shampoo",
@@ -258,69 +319,91 @@ RSpec.describe "Manual, pre-Brexit notifications", :with_stubbed_antivirus, type
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "No"
 
     expect_to_be_on__are_you_likely_to_notify_eu_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_are_you_likely_to_notify_eu_with "No"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_are_you_likely_to_notify_eu_page
     answer_product_name_with "SkinSoft tangerine shampoo"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__is_product_for_under_threes_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_for_under_threes_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_is_product_for_under_threes_page
     answer_is_product_multi_item_kit_with "No, this is a single product"
 
     exepct_to_be_on_upload_product_label_page
+    expect_back_link_to_multi_item_kits_page
     upload_product_label
 
     expect_to_be_on__is_item_available_in_shades_page
+    expect_back_link_to_upload_product_label_page
     answer_is_item_available_in_shades_with "No"
 
     expect_to_be_on__physical_form_of_item_page
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid"
 
     expect_to_be_on__what_is_product_contained_in_page
+    expect_back_link_to_physical_form_of_item_page
     answer_what_is_product_contained_in_with "A pressurised container, an impregnated sponge, wipe, patch or pad, or is encapsulated"
 
     expect_to_be_on__what_type_of_applicator_page
+    expect_back_link_to_what_is_product_contained_in_page
     answer_what_type_of_applicator_with "Pressurised spray"
 
     expect_to_be_on__does_item_contain_cmrs_page
+    expect_back_link_to_what_type_of_applicator_page
     answer_does_item_contain_cmrs_with "No"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_does_item_contain_cmrs_page
     answer_does_item_contain_nanomaterials_with "No"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_item_category_with "Hair and scalp products"
 
     expect_to_be_on__item_subcategoy_page(category: "hair and scalp products")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Hair and scalp care and cleansing products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair and scalp care and cleansing products")
+    expect_back_link_to_item_category_page("hair_and_scalp_products")
     answer_item_sub_subcategory_with "Shampoo"
 
     expect_to_be_on__formulation_method_page
+    expect_back_link_to_item_category_page("hair_and_scalp_care_and_cleansing_products")
     answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_formulation_method_page
     give_frame_formulation_as "Soap Shampoo"
 
     expect_to_be_on__poisonous_ingredients_page
+    expect_back_link_to_frame_formulation_select_page
     answer_does_product_contain_poisonous_ingredients_with "Yes"
 
     expect_to_be_on__upload_poisonous_ingredients_page
+    expect_back_link_to_poisonous_ingredients_page
     upload_ingredients_pdf
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_upload_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "The minimum pH is 3 or higher, and the maximum pH is 10 or lower"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft tangerine shampoo")
+    expect_back_link_to_what_is_ph_range_of_product_page
 
     expect_check_your_answers_page_to_contain(
       product_name: "SkinSoft tangerine shampoo",

--- a/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     click_link "Add poisonous ingredients document"
 
     expect_to_be_on__upload_poisonous_ingredients_page
+    expect_back_link_to_check_your_answers_page
     upload_ingredients_pdf
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft deep blue mouthwash")

--- a/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
@@ -11,51 +11,67 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "No, I’ll enter information manually"
 
     expect_to_be_on__was_product_notified_before_brexit_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_product_name_with "SkinSoft deep blue mouthwash"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_multi_item_kit_with "No, this is a single product"
 
     expect_to_be_on__is_item_available_in_shades_page
+    expect_back_link_to_multi_item_kits_page
     answer_is_item_available_in_shades_with "No"
 
     expect_to_be_on__physical_form_of_item_page
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_physical_form_of_item_page
     answer_does_item_contain_nanomaterials_with "No"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_item_category_with "Oral hygiene products"
 
     expect_to_be_on__item_subcategoy_page(category: "oral hygiene products")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Mouth wash / breath spray"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "mouth wash / breath spray")
+    expect_back_link_to_item_category_page("oral_hygiene_products")
     answer_item_sub_subcategory_with "Mouth wash"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_item_category_page("mouth_wash")
     give_frame_formulation_as "Mouthwash"
 
     expect_to_be_on__poisonous_ingredients_page
+    expect_back_link_to_frame_formulation_select_page
     answer_does_product_contain_poisonous_ingredients_with "No"
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft deep blue mouthwash")
+    expect_back_link_to_what_is_ph_range_of_product_page
 
     expect_check_your_answers_page_to_contain(
       product_name: "SkinSoft deep blue mouthwash",
@@ -81,51 +97,66 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "No, I’ll enter information manually"
 
     expect_to_be_on__was_product_notified_before_brexit_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_product_name_with "SkinSoft deep blue mouthwash"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_multi_item_kit_with "No, this is a single product"
 
     expect_to_be_on__is_item_available_in_shades_page
+    expect_back_link_to_multi_item_kits_page
     answer_is_item_available_in_shades_with "No"
 
     expect_to_be_on__physical_form_of_item_page
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_physical_form_of_item_page
     answer_does_item_contain_nanomaterials_with "No"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_item_category_with "Oral hygiene products"
 
     expect_to_be_on__item_subcategoy_page(category: "oral hygiene products")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Mouth wash / breath spray"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "mouth wash / breath spray")
+    expect_back_link_to_item_category_page("oral_hygiene_products")
     answer_item_sub_subcategory_with "Mouth wash"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_item_category_page("mouth_wash")
     give_frame_formulation_as "Mouthwash"
 
     expect_to_be_on__poisonous_ingredients_page
     answer_does_product_contain_poisonous_ingredients_with "Yes"
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft deep blue mouthwash")
+    expect_back_link_to_what_is_ph_range_of_product_page
 
     expect_check_your_answers_page_to_contain(
       product_name: "SkinSoft deep blue mouthwash",
@@ -160,96 +191,127 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "No, I’ll enter information manually"
 
     expect_to_be_on__was_product_notified_before_brexit_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_product_name_with "SkinSoft strawberry blonde hair dye"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_multi_item_kit_with "Yes"
 
     expect_to_be_on__how_are_items_used_together_page
+    expect_back_link_to_multi_item_kits_page
     answer_does_contain_items_that_need_to_be_mixed_with "No, the items are used in sequence"
 
     expect_to_be_on__kit_items_page
+    expect_back_link_to_how_are_items_used_together_page
     add_an_item
 
     expect_to_be_on__what_is_item_called_page
+    expect_back_link_to_kit_items_page
     answer_item_name_with "SkinSoft strawberry blonde hair colourant"
 
     expect_to_be_on__is_item_available_in_shades_page(item_name: "SkinSoft strawberry blonde hair colourant")
+    expect_back_link_to_what_is_item_called_page
     answer_is_item_available_in_shades_with "No", item_name: "SkinSoft strawberry blonde hair colourant"
 
     expect_to_be_on__physical_form_of_item_page(item_name: "SkinSoft strawberry blonde hair colourant")
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid", item_name: "SkinSoft strawberry blonde hair colourant"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_physical_form_of_item_page
     answer_does_item_contain_nanomaterials_with "No", item_name: "SkinSoft strawberry blonde hair colourant"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_item_category_with "Hair and scalp products"
 
     expect_to_be_on__item_subcategoy_page(category: "hair and scalp products", item_name: "SkinSoft strawberry blonde hair colourant")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Hair colouring products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair colouring products", item_name: "SkinSoft strawberry blonde hair colourant")
+    expect_back_link_to_item_category_page("hair_and_scalp_products")
     answer_item_sub_subcategory_with "Oxidative hair colour products"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_item_category_page("hair_colouring_products")
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"
 
     expect_to_be_on__poisonous_ingredients_page
+    expect_back_link_to_frame_formulation_select_page
     answer_does_product_contain_poisonous_ingredients_with "No"
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
     expect_to_be_on__kit_items_page
+    expect_back_link_to_what_is_ph_range_of_product_page
     add_an_item
 
     expect_to_be_on__what_is_item_called_page
+    expect_back_link_to_kit_items_page
     answer_item_name_with "SkinSoft strawberry blonde hair fixer"
 
     expect_to_be_on__is_item_available_in_shades_page(item_name: "SkinSoft strawberry blonde hair fixer")
+    expect_back_link_to_what_is_item_called_page
     answer_is_item_available_in_shades_with "No", item_name: "SkinSoft strawberry blonde hair fixer"
 
     expect_to_be_on__physical_form_of_item_page item_name: "SkinSoft strawberry blonde hair fixer"
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid", item_name: "SkinSoft strawberry blonde hair fixer"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_physical_form_of_item_page
     answer_does_item_contain_nanomaterials_with "No", item_name: "SkinSoft strawberry blonde hair fixer"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_item_category_with "Hair and scalp products"
 
     expect_to_be_on__item_subcategoy_page(category: "hair and scalp products", item_name: "SkinSoft strawberry blonde hair fixer")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Hair colouring products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair colouring products", item_name: "SkinSoft strawberry blonde hair fixer")
+    expect_back_link_to_item_category_page("hair_and_scalp_products")
     answer_item_sub_subcategory_with "Oxidative hair colour products"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_item_category_page("hair_colouring_products")
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Or Three Components - Oxidative Part"
 
     expect_to_be_on__poisonous_ingredients_page
+    expect_back_link_to_frame_formulation_select_page
     answer_does_product_contain_poisonous_ingredients_with "No"
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
     expect_to_be_on__kit_items_page
+    expect_back_link_to_what_is_ph_range_of_product_page
     click_button "Continue"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft strawberry blonde hair dye")
+    expect_back_link_to_kit_items_page
 
     expect_check_your_answers_page_for_kit_items_to_contain(
       product_name: "SkinSoft strawberry blonde hair dye",
@@ -294,69 +356,91 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "No, I’ll enter information manually"
 
     expect_to_be_on__was_product_notified_before_brexit_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_product_name_with "SkinSoft carbon black eyeshadow"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_multi_item_kit_with "No, this is a single product"
 
     expect_to_be_on__is_item_available_in_shades_page
+    expect_back_link_to_multi_item_kits_page
     answer_is_item_available_in_shades_with "No"
 
     expect_to_be_on__physical_form_of_item_page
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Solid or pressed powder"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_physical_form_of_item_page
     answer_does_item_contain_nanomaterials_with "Yes"
 
     expect_to_be_on__is_item_intended_to_be_rinsed_off_or_left_on_page
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_is_item_intended_to_be_rinsed_off_or_left_on_with "Left on"
 
     expect_to_be_on__how_is_user_exposed_to_nanomaterials_page
+    expect_back_link_to_is_item_intended_to_be_rinsed_off_or_left_on_page
     answer_how_user_is_exposed_to_nanomaterials_with "Dermal"
 
     expect_to_be_on__list_the_nanomaterials_page
+    expect_back_link_to_how_is_user_exposed_to_nanomaterials_page
     answer_nanomaterial_names_with "Carbon Black"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_list_the_nanomaterials_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_nanomaterial_conform_to_restrictions_page
     answer_item_category_with "Skin products"
 
     expect_to_be_on__item_subcategoy_page(category: "skin products")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Make-up products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "make-up products")
+    expect_back_link_to_item_category_page("skin_products")
     answer_item_sub_subcategory_with "Eye shadow"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_item_category_page("makeup_products")
     give_frame_formulation_as "Eye Shadow, Blusher And Liner (Powder)"
 
     expect_to_be_on__poisonous_ingredients_page
+    expect_back_link_to_frame_formulation_select_page
     answer_does_product_contain_poisonous_ingredients_with "Yes"
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft carbon black eyeshadow")
+    expect_back_link_to_what_is_ph_range_of_product_page
 
     expect_check_your_answers_page_to_contain(
       product_name: "SkinSoft carbon black eyeshadow",
@@ -384,132 +468,175 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "No, I’ll enter information manually"
 
     expect_to_be_on__was_product_notified_before_brexit_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_product_name_with "SkinSoft nano black hair dye kit"
 
     expect_to_be_on__internal_reference_page
+    expect_back_link_to_what_is_product_called_page
     answer_do_you_want_to_give_an_internal_reference_with "No"
 
     expect_to_be_on__multi_item_kits_page
+    expect_back_link_to_internal_reference_page
     answer_is_product_multi_item_kit_with "Yes"
 
     expect_to_be_on__how_are_items_used_together_page
+    expect_back_link_to_multi_item_kits_page
     answer_does_contain_items_that_need_to_be_mixed_with "No, the items are used in sequence"
 
     expect_to_be_on__kit_items_page
+    expect_back_link_to_how_are_items_used_together_page
     add_an_item
 
     expect_to_be_on__what_is_item_called_page
+    expect_back_link_to_kit_items_page
     answer_item_name_with "SkinSoft nano black hair dye kit colourant"
 
     expect_to_be_on__is_item_available_in_shades_page(item_name: "SkinSoft nano black hair dye kit colourant")
+    expect_back_link_to_what_is_item_called_page
     answer_is_item_available_in_shades_with "No", item_name: "SkinSoft nano black hair dye kit colourant"
 
     expect_to_be_on__physical_form_of_item_page(item_name: "SkinSoft nano black hair dye kit colourant")
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid", item_name: "SkinSoft nano black hair dye kit colourant"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_physical_form_of_item_page
     answer_does_item_contain_nanomaterials_with "Yes", item_name: "SkinSoft nano black hair dye kit colourant"
 
     expect_to_be_on__is_item_intended_to_be_rinsed_off_or_left_on_page item_name: "SkinSoft nano black hair dye kit colourant"
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_is_item_intended_to_be_rinsed_off_or_left_on_with "Rinsed off", item_name: "SkinSoft nano black hair dye kit colourant"
 
     expect_to_be_on__how_is_user_exposed_to_nanomaterials_page
+    expect_back_link_to_is_item_intended_to_be_rinsed_off_or_left_on_page
     answer_how_user_is_exposed_to_nanomaterials_with "Dermal"
 
     expect_to_be_on__list_the_nanomaterials_page item_name: "SkinSoft nano black hair dye kit colourant"
+    expect_back_link_to_how_is_user_exposed_to_nanomaterials_page
     answer_nanomaterial_names_with "Carbon Black"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_list_the_nanomaterials_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_nanomaterial_conform_to_restrictions_page
     answer_item_category_with "Hair and scalp products"
 
     expect_to_be_on__item_subcategoy_page(category: "hair and scalp products", item_name: "SkinSoft nano black hair dye kit colourant")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Hair colouring products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair colouring products", item_name: "SkinSoft nano black hair dye kit colourant")
+    expect_back_link_to_item_category_page("hair_and_scalp_products")
     answer_item_sub_subcategory_with "Oxidative hair colour products"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_item_category_page("hair_colouring_products")
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"
 
     expect_to_be_on__poisonous_ingredients_page
+    expect_back_link_to_frame_formulation_select_page
     answer_does_product_contain_poisonous_ingredients_with "No"
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
     expect_to_be_on__kit_items_page
+    expect_back_link_to_what_is_ph_range_of_product_page
     add_an_item
 
     expect_to_be_on__what_is_item_called_page
+    expect_back_link_to_kit_items_page
     answer_item_name_with "SkinSoft nano black hair dye kit fixer"
 
     expect_to_be_on__is_item_available_in_shades_page(item_name: "SkinSoft nano black hair dye kit fixer")
+    expect_back_link_to_what_is_item_called_page
     answer_is_item_available_in_shades_with "No", item_name: "SkinSoft nano black hair dye kit fixer"
 
     expect_to_be_on__physical_form_of_item_page(item_name: "SkinSoft nano black hair dye kit fixer")
+    expect_back_link_to_is_item_available_in_shades_page
     answer_what_is_physical_form_of_item_with "Liquid", item_name: "SkinSoft nano black hair dye kit fixer"
 
     expect_to_be_on__does_item_contain_nanomaterial_page
+    expect_back_link_to_physical_form_of_item_page
     answer_does_item_contain_nanomaterials_with "Yes", item_name: "SkinSoft nano black hair dye kit fixer"
 
     expect_to_be_on__is_item_intended_to_be_rinsed_off_or_left_on_page item_name: "SkinSoft nano black hair dye kit fixer"
+    expect_back_link_to_does_item_contain_nanomaterial_page
     answer_is_item_intended_to_be_rinsed_off_or_left_on_with "Rinsed off", item_name: "SkinSoft nano black hair dye kit fixer"
 
     expect_to_be_on__how_is_user_exposed_to_nanomaterials_page
+    expect_back_link_to_is_item_intended_to_be_rinsed_off_or_left_on_page
     answer_how_user_is_exposed_to_nanomaterials_with "Dermal"
 
     expect_to_be_on__list_the_nanomaterials_page item_name: "SkinSoft nano black hair dye kit fixer"
+    expect_back_link_to_how_is_user_exposed_to_nanomaterials_page
     answer_nanomaterial_names_with "Carbon Black"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_list_the_nanomaterials_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "Carbon Black"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "Carbon Black"
 
     expect_to_be_on__item_category_page
+    expect_back_link_to_does_nanomaterial_conform_to_restrictions_page
     answer_item_category_with "Hair and scalp products"
 
     expect_to_be_on__item_subcategoy_page(category: "hair and scalp products", item_name: "SkinSoft nano black hair dye kit fixer")
+    expect_back_link_to_item_category_page
     answer_item_subcategory_with "Hair colouring products"
 
     expect_to_be_on__item_sub_subcategory_page(subcategory: "hair colouring products", item_name: "SkinSoft nano black hair dye kit fixer")
+    expect_back_link_to_item_category_page("hair_and_scalp_products")
     answer_item_sub_subcategory_with "Oxidative hair colour products"
 
     expect_to_be_on__frame_formulation_select_page
+    expect_back_link_to_item_category_page("hair_colouring_products")
     give_frame_formulation_as "Hair Colorant (Permanent, Oxidative Type) - Type 1 : Two Components - Colorant Part"
 
     expect_to_be_on__poisonous_ingredients_page
+    expect_back_link_to_frame_formulation_select_page
     answer_does_product_contain_poisonous_ingredients_with "No"
 
     expect_to_be_on__what_is_ph_range_of_product_page
+    expect_back_link_to_poisonous_ingredients_page
     answer_what_is_ph_range_of_product_with "It does not have a pH"
 
     expect_to_be_on__kit_items_page
+    expect_back_link_to_what_is_ph_range_of_product_page
     click_button "Continue"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft nano black hair dye kit")
+    expect_back_link_to_kit_items_page
 
     expect_check_your_answers_page_for_kit_items_to_contain(
       product_name: "SkinSoft nano black hair dye kit",

--- a/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_pre_brexit_notifications_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
-    expect_back_link_to_was_eu_notified_about_products_page
+    expect_back_link_to_was_product_notified_before_brexit_page
     answer_product_name_with "SkinSoft deep blue mouthwash"
 
     expect_to_be_on__internal_reference_page
@@ -109,7 +109,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
-    expect_back_link_to_was_eu_notified_about_products_page
+    expect_back_link_to_was_product_notified_before_brexit_page
     answer_product_name_with "SkinSoft deep blue mouthwash"
 
     expect_to_be_on__internal_reference_page
@@ -203,7 +203,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
-    expect_back_link_to_was_eu_notified_about_products_page
+    expect_back_link_to_was_product_notified_before_brexit_page
     answer_product_name_with "SkinSoft strawberry blonde hair dye"
 
     expect_to_be_on__internal_reference_page
@@ -368,7 +368,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
-    expect_back_link_to_was_eu_notified_about_products_page
+    expect_back_link_to_was_product_notified_before_brexit_page
     answer_product_name_with "SkinSoft carbon black eyeshadow"
 
     expect_to_be_on__internal_reference_page
@@ -480,7 +480,7 @@ RSpec.describe "Manual, pre-Brexit notifications", type: :feature do
     answer_was_product_notified_before_brexit_with "Yes"
 
     expect_to_be_on__what_is_product_called_page
-    expect_back_link_to_was_eu_notified_about_products_page
+    expect_back_link_to_was_product_notified_before_brexit_page
     answer_product_name_with "SkinSoft nano black hair dye kit"
 
     expect_to_be_on__internal_reference_page

--- a/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
+++ b/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
@@ -12,12 +12,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "Yes"
 
     expect_to_be_on__upload_eu_notification_files_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     upload_zip_file "testExportFile.zip"
 
     visit responsible_person_notifications_path(responsible_person)
@@ -48,12 +51,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "Yes"
 
     expect_to_be_on__upload_eu_notification_files_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     upload_zip_file "testNotificationUsingRanges.zip"
 
     visit responsible_person_notifications_path(responsible_person)
@@ -85,12 +91,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "Yes"
 
     expect_to_be_on__upload_eu_notification_files_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     upload_zip_file "testMissingFormulationDocumentPostExit.zip"
 
     visit responsible_person_notifications_path(responsible_person)
@@ -99,13 +108,16 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     click_link "Add missing information"
 
     expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
+    expect_back_link_to_incomplete_notifications_page
     upload_formulation_file
 
     expect(page.current_path).to end_with("/product_image_upload/new")
+    expect_back_link_to_incomplete_notifications_page
     expect(page).to have_h1("Upload an image of the product label")
     upload_product_label
 
     expect_to_be_on__check_your_answers_page(product_name: "Beautify Facial Night Cream")
+    expect_back_link_to_incomplete_notifications_page
     expect_check_your_answers_page_to_contain(
       product_name: "Beautify Facial Night Cream",
       number_of_components: "1",
@@ -130,12 +142,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "Yes"
 
     expect_to_be_on__upload_eu_notification_files_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     upload_zip_file "testMissingFormulationDocument.zip"
 
     visit responsible_person_notifications_path(responsible_person)
@@ -168,12 +183,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "Yes"
 
     expect_to_be_on__upload_eu_notification_files_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     upload_zip_file "testNanomaterialAndMissingFormulation.zip"
 
     visit responsible_person_notifications_path(responsible_person)
@@ -182,15 +200,19 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     click_link "Add missing information"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft shocking green hair dye")
+    expect_back_link_to_incomplete_notifications_page
     expect_check_your_answers_page_to_contain(
       product_name: "SkinSoft shocking green hair dye",
       number_of_components: "1",
@@ -223,33 +245,43 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     click_link "Add missing information"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__check_your_answers_page(product_name: "Multi-Item-RangeDoc_pHRange_ExactDoc_Nano")
+    expect_back_link_to_incomplete_notifications_page
     expect_check_your_answers_page_for_kit_items_to_contain(
       product_name: "Multi-Item-RangeDoc_pHRange_ExactDoc_Nano",
       number_of_components: "2",
@@ -289,12 +321,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit new_responsible_person_add_notification_path(responsible_person)
 
     expect_to_be_on__was_eu_notified_about_products_page
+    expect_back_link_to_notifications_page
     answer_was_eu_notified_with "Yes"
 
     expect_to_be_on__do_you_have_the_zip_files_page
+    expect_back_link_to_was_eu_notified_about_products_page
     answer_do_you_have_zip_files_with "Yes"
 
     expect_to_be_on__upload_eu_notification_files_page
+    expect_back_link_to_do_you_have_the_zip_files_page
     upload_zip_file "Multi-Item-RangeDoc_pHRange_Exactvalues_Nano_modified.zip"
 
     visit responsible_person_notifications_path(responsible_person)
@@ -303,33 +338,43 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     click_link "Add missing information"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__check_your_answers_page(product_name: "Multi-Item-RangeDoc_pHRange_Exactvalues_Nano")
+    expect_back_link_to_incomplete_notifications_page
     expect_check_your_answers_page_for_kit_items_to_contain(
       product_name: "Multi-Item-RangeDoc_pHRange_Exactvalues_Nano",
       number_of_components: "2",
@@ -377,33 +422,43 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     click_link "Add missing information"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
     answer_is_nanomaterial_listed_in_ec_regulation_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+    expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
     expect_to_be_on__check_your_answers_page(product_name: "Multi-Item-Rangevalues_Exactvalues_Nano")
+    expect_back_link_to_incomplete_notifications_page
     expect_check_your_answers_page_for_kit_items_to_contain(
       product_name: "Multi-Item-Rangevalues_Exactvalues_Nano",
       number_of_components: "2",
@@ -444,12 +499,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
       visit new_responsible_person_add_notification_path(responsible_person)
 
       expect_to_be_on__was_eu_notified_about_products_page
+      expect_back_link_to_notifications_page
       answer_was_eu_notified_with "Yes"
 
       expect_to_be_on__do_you_have_the_zip_files_page
+      expect_back_link_to_was_eu_notified_about_products_page
       answer_do_you_have_zip_files_with "Yes"
 
       expect_to_be_on__upload_eu_notification_files_page
+      expect_back_link_to_do_you_have_the_zip_files_page
       upload_zip_file "testExportFile.zip"
 
       visit responsible_person_notifications_path(responsible_person)
@@ -464,12 +522,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
       visit new_responsible_person_add_notification_path(responsible_person)
 
       expect_to_be_on__was_eu_notified_about_products_page
+      expect_back_link_to_notifications_page
       answer_was_eu_notified_with "Yes"
 
       expect_to_be_on__do_you_have_the_zip_files_page
+      expect_back_link_to_was_eu_notified_about_products_page
       answer_do_you_have_zip_files_with "Yes"
 
       expect_to_be_on__upload_eu_notification_files_page
+      expect_back_link_to_do_you_have_the_zip_files_page
       upload_zip_file "testExportFile.zip"
 
       visit responsible_person_notifications_path(responsible_person)

--- a/cosmetics-web/spec/requests/check_your_answers_page_spec.rb
+++ b/cosmetics-web/spec/requests/check_your_answers_page_spec.rb
@@ -65,13 +65,14 @@ RSpec.describe "Check your answers page", type: :request do
 
     context "when the notification was post-Brexit" do
       let(:notification) { create(:notification, :post_brexit, responsible_person: responsible_person) }
+      let!(:component) { create(:component, notification: notification) }
 
       before do
         get edit_responsible_person_notification_path(params)
       end
 
-      it "includes a back link to the image upload page" do
-        expect(response.body).to have_back_link_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/build/add_product_image")
+      it "includes a back link to the pH question" do
+        expect(response.body).to have_back_link_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/components/#{component.id}/trigger_question/select_ph_range")
       end
     end
 

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -165,6 +165,10 @@ def expect_to_be_on__is_product_for_under_threes_page
   expect(page).to have_h1("Is the product intended to be used on children under 3 years old?")
 end
 
+def expect_back_link_to_is_product_for_under_threes_page
+  expect_back_link_to(/\/build\/for_children_under_three$/)
+end
+
 def expect_to_be_on__multi_item_kits_page
   expect(page.current_path).to end_with("/build/single_or_multi_component")
   expect(page).to have_h1("Multi-item kits")
@@ -216,14 +220,26 @@ def expect_to_be_on__what_is_product_contained_in_page(item_name: nil)
   expect(page).to have_h1("What is the #{item_name || 'the product'} contained in?")
 end
 
+def expect_back_link_to_what_is_product_contained_in_page
+  expect_back_link_to(/\/build\/contains_special_applicator$/)
+end
+
 def expect_to_be_on__what_type_of_applicator_page
   expect(page.current_path).to end_with("/select_special_applicator_type")
   expect(page).to have_h1("What type of applicator?")
 end
 
+def expect_back_link_to_what_type_of_applicator_page
+  expect_back_link_to(/\/build\/select_special_applicator_type$/)
+end
+
 def expect_to_be_on__does_item_contain_cmrs_page
   expect(page.current_path).to end_with("/build/contains_cmrs")
   expect(page).to have_h1("Carcinogenic, mutagenic or reprotoxic substances")
+end
+
+def expect_back_link_to_does_item_contain_cmrs_page
+  expect_back_link_to(/\/build\/contains_cmrs$/)
 end
 
 def expect_to_be_on__does_item_contain_nanomaterial_page
@@ -337,6 +353,10 @@ def expect_to_be_on__upload_poisonous_ingredients_page
   expect(page).to have_h1("Upload list of poisonous ingredients")
 end
 
+def expect_back_link_to_upload_poisonous_ingredients_page
+  expect_back_link_to(/\/build\/upload_formulation$/)
+end
+
 def expect_to_be_on__poisonous_ingredients_page
   expect(page.current_path).to end_with("/contains_poisonous_ingredients")
   expect(page).to have_h1("Ingredients the National Poison Information Service needs to know about")
@@ -372,6 +392,10 @@ end
 def exepct_to_be_on_upload_product_label_page
   expect(page.current_path).to end_with("/add_product_image")
   expect(page).to have_h1("Upload an image of the product label")
+end
+
+def expect_back_link_to_upload_product_label_page
+  expect_back_link_to(/\/build\/add_product_image$/)
 end
 
 def expect_to_be_on__upload_formulation_document_page(header_text)

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -89,10 +89,21 @@ def expect_to_be_on_my_account_page
   expect(page).to have_current_path(/\/my_account/)
 end
 
+def expect_back_link_to(path)
+  expect(page).to have_link("Back", href: path)
+end
+
+def expect_back_link_to_notifications_page
+  expect_back_link_to("/responsible_persons/#{responsible_person.id}/notifications")
+end
+
 def expect_to_be_on__was_eu_notified_about_products_page
   expect(page.current_path).to eql("/responsible_persons/#{responsible_person.id}/add_notification/have_products_been_notified_in_eu")
-
   expect(page).to have_h1("Has the EU been notified about these products using CPNP?")
+end
+
+def expect_back_link_to_was_eu_notified_about_products_page
+  expect_back_link_to("/responsible_persons/#{responsible_person.id}/add_notification/have_products_been_notified_in_eu")
 end
 
 def expect_to_be_on__are_you_likely_to_notify_eu_page
@@ -100,10 +111,17 @@ def expect_to_be_on__are_you_likely_to_notify_eu_page
   expect(page).to have_h1("Are you likely to notify the EU about these products?")
 end
 
+def expect_back_link_to_are_you_likely_to_notify_eu_page
+  expect_back_link_to("/responsible_persons/#{responsible_person.id}/add_notification/will_products_be_notified_in_eu")
+end
+
 def expect_to_be_on__do_you_have_the_zip_files_page
   expect(page.current_path).to eql("/responsible_persons/#{responsible_person.id}/add_notification/do_you_have_files_from_eu_notification")
-
   expect(page).to have_h1("EU notification ZIP files")
+end
+
+def expect_back_link_to_do_you_have_the_zip_files_page
+  expect_back_link_to("/responsible_persons/#{responsible_person.id}/add_notification/do_you_have_files_from_eu_notification")
 end
 
 def expect_to_be_on__upload_eu_notification_files_page
@@ -111,9 +129,17 @@ def expect_to_be_on__upload_eu_notification_files_page
   expect(page).to have_h1("Upload your EU notification files")
 end
 
+def expect_back_link_to_upload_eu_notification_files_page
+  expect_back_link_to("/responsible_persons/#{responsible_person.id}/add_notification/do_you_have_files_from_eu_notification")
+end
+
 def expect_to_be_on__was_product_notified_before_brexit_page
   expect(page.current_path).to eql("/responsible_persons/#{responsible_person.id}/add_notification/was_product_on_sale_before_eu_exit")
   expect(page).to have_h1("Was this product notified in the EU before 1 January 2021?")
+end
+
+def expect_back_link_to_was_product_notified_before_brexit_page
+  expect_back_link_to("/responsible_persons/#{responsible_person.id}/add_notification/was_product_on_sale_before_eu_exit")
 end
 
 def expect_to_be_on__what_is_product_called_page
@@ -121,9 +147,17 @@ def expect_to_be_on__what_is_product_called_page
   expect(page).to have_h1("What’s the product called?")
 end
 
+def expect_back_link_to_what_is_product_called_page
+  expect_back_link_to(/\/build\/add_product_name$/)
+end
+
 def expect_to_be_on__internal_reference_page
   expect(page.current_path).to end_with("/build/add_internal_reference")
   expect(page).to have_h1("Internal reference")
+end
+
+def expect_back_link_to_internal_reference_page
+  expect_back_link_to(/\/build\/add_internal_reference$/)
 end
 
 def expect_to_be_on__is_product_for_under_threes_page
@@ -136,14 +170,26 @@ def expect_to_be_on__multi_item_kits_page
   expect(page).to have_h1("Multi-item kits")
 end
 
+def expect_back_link_to_multi_item_kits_page
+  expect_back_link_to(/\/build\/single_or_multi_component$/)
+end
+
 def expect_to_be_on__kit_items_page
   expect(page.current_path).to end_with("/build/add_new_component")
   expect(page).to have_h1("Kit items")
 end
 
+def expect_back_link_to_kit_items_page
+  expect_back_link_to(/\/build\/add_new_component$/)
+end
+
 def expect_to_be_on__what_is_item_called_page
   expect(page.current_path).to end_with("/build/add_component_name")
   expect(page).to have_h1("What’s the item called?")
+end
+
+def expect_back_link_to_what_is_item_called_page
+  expect_back_link_to(/\/build\/add_component_name$/)
 end
 
 def expect_to_be_on__is_item_available_in_shades_page(item_name: nil)
@@ -152,9 +198,17 @@ def expect_to_be_on__is_item_available_in_shades_page(item_name: nil)
   expect(page).to have_h1(expected_title)
 end
 
+def expect_back_link_to_is_item_available_in_shades_page
+  expect_back_link_to(/\/build\/number_of_shades$/)
+end
+
 def expect_to_be_on__physical_form_of_item_page(item_name: nil)
   expect(page.current_path).to end_with("/build/add_physical_form")
   expect(page).to have_h1("What is the physical form of the #{item_name || 'the product'}?")
+end
+
+def expect_back_link_to_physical_form_of_item_page
+  expect_back_link_to(/\/build\/add_physical_form$/)
 end
 
 def expect_to_be_on__what_is_product_contained_in_page(item_name: nil)
@@ -177,9 +231,17 @@ def expect_to_be_on__does_item_contain_nanomaterial_page
   expect(page).to have_h1("Nanomaterials")
 end
 
+def expect_back_link_to_does_item_contain_nanomaterial_page
+  expect_back_link_to(/\/build\/contains_nanomaterials$/)
+end
+
 def expect_to_be_on__is_item_intended_to_be_rinsed_off_or_left_on_page(item_name: nil)
   expect(page.current_path).to end_with("/build/add_exposure_condition")
   expect(page).to have_h1("Is #{item_name || 'the product'} intended to be rinsed off or left on?")
+end
+
+def expect_back_link_to_is_item_intended_to_be_rinsed_off_or_left_on_page
+  expect_back_link_to(/\/build\/add_exposure_condition$/)
 end
 
 def expect_to_be_on__how_is_user_exposed_to_nanomaterials_page
@@ -187,9 +249,17 @@ def expect_to_be_on__how_is_user_exposed_to_nanomaterials_page
   expect(page).to have_h1("How is the user likely to be exposed to the nanomaterials?")
 end
 
+def expect_back_link_to_how_is_user_exposed_to_nanomaterials_page
+  expect_back_link_to(/\/build\/add_exposure_routes$/)
+end
+
 def expect_to_be_on__list_the_nanomaterials_page(item_name: nil)
   expect(page.current_path).to end_with("/build/list_nanomaterials")
   expect(page).to have_h1("List the nanomaterials in #{item_name || 'the product'}")
+end
+
+def expect_back_link_to_list_the_nanomaterials_page
+  expect_back_link_to(/\/build\/list_nanomaterials$/)
 end
 
 def expect_to_be_on__what_is_the_purpose_of_nanomaterial_page(nanomaterial_name:)
@@ -197,9 +267,17 @@ def expect_to_be_on__what_is_the_purpose_of_nanomaterial_page(nanomaterial_name:
   expect(page).to have_h1("What is the purpose of #{nanomaterial_name}")
 end
 
+def expect_back_link_to_what_is_the_purpose_of_nanomaterial_page
+  expect_back_link_to(/\/build\/select_purposes$/)
+end
+
 def expect_to_be_on__is_nanomaterial_listed_in_ec_regulation_page(nanomaterial_name:)
   expect(page.current_path).to end_with("/build/confirm_restrictions")
   expect(page).to have_h1("Is #{nanomaterial_name} listed in EC regulation 1223/2009, Annex 4?")
+end
+
+def expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
+  expect_back_link_to(/\/build\/confirm_restrictions$/)
 end
 
 def expect_to_be_on__does_nanomaterial_conform_to_restrictions_page(nanomaterial_name:)
@@ -207,9 +285,21 @@ def expect_to_be_on__does_nanomaterial_conform_to_restrictions_page(nanomaterial
   expect(page).to have_h1("Does the #{nanomaterial_name} conform to the restrictions set out in Annex 4?")
 end
 
+def expect_back_link_to_does_nanomaterial_conform_to_restrictions_page
+  expect_back_link_to(/\/build\/confirm_usage$/)
+end
+
 def expect_to_be_on__item_category_page
   expect(page.current_path).to end_with("/build/select_category")
   expect(page).to have_h1("What category of cosmetic product is it?")
+end
+
+def expect_back_link_to_item_category_page(category = nil)
+  if category
+    expect_back_link_to(/\/build\/select_category\?category\=#{category}/)
+  else
+    expect_back_link_to(/\/build\/select_category/)
+  end
 end
 
 def expect_to_be_on__item_subcategoy_page(category:, item_name: nil)
@@ -227,11 +317,19 @@ def expect_to_be_on__formulation_method_page(item_name: nil)
   expect(page).to have_h1("How do you want to give the formulation of #{item_name || 'the product'}?")
 end
 
+def expect_back_link_to_formulation_method_page
+  expect_back_link_to(/\/build\/select_formulation_type$/)
+end
+
 # Exact concentrations of the ingredients
 # Concentration ranges of the ingredients
 def expect_to_be_on__upload_ingredients_page(header_text)
   expect(page.current_path).to end_with("/build/upload_formulation")
   expect(page).to have_h1(header_text)
+end
+
+def expect_back_link_to_upload_ingredients_page
+  expect_back_link_to(/\/build\/upload_formulation$/)
 end
 
 def expect_to_be_on__upload_poisonous_ingredients_page
@@ -244,9 +342,17 @@ def expect_to_be_on__poisonous_ingredients_page
   expect(page).to have_h1("Ingredients the National Poison Information Service needs to know about")
 end
 
+def expect_back_link_to_poisonous_ingredients_page
+  expect_back_link_to(/\/build\/contains_poisonous_ingredients$/)
+end
+
 def expect_to_be_on__what_is_ph_range_of_product_page
   expect(page.current_path).to end_with("/trigger_question/select_ph_range")
   expect(page).to have_h1("What is the pH range of the product?")
+end
+
+def expect_back_link_to_what_is_ph_range_of_product_page
+  expect_back_link_to(/\/trigger_question\/select_ph_range$/)
 end
 
 def expect_to_be_on__check_your_answers_page(product_name:)
@@ -257,6 +363,10 @@ end
 def expect_to_be_on__how_are_items_used_together_page
   expect(page.current_path).to end_with("/is_mixed")
   expect(page).to have_h1("Does the kit contain items that need to be mixed?")
+end
+
+def expect_back_link_to_how_are_items_used_together_page
+  expect_back_link_to(/is_mixed$/)
 end
 
 def exepct_to_be_on_upload_product_label_page
@@ -357,6 +467,10 @@ end
 def expect_to_be_on__frame_formulation_select_page
   expect(page.current_path).to end_with("/build/select_frame_formulation")
   expect(page).to have_h1("Choose frame formulation")
+end
+
+def expect_back_link_to_frame_formulation_select_page
+  expect_back_link_to(/\/build\/select_frame_formulation$/)
 end
 
 def expect_to_see_incomplete_notification_with_eu_reference_number(eu_reference_number)

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -97,6 +97,10 @@ def expect_back_link_to_notifications_page
   expect_back_link_to("/responsible_persons/#{responsible_person.id}/notifications")
 end
 
+def expect_back_link_to_incomplete_notifications_page
+  expect_back_link_to("/responsible_persons/#{responsible_person.id}/notifications#incomplete")
+end
+
 def expect_to_be_on__was_eu_notified_about_products_page
   expect(page.current_path).to eql("/responsible_persons/#{responsible_person.id}/add_notification/have_products_been_notified_in_eu")
   expect(page).to have_h1("Has the EU been notified about these products using CPNP?")
@@ -523,12 +527,15 @@ end
 
 def go_to_upload_notification_page
   expect_to_be_on__was_eu_notified_about_products_page
+  expect_back_link_to_notifications_page
   page.choose("Yes")
   click_button "Continue"
   expect_to_be_on__do_you_have_the_zip_files_page
+  expect_back_link_to_was_eu_notified_about_products_page
   page.choose("Yes")
   click_button "Continue"
   expect_to_be_on__upload_eu_notification_files_page
+  expect_back_link_to_do_you_have_the_zip_files_page
 end
 
 def answer_was_eu_notified_with(answer)

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -384,6 +384,10 @@ def expect_to_be_on__check_your_answers_page(product_name:)
   expect(page).to have_h1(product_name)
 end
 
+def expect_back_link_to_check_your_answers_page
+  expect_back_link_to(/\/responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit$/)
+end
+
 def expect_to_be_on__how_are_items_used_together_page
   expect(page.current_path).to end_with("/is_mixed")
   expect(page).to have_h1("Does the kit contain items that need to be mixed?")


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-962)

## Description
There are many steps in our notification flows where the backlinks are pointing to the wrong place.

This PR does:
- Extend the feature tests covering the notification flows to include assertions over each of steps backlink.
- Fix multiple backlinks to point where they should.

## Highlights
- We recently moved the "upload image". Since that change, none of the pre-EU exit notifications should go through that step, and no backlink in any of the pre-EU exit notification flow should point to "upload image" page. For the flows that have the "upload image" step, it is not the last step anymore. We needed to fix both issues in multiple spots.
- Fixed nanomaterial steps backlinks for both manual and zip flows.
- Backlinks on questions about EU notification fixed. Fixed further step backlinks to point to the right EU question step.
- Fixed backlinks to PH range, so they point to either selecting predefined range or the PH values manual introduction depending on the current value instead of always defaulting to the PH range step.
- Fixed backlink on PH page to point to the correct last step of frame formulation depending on the previous answer.
- Backlinks to the product category selection now point to the last sub-category chosen instead of the start of the category selection steps.
- Backlinks to the nanomaterials step now point to the last step for the previous nanoelement introduced.

## Implementation notes
On the feature specs, decided to create `expect_back_link_to_***_page` independent over the `expect_to_be_on_***_page` as many times the same page has a different back-link depending on the flow. 
Preferred to be consistent and took the same approach everywhere.