### PR TITLE
Introduce stricter email format validation

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -34,7 +34,6 @@ gem "sidekiq-cron", "~> 1.1.0"
 gem "slim-rails", "~> 3.2.0"
 gem "slowpoke", "~> 0.3.0"
 gem "strong_migrations", "~> 0.5.1"
-gem "validate_email", "~> 0.1"
 gem "webpacker", "~> 4.2.2"
 gem "wicked", "~> 1.3.4"
 

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -419,9 +419,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.7.0)
-    validate_email (0.1.6)
-      activemodel (>= 3.0)
-      mail (>= 2.2.5)
     warden (1.2.9)
       rack (>= 2.0.9)
     webmock (3.11.1)
@@ -504,7 +501,6 @@ DEPENDENCIES
   solargraph (~> 0.39.17)
   sprockets (~> 3.7.2)
   strong_migrations (~> 0.5.1)
-  validate_email (~> 0.1)
   webmock (~> 3.8)
   webpacker (~> 4.2.2)
   wicked (~> 1.3.4)

--- a/cosmetics-web/app/models/contact_person.rb
+++ b/cosmetics-web/app/models/contact_person.rb
@@ -3,12 +3,9 @@ class ContactPerson < ApplicationRecord
 
   validates :name, presence: true
   validates :email_address,
-            email: {
-              message: I18n.t(:wrong_format, scope: "contact_person.email_address"),
-            }
-  validates :email_address, presence: { message: I18n.t(:blank, scope: "contact_person.email_address") }
-  validates :phone_number, presence: true
+            presence: true,
+            email: { message: :wrong_format, if: -> { email_address.present? } }
   validates :phone_number,
-            phone: { message: I18n.t(:invalid, scope: "contact_person.phone_number"), allow_landline: true, allow_international: true },
-            if: -> { phone_number.present? }
+            presence: true,
+            phone: { message: :invalid, allow_landline: true, allow_international: true, if: -> { phone_number.present? } }
 end

--- a/cosmetics-web/app/models/pending_responsible_person_user.rb
+++ b/cosmetics-web/app/models/pending_responsible_person_user.rb
@@ -6,13 +6,9 @@ class PendingResponsiblePersonUser < ApplicationRecord
   belongs_to :responsible_person
 
   validates :email_address,
-            email: {
-              message: I18n.t(:wrong_format, scope: EMAIL_ERROR_MESSAGE_SCOPE),
-              if: -> { email_address.present? },
-            }
-  validates :email_address,
-            presence: { message: I18n.t(:blank, scope: EMAIL_ERROR_MESSAGE_SCOPE) },
-            uniqueness: { scope: [:responsible_person], message: I18n.t(:taken, scope: EMAIL_ERROR_MESSAGE_SCOPE) }
+            email: { message: :wrong_format, if: -> { email_address.present? } },
+            presence: true,
+            uniqueness: { scope: [:responsible_person], message: :taken }
   validate :email_address_not_in_team?
 
   before_create :generate_token

--- a/cosmetics-web/app/models/user.rb
+++ b/cosmetics-web/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   attribute :old_password, :string
   attribute :invite, :boolean
 
-  validates :new_email, email: { allow_nil: true }
+  validates :new_email, email: { message: :invalid, allow_nil: true }
   validates :name, presence: true, unless: -> { invite }
 
   def send_new_email_confirmation_email

--- a/cosmetics-web/app/validators/email_validator.rb
+++ b/cosmetics-web/app/validators/email_validator.rb
@@ -1,0 +1,19 @@
+class EmailValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    mail = Mail::Address.new(value)
+
+    unless email_accepted?(mail, value)
+      record.errors.add(attribute, options[:message])
+    end
+  rescue Mail::Field::ParseError
+    record.errors.add(attribute, options[:message])
+  end
+
+private
+
+  def email_accepted?(parsed_email, value)
+    parsed_email.address == value && # Parsed address corresponds to introduced value
+      parsed_email.address =~ URI::MailTo::EMAIL_REGEXP && # Valid email format
+      parsed_email.domain.split(".").length > 1 # Exclude local domains (eg: user@example)
+  end
+end

--- a/cosmetics-web/app/validators/email_validator.rb
+++ b/cosmetics-web/app/validators/email_validator.rb
@@ -13,7 +13,8 @@ private
 
   def email_accepted?(parsed_email, value)
     parsed_email.address == value && # Parsed address corresponds to introduced value
-      parsed_email.address =~ URI::MailTo::EMAIL_REGEXP && # Valid email format
-      parsed_email.domain.split(".").length > 1 # Exclude local domains (eg: user@example)
+      URI::MailTo::EMAIL_REGEXP.match?(value) && # Valid email format
+      parsed_email.domain.split(".").length > 1 && # Exclude local domains (eg: user@example)
+      /[a-zA-Z]/.match?(value[-1]) # Last character of the Top Level Domain is a letter
   end
 end

--- a/cosmetics-web/app/views/responsible_persons/contact_persons/_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/contact_persons/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @contact_person, url: url, method: method do |form| %>
+<%= form_with model: @contact_person, url: url, html: { novalidate: true }, method: method do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/cosmetics-web/config/initializers/devise.rb
+++ b/cosmetics-web/config/initializers/devise.rb
@@ -191,7 +191,8 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = URI::MailTo::EMAIL_REGEXP # Stricter than the default
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -89,7 +89,6 @@ en:
               wrong_format: "Enter email address in the correct format, like name@example.com"
               blank: "Enter email address"
               this_team: "This email address already belongs to member of this team"
-              other_team: "You can not invite this email address to join your team"
               taken: "This person has already been invited to this team"
         trigger_question:
           attributes:
@@ -128,14 +127,25 @@ en:
               confirmation: "Password and confirmation does not match"
         user:
           attributes:
+            email:
+              invalid: &invalid_email "Enter your email address in the correct format, like name@example.com"
             mobile_number:
               invalid: "Enter a mobile number, like 07700 900 982 or +44 7700 900 982"
+            new_email:
+              invalid: *invalid_email
             password:
               too_short: "Password must be at least 8 characters"
         responsible_person:
           attributes:
             name:
               taken: "This Responsible Person name is already in use"
+        contact_person:
+          attributes:
+            email_address:
+              wrong_format: *invalid_email
+              blank: "Enter your email address"
+            phone_number:
+              invalid: "Enter a valid phone number, like 0344 411 1444 or +44 7700 900 982"
   activemodel:
     attributes:
       registration/account_security_form:
@@ -224,15 +234,9 @@ en:
       above_10: "Above 10"
       not_applicable: "No pH"
       not_given: "Not given"
-  contact_person:
-    email_address:
-      wrong_format: "Enter your email address in the correct format, like name@example.com"
-      blank: "Enter your email address"
-    phone_number:
-      invalid: "Enter a valid phone number, like 0344 411 1444 or +44 7700 900 982"
   email_form_validation:
-    wrong_email_or_password: "Enter your email address in the correct format, like name@example.com"
-    wrong_format: "Enter your email address in the correct format, like name@example.com"
+    wrong_email_or_password: *invalid_email
+    wrong_format: *invalid_email
     blank: "Enter your email address"
   users:
     check_your_email:

--- a/cosmetics-web/spec/forms/sign_in_form_spec.rb
+++ b/cosmetics-web/spec/forms/sign_in_form_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe SignInForm do
     end
 
     context "when the email is not blank" do
-      context "when it does not contain an @" do
-        let(:email) { "not_an_email" }
+      context "when the email is in the wrong format" do
+        let(:email) { "user@example..com" }
 
         it "is not valid" do
           expect(form).to be_invalid
@@ -31,6 +31,18 @@ RSpec.describe SignInForm do
 
         it "populates an error message" do
           expect(form.errors.full_messages_for(:email)).to eq(["Enter your email address in the correct format, like name@example.com"])
+        end
+      end
+
+      context "when the email is in the correct format" do
+        let(:email) { "user+3@example.co.uk" }
+
+        it "is valid" do
+          expect(form).to be_valid
+        end
+
+        it "does not populate an error message" do
+          expect(form.errors.full_messages_for(:email)).to be_empty
         end
       end
     end

--- a/cosmetics-web/spec/models/contact_person_spec.rb
+++ b/cosmetics-web/spec/models/contact_person_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ContactPerson, type: :model do
   it "fails if an email address is not specified" do
     contact_person.email_address = nil
     expect(contact_person.save).to be false
-    expect(contact_person.errors[:email_address]).to include("Enter your email address in the correct format, like name@example.com")
+    expect(contact_person.errors[:email_address]).to include("Enter your email address")
   end
 
   it "fails if the email address format is invalid" do

--- a/cosmetics-web/spec/validators/email_validator_spec.rb
+++ b/cosmetics-web/spec/validators/email_validator_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe EmailValidator do
     "user@example.com,",
     "user@example..com",
     "user@example",
+    "user@example.com2",
   ]
 
   valid_emails.each do |email|

--- a/cosmetics-web/spec/validators/email_validator_spec.rb
+++ b/cosmetics-web/spec/validators/email_validator_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe EmailValidator do
+  subject(:validator) { validator_class.new(email) }
+
+  let(:error_msg) { "Enter your email address in the correct format, like name@example.com" }
+
+  let(:validator_class) do
+    Class.new do
+      include ActiveModel::Validations
+      attr_accessor :email
+
+      validates :email, email: { message: ERROR_MSG }
+
+      def initialize(email)
+        @email = email
+      end
+
+      def self.name
+        "ValidatorClass"
+      end
+    end
+  end
+
+  before do
+    stub_const("ERROR_MSG", error_msg)
+    validator.validate
+  end
+
+  valid_emails = [
+    "user@example.com",
+    "user+extra@example.com",
+    "user@example.co.uk",
+  ]
+
+  invalid_emails = [
+    nil,
+    1234,
+    "",
+    "notanemail",
+    "user@ example.com",
+    "user@example .com",
+    "useratexample.com",
+    "user@example.com,",
+    "user@example..com",
+    "user@example",
+  ]
+
+  valid_emails.each do |email|
+    context "with valid email (#{email})" do
+      let(:email) { email }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      it "does not populate an error message" do
+        expect(validator.errors.messages[:email]).to be_empty
+      end
+    end
+  end
+
+  invalid_emails.each do |email|
+    context "with invalid email (#{email})" do
+      let(:email) { email }
+
+      it "is not valid" do
+        expect(validator).not_to be_valid
+      end
+
+      it "populates an error message" do
+        expect(validator.errors.messages[:email]).to eq [error_msg]
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/validators/email_validator_spec.rb
+++ b/cosmetics-web/spec/validators/email_validator_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe EmailValidator do
     "user@example..com",
     "user@example",
     "user@example.com2",
+    "John Doe<john.doe@example.com>",
   ]
 
   valid_emails.each do |email|


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1061)

We had multiple occurrences of clearly wrong emails being accepted by our validations and failing when Notify service attempted to use the address.

The validate_email gem was severely deprecated, and its validation was so relaxed that was accepting emails like
`user @example.co,m`, `user @ example . com`...
The gem's only value was to define a custom email validator that checked that the email address could be parsed and that the email address domain is not local (`user@example`).

The approach taken was to remove the gem, create our own custom email validator reproducing the gem behaviour, and extend the validator to check the email against accepted email format REGEXP.

To validate the email format we are using `URI::MailTo::EMAIL_REGEXP`, that is standard in Ruby library and strict enough to catch the majority of typos users may be introducing.
The downside with this regexp is that accepts local domains, as they technically are valid email addresses.

But, as we combine both the REGEXP and the domain check, we have both fronts covered.

The Ruby regexp has also been set as the email format regexp used by Devise. As Devise default one is way too relaxed and allows multiple typos.

There is an [open issue on Devise](https://github.com/heartcombo/devise/issues/3820) pushing for using this regexp as default as the current default. 