### PR TITLE
Bugs related to pre brexit poisonous ingredients flow

### DIFF
--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -167,6 +167,12 @@ class Component < ApplicationRecord
     notification.is_multicomponent? ? name : "product"
   end
 
+  def poisonous_ingredients_answer
+    return if contains_poisonous_ingredients.nil?
+
+    contains_poisonous_ingredients? ? "Yes" : "No"
+  end
+
 private
 
   # This takes any value and returns nil if the value

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -145,7 +145,7 @@
         <%= component.poisonous_ingredients_answer %>
       </td>
     </tr>
-    <% if component.contains_poisonous_ingredients %>
+    <% if component.contains_poisonous_ingredients && (allow_edits || component.formulation_file.attached?) %>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row">Poisonous ingredients</th>
         <td class="govuk-table__cell">

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -142,10 +142,10 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="row">Contains poisonous ingredients</th>
       <td class="govuk-table__cell">
-        <%= component.contains_poisonous_ingredients.present? ? "Yes" : "No" %>
+        <%= component.poisonous_ingredients_answer %>
       </td>
     </tr>
-    <% if component.contains_poisonous_ingredients.present? %>
+    <% if component.contains_poisonous_ingredients %>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row">Poisonous ingredients</th>
         <td class="govuk-table__cell">
@@ -161,7 +161,7 @@
             <% else %>
               <%= "The uploaded file has been flagged as a virus" %>
             <% end %>
-          <% else %>
+          <% elsif allow_edits %>
             <%= link_to "Add poisonous ingredients document",
                     responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :upload_formulation),
                     class: "govuk-link--no-visited-state" %>

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -145,7 +145,7 @@
         <%= component.poisonous_ingredients_answer %>
       </td>
     </tr>
-    <% if component.contains_poisonous_ingredients && (allow_edits || component.formulation_file.attached?) %>
+    <% if component.contains_poisonous_ingredients%>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row">Poisonous ingredients</th>
         <td class="govuk-table__cell">
@@ -165,6 +165,8 @@
             <%= link_to "Add poisonous ingredients document",
                     responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :upload_formulation),
                     class: "govuk-link--no-visited-state" %>
+          <% else %>
+            Not provided
           <% end %>
         </td>
       </tr>

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -420,4 +420,22 @@ RSpec.describe Component, type: :model do
       end
     end
   end
+
+  describe "#poisonous_ingredients_answer" do
+    let(:component) { build(:component) }
+
+    it "returns nil if contains_poisonous_ingredients is nil" do
+      expect(component.poisonous_ingredients_answer).to eq nil
+    end
+
+    it "returns 'Yes' if contains_poisonous_ingredients is true" do
+      component.update(contains_poisonous_ingredients: true)
+      expect(component.poisonous_ingredients_answer).to eq "Yes"
+    end
+
+    it "returns 'No' if contains_poisonous_ingredients is false" do
+      component.update(contains_poisonous_ingredients: false)
+      expect(component.poisonous_ingredients_answer).to eq "No"
+    end
+  end
 end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-1063

## Description
- Submitted notifications (for manual pre-brexit) should not show link to upload poisonous ingredients

- Do not auto populate contains poisonous ingredients to no

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
