### PR TITLE
Fix responsible person bug which causes page 2 of the form to loop

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/contact_persons/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/contact_persons/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "New contact person" %>
 <% content_for :after_header do %>
-  <%= govukBackLink text: "Back", href: account_path(:enter_details) %>
+  <%= govukBackLink text: "Back", href: account_path(:select_type) %>
 <% end %>
 
 <%= render "responsible_persons/contact_persons/form", contact_person: @contact_person, url: responsible_person_contact_persons_path(@responsible_person), method: :post %>


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-1024

## Description
Fix responsible person bug which causes page 2 of the form to loop

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
