### PR TITLE
Notify deployment status to Slack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,3 +121,52 @@ jobs:
       run: |
         source cosmetics-web/deploy-github-functions.sh
         gh_deploy_failure production $LOG_URL
+
+    - name: Notify deployment success to Slack
+      uses: 8398a7/action-slack@v3 # https://github.com/marketplace/actions/action-slack
+      with:
+        status: custom
+        fields: workflow,job,commit,repo,ref,author,took # selectable (default: repo,message)
+        custom_payload: |
+          {
+            attachments: [{
+              color: 'good',
+              text: `Production ${process.env.AS_WORKFLOW} succeed.\n<https://cosmetics-pr-${{ github.event.number }}-submit-web.london.cloudapps.digital|Deployed service>\n(${process.env.AS_COMMIT}) of <https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|PR-${{ github.event.number }}> by ${process.env.AS_AUTHOR}`,
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ACTION_STATUS_WEBHOOK_URL }} # required
+      if: success()
+
+    - name: Notify deployment failure to Slack
+      uses: 8398a7/action-slack@v3 # https://github.com/marketplace/actions/action-slack
+      with:
+        status: custom
+        fields: workflow,job,commit,repo,ref,author,took # selectable (default: repo,message)
+        custom_payload: |
+          {
+            attachments: [{
+              color: 'danger',
+              text: `Production ${process.env.AS_WORKFLOW} failed.\n(${process.env.AS_COMMIT}) of <https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|PR-${{ github.event.number }}> by ${process.env.AS_AUTHOR}`,
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ACTION_STATUS_WEBHOOK_URL }} # required
+      if: failure()
+
+    - name: Notify deployment cancellation Slack
+      uses: 8398a7/action-slack@v3 # https://github.com/marketplace/actions/action-slack
+      with:
+        status: custom
+        fields: workflow,job,commit,repo,ref,author,took # selectable (default: repo,message)
+        custom_payload: |
+          {
+            attachments: [{
+              color: 'warning',
+              type: 'mrkdwn',
+              text: `Production ${process.env.AS_WORKFLOW} cancelled.\n(${process.env.AS_COMMIT}) of <https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|PR-${{ github.event.number }}> by ${process.env.AS_AUTHOR}`,
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ACTION_STATUS_WEBHOOK_URL }} # required
+      if: cancelled()

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -76,3 +76,52 @@ jobs:
       run: |
         source cosmetics-web/deploy-github-functions.sh
         gh_deploy_failure review-app-${PR_NUMBER} $LOG_URL
+
+    - name: Notify deployment success to Slack
+      uses: 8398a7/action-slack@v3 # https://github.com/marketplace/actions/action-slack
+      with:
+        status: custom
+        fields: workflow,job,commit,repo,ref,author,took # selectable (default: repo,message)
+        custom_payload: |
+          {
+            attachments: [{
+              color: 'good',
+              text: `${process.env.AS_WORKFLOW} deployment succeed.\n<https://cosmetics-pr-${{ github.event.number }}-submit-web.london.cloudapps.digital|Deployed service>\n(${process.env.AS_COMMIT}) of <https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|PR-${{ github.event.number }}> by ${process.env.AS_AUTHOR}`,
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ACTION_STATUS_WEBHOOK_URL }} # required
+      if: success()
+
+    - name: Notify deployment failure to Slack
+      uses: 8398a7/action-slack@v3 # https://github.com/marketplace/actions/action-slack
+      with:
+        status: custom
+        fields: workflow,job,commit,repo,ref,author,took # selectable (default: repo,message)
+        custom_payload: |
+          {
+            attachments: [{
+              color: 'danger',
+              text: `${process.env.AS_WORKFLOW} deployment failed.\n(${process.env.AS_COMMIT}) of <https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|PR-${{ github.event.number }}> by ${process.env.AS_AUTHOR}`,
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ACTION_STATUS_WEBHOOK_URL }} # required
+      if: failure()
+
+    - name: Notify deployment cancellation Slack
+      uses: 8398a7/action-slack@v3 # https://github.com/marketplace/actions/action-slack
+      with:
+        status: custom
+        fields: workflow,job,commit,repo,ref,author,took # selectable (default: repo,message)
+        custom_payload: |
+          {
+            attachments: [{
+              color: 'warning',
+              type: 'mrkdwn',
+              text: `${process.env.AS_WORKFLOW} deployment cancelled.\n(${process.env.AS_COMMIT}) of <https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|PR-${{ github.event.number }}> by ${process.env.AS_AUTHOR}`,
+            }]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ACTION_STATUS_WEBHOOK_URL }} # required
+      if: cancelled()


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1069)

This PR adds a new step to the ReviewAPP/Production Github Actions deployment workflows to notify the deployment output status to Slack.

Originally implemented it on the Review Apps so is testable when pushing this PR. Happy to remove it from Review Apps if is going to be too noisy and leave it only for production deployments.

