### PR TITLE
Revert "Increase production deploy timeouts"

### DIFF
--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -24,10 +24,10 @@ cp -a ./infrastructure/env/. ./cosmetics-web/env/
 # time each app takes to start multiplied by the number of instances.
 #
 # See https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html
-export CF_STARTUP_TIMEOUT=35
+export CF_STARTUP_TIMEOUT=20
 
 # Deploy the submit app and set the hostname
-cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 240 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling
+cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling
 
 # Remove the copied infrastructure env files to clean up
 rm -R cosmetics-web/env/

--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -24,7 +24,7 @@ cp -a ./infrastructure/env/. ./cosmetics-web/env/
 # time each app takes to start multiplied by the number of instances.
 #
 # See https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html
-export CF_STARTUP_TIMEOUT=20
+export CF_STARTUP_TIMEOUT=35
 
 # Deploy the submit app and set the hostname
 cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling

--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -11,7 +11,6 @@ applications:
     SUBMIT_HOST: ((submit-host))
     COSMETICS_HOST: ((submit-host))
   stack: cflinuxfs3
-  timeout: 240
   services:
     - cosmetics-database
     - cosmetics-elasticsearch-7


### PR DESCRIPTION
Reverts UKGovernmentBEIS/beis-opss-cosmetics#1956

The maximum configurable timeout for CloudFoundry is 180 seconds. Trying to increase it resulted in a failure.