### PR TITLE
Deployment issues fix attempts

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -27,7 +27,7 @@ gem "rails", "~> 5.2.3"
 gem "request_store", "~> 1.5.0"
 gem "rest-client", "~> 2.1.0"
 gem "rubyzip", ">= 1.2.1"
-gem "scout_apm"
+# gem "scout_apm" # Temporally disabled due to poor start time issues
 gem "sentry-raven", "~> 3.1"
 gem "sidekiq", "~> 5.2.7"
 gem "sidekiq-cron", "~> 1.1.0"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -348,8 +348,6 @@ GEM
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
-    scout_apm (4.0.3)
-      parser
     sentry-raven (3.1.1)
       faraday (>= 1.0)
     sidekiq (5.2.9)
@@ -489,7 +487,6 @@ DEPENDENCIES
   rubocop-rspec (~> 1.42.0)
   ruby-debug-ide (~> 0.7.0)
   rubyzip (>= 1.2.1)
-  scout_apm
   sentry-raven (~> 3.1)
   sidekiq (~> 5.2.7)
   sidekiq-cron (~> 1.1.0)

--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -24,7 +24,7 @@ cp -a ./infrastructure/env/. ./cosmetics-web/env/
 # time each app takes to start multiplied by the number of instances.
 #
 # See https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html
-export CF_STARTUP_TIMEOUT=35
+export CF_STARTUP_TIMEOUT=25
 
 # Deploy the submit app and set the hostname
 cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling


### PR DESCRIPTION
1. Temporally disable Scout gem
    Scout start time is being very slow and possibly causing deployment timeout issues.
2. Restore the previous value for the app startup timeout.
    This wasn't the issue but individual instances crashing.

