### PR TITLE
Reduce Staging app instances in CloudFoundry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,8 +44,10 @@ jobs:
         APP_NAME: cosmetics-web
         SUBMIT_HOST: staging-submit.cosmetic-product-notifications.service.gov.uk
         SEARCH_HOST: staging-search.cosmetic-product-notifications.service.gov.uk
+        WEB_INSTANCES: 2
         WEB_MAX_THREADS: 1
         WORKER_MAX_THREADS: 10
+        WORKER_INSTANCES: 2
         CF_USERNAME: ${{ secrets.PaaSUsernameStaging }}
         CF_PASSWORD: ${{ secrets.PaaSPasswordStaging }}
       run: |
@@ -94,8 +96,10 @@ jobs:
         APP_NAME: cosmetics-web
         SUBMIT_HOST: submit.cosmetic-product-notifications.service.gov.uk
         SEARCH_HOST: search.cosmetic-product-notifications.service.gov.uk
+        WEB_INSTANCES: 8
         WEB_MAX_THREADS: 1
         WORKER_MAX_THREADS: 10
+        WORKER_INSTANCES: 4
         CF_USERNAME: ${{ secrets.PaaSUsernameProduction }}
         CF_PASSWORD: ${{ secrets.PaaSPasswordProduction }}
       run: |

--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -27,7 +27,7 @@ cp -a ./infrastructure/env/. ./cosmetics-web/env/
 export CF_STARTUP_TIMEOUT=35
 
 # Deploy the submit app and set the hostname
-cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --var web-max-threads=$WEB_MAX_THREADS --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling
+cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --var web-instances=$WEB_INSTANCES --var web-max-threads=$WEB_MAX_THREADS --var worker-instances=$WORKER_INSTANCES --var worker-max-threads=$WORKER_MAX_THREADS --strategy rolling
 
 # Remove the copied infrastructure env files to clean up
 rm -R cosmetics-web/env/

--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -32,13 +32,13 @@ applications:
       env:
         RAILS_MAX_THREADS: ((web-max-threads))
       command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate && bundle exec puma
-      instances: 8
+      instances: ((web-instances))
       memory: 4G
     - type: worker
       env:
         RAILS_MAX_THREADS: ((worker-max-threads))
       command: export $(./env/get-env-from-vcap.sh) && bin/yarn install && bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
-      instances: 4
+      instances: ((worker-instances))
       memory: 2G
       disk_quota: 2G


### PR DESCRIPTION
Staging is having 8 web and 4 worker instances as Production. This is a massive and costly overallocation of resources.

Did set it to 2 instances just to be able to reproduce "having multiple web/worker instances" as production.
