### PR TITLE
Add reference number to notification delete log

### DIFF
--- a/cosmetics-web/app/services/notification_delete_service.rb
+++ b/cosmetics-web/app/services/notification_delete_service.rb
@@ -17,6 +17,7 @@ class NotificationDeleteService
         n.notification_created_at = @notification.created_at
         n.notification_updated_at = @notification.updated_at
         n.cpnp_reference = @notification.cpnp_reference
+        n.reference_number = @notification.reference_number
       end
       @notification.destroy!
     end

--- a/cosmetics-web/db/migrate/20210128101635_add_reference_number_to_notification_delete_logs.rb
+++ b/cosmetics-web/db/migrate/20210128101635_add_reference_number_to_notification_delete_logs.rb
@@ -1,0 +1,5 @@
+class AddReferenceNumberToNotificationDeleteLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :notification_delete_logs, :reference_number, :integer
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_20_144330) do
+ActiveRecord::Schema.define(version: 2021_01_28_101635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -148,6 +148,7 @@ ActiveRecord::Schema.define(version: 2021_01_20_144330) do
     t.string "cpnp_reference"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "reference_number"
     t.index ["responsible_person_id"], name: "index_notification_delete_logs_on_responsible_person_id"
   end
 

--- a/cosmetics-web/spec/services/notification_delete_service_spec.rb
+++ b/cosmetics-web/spec/services/notification_delete_service_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe NotificationDeleteService do
       notification_created_at: notification.created_at,
       notification_updated_at: notification.updated_at,
       cpnp_reference: notification.cpnp_reference,
+      reference_number: notification.reference_number,
     )
   end
 
@@ -57,6 +58,7 @@ RSpec.describe NotificationDeleteService do
         notification_created_at: notification.created_at,
         notification_updated_at: notification.updated_at,
         cpnp_reference: notification.cpnp_reference,
+        reference_number: notification.reference_number,
       )
     end
   end


### PR DESCRIPTION
Reference number is used to identify notification.