### PR TITLE
Update nanomaterials flow

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -5,6 +5,7 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
         :confirm_restrictions,
         :must_be_listed,
         :confirm_usage,
+        :must_conform_to_restrictions,
         :non_standard_nanomaterial_notified,
         :when_products_containing_nanomaterial_can_be_placed_on_market,
         :notify_your_nanomaterial
@@ -161,7 +162,7 @@ private
     when "yes"
       redirect_to finish_wizard_path
     when "no"
-      redirect_to wizard_path(:non_standard_nanomaterial_notified)
+      redirect_to wizard_path(:must_conform_to_restrictions)
     else
       @nano_element.errors.add :confirm_usage, "Select an option"
       render step

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -3,6 +3,7 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
 
   steps :select_purposes,
         :confirm_restrictions,
+        :must_be_listed,
         :confirm_usage,
         :non_standard_nanomaterial_notified,
         :when_products_containing_nanomaterial_can_be_placed_on_market,
@@ -143,9 +144,9 @@ private
     @nano_element.update_with_context(nano_element_params, step)
     case confirm_restrictions
     when "yes"
-      render_wizard @nano_element
+      redirect_to wizard_path(:confirm_usage)
     when "no"
-      redirect_to wizard_path(:non_standard_nanomaterial_notified)
+      redirect_to wizard_path(:must_be_listed)
     else
       @nano_element.errors.add :confirm_restrictions, "Select an option"
       render step

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -14,7 +14,7 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
   before_action :set_nano_element
 
   def show
-    if step == :confirm_restrictions && @nano_element.non_standard_single_purpose?
+    if step == :confirm_restrictions && @nano_element.non_standard? && @nano_element.purposes.one?
       return redirect_to wizard_path(:non_standard_nanomaterial_notified)
     end
 
@@ -52,7 +52,7 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
     when :confirm_usage
       wizard_path(:confirm_restrictions)
     when :non_standard_nanomaterial_notified
-      if @nano_element.non_standard_single_purpose?
+      if @nano_element.purposes.one?
         wizard_path(:select_purposes)
       else
         wizard_path(:confirm_usage)

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -13,7 +13,7 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
   before_action :set_nano_element
 
   def show
-    if step == :confirm_restrictions && @nano_element.non_standard?
+    if step == :confirm_restrictions && @nano_element.non_standard_single_purpose?
       return redirect_to wizard_path(:non_standard_nanomaterial_notified)
     end
 

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -52,7 +52,11 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
     when :confirm_usage
       wizard_path(:confirm_restrictions)
     when :non_standard_nanomaterial_notified
-      wizard_path(:select_purposes)
+      if @nano_element.non_standard_single_purpose?
+        wizard_path(:select_purposes)
+      else
+        wizard_path(:confirm_usage)
+      end
     when :when_products_containing_nanomaterial_can_be_placed_on_market, :notify_your_nanomaterial
       wizard_path(:non_standard_nanomaterial_notified)
     else
@@ -160,7 +164,11 @@ private
     @nano_element.update_with_context(nano_element_params, step)
     case confirm_usage
     when "yes"
-      redirect_to finish_wizard_path
+      if @nano_element.non_standard?
+        redirect_to wizard_path(:non_standard_nanomaterial_notified)
+      else
+        redirect_to finish_wizard_path
+      end
     when "no"
       redirect_to wizard_path(:must_conform_to_restrictions)
     else

--- a/cosmetics-web/app/helpers/nanomaterial_helper.rb
+++ b/cosmetics-web/app/helpers/nanomaterial_helper.rb
@@ -12,7 +12,7 @@ module NanomaterialHelper
   end
 
   def get_ec_regulation_annex_details_for_nanomaterial_purposes(purposes)
-    annex_numbers = purposes.map { |purpose| get_ec_regulation_annex_number_for_nanomaterial_purpose(purpose) }
+    annex_numbers = purposes.filter_map { |purpose| get_ec_regulation_annex_number_for_nanomaterial_purpose(purpose) }
     "#{'Annex'.pluralize(annex_numbers.count)} #{to_sentence(annex_numbers, last_word_connector: ' and ')}"
   end
 

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -27,6 +27,10 @@ class NanoElement < ApplicationRecord
     purposes.present? && purposes.include?("other")
   end
 
+  def non_standard_single_purpose?
+    non_standard? && purposes.size == 1
+  end
+
 private
 
   def toxicology_required?

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -27,10 +27,6 @@ class NanoElement < ApplicationRecord
     purposes.present? && purposes.include?("other")
   end
 
-  def non_standard_single_purpose?
-    non_standard? && purposes.size == 1
-  end
-
 private
 
   def toxicology_required?

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/confirm_restrictions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/confirm_restrictions.html.erb
@@ -6,10 +6,10 @@
   <h1 class="govuk-fieldset__heading govuk-label--l"><%= question %></h1>
 
   <p>
-    <% @nano_element.purposes.each do |purpose| %>
+    <% @nano_element.purposes.reject { |p| p == "other" }.each do |purpose| %>
       <% purpose_name = get_display_name_for_nanomaterial_purpose(purpose) %>
       <% annex_number = get_ec_regulation_annex_number_for_nanomaterial_purpose(purpose) %>
-      <% link_text = "Annex #{annex_number} list of #{purpose_name.pluralize} (opens in a new window)" %>
+      <% link_text = "Annex #{annex_number} list of #{purpose_name.pluralize}" %>
       <% link_url = get_ec_regulation_link_for_annex_number(annex_number) %>
       View the <%= link_to link_text, link_url, target: "_blank", rel: "noopener" %>
       <br>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_be_listed.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_be_listed.html.erb
@@ -1,0 +1,15 @@
+<% title = "You cannot notify products containing #{@nano_element.inci_name}" %>
+
+<% content_for :page_title, title %>
+<% content_for :after_header do %>
+  <%= govukBackLink text: "Back", href: previous_wizard_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= title %></h1>
+
+    <p>If you are using a nanomaterial as a colourant, preservative or UV filter it must be listed in the annexes.</p>
+    <p>Go to <%= link_to "your cosmetic products", responsible_person_notifications_path(current_responsible_person), class: "govuk-link--no-visited-state" %>.</p>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_conform_to_restrictions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_conform_to_restrictions.html.erb
@@ -1,0 +1,15 @@
+<% title = "You cannot notify products containing #{@nano_element.inci_name}" %>
+
+<% content_for :page_title, title %>
+<% content_for :after_header do %>
+  <%= govukBackLink text: "Back", href: previous_wizard_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= title %></h1>
+
+    <p>If you are using a nanomaterial as a colourant, preservative or UV filter it must conform to the restrictions set out in the annexes.</p>
+    <p>Go to <%= link_to "your cosmetic products", responsible_person_notifications_path(current_responsible_person), class: "govuk-link--no-visited-state" %>.</p>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/non_standard_nanomaterial_notified.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/non_standard_nanomaterial_notified.html.erb
@@ -1,4 +1,4 @@
-<% title = "Have you submitted a notification about #{@nano_element.inci_name} in the GB since #{display_full_month_date EU_EXIT_DATE}?" %>
+<% title = "Have you submitted a notification about #{@nano_element.inci_name} in GB since #{display_full_month_date EU_EXIT_DATE}?" %>
 <% question = title %>
 <% items = [{ text: "Yes", value: "yes" }, { text: "No", value: "no" }, { text: "Not sure", value: "not sure" }] %>
 

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/non_standard_nanomaterial_notified.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/non_standard_nanomaterial_notified.html.erb
@@ -1,4 +1,4 @@
-<% title = "Have you submitted a notification about #{@nano_element.inci_name} in the UK since Brexit?" %>
+<% title = "Have you submitted a notification about #{@nano_element.inci_name} in the GB since 1 January 2021?" %>
 <% question = title %>
 <% items = [{ text: "Yes", value: "yes" }, { text: "No", value: "no" }, { text: "Not sure", value: "not sure" }] %>
 

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/non_standard_nanomaterial_notified.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/non_standard_nanomaterial_notified.html.erb
@@ -1,4 +1,4 @@
-<% title = "Have you submitted a notification about #{@nano_element.inci_name} in the GB since 1 January 2021?" %>
+<% title = "Have you submitted a notification about #{@nano_element.inci_name} in the GB since #{display_full_month_date EU_EXIT_DATE}?" %>
 <% question = title %>
 <% items = [{ text: "Yes", value: "yes" }, { text: "No", value: "no" }, { text: "Not sure", value: "not sure" }] %>
 

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/notify_your_nanomaterial.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/notify_your_nanomaterial.html.erb
@@ -9,6 +9,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p>Read <%= link_to "how to notify nanomaterials", how_to_notify_nanomaterials_path %>.</p>
+    <p>Read <%= link_to "how to notify nanomaterials", how_to_notify_nanomaterials_path, target: '_new' %>.</p>
+    <p>Go to <%= link_to "your cosmetic products", responsible_person_notifications_path(current_responsible_person), class: "govuk-link--no-visited-state" %>.</p>
   </div>
 </div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/when_products_containing_nanomaterial_can_be_placed_on_market.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/when_products_containing_nanomaterial_can_be_placed_on_market.html.erb
@@ -10,11 +10,26 @@
 
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p>The date depends on whether or not you notified the nanomaterial using CPNP before 1 January 2021.</p>
+    <p>
+      The date depends on whether or not you notified the nanomaterial using CPNP before
+      <span class="no-wrap"><%= display_full_month_date(EU_EXIT_DATE) %>.</span>
+    </p>
 
-    <p>If you notified <%= @nano_element.inci_name %> using CPNP before 1 January 2021, and notified it in GB before 31 March 2021 you must wait 7 months from the original EU notification before you can place products containing <%= @nano_element.inci_name %> on the market.</p>
+    <p>
+      If you notified <%= @nano_element.inci_name %> using CPNP before
+      <span class="no-wrap"><%= display_full_month_date(EU_EXIT_DATE) %>,</span>
+      and notified it in GB before
+      <span class="no-wrap"><%= display_full_month_date(SUBMISSION_WINDOW_END_DATE) %></span>
+      you must wait 7 months from the original EU notification before you can place products
+      containing <%= @nano_element.inci_name %> on the market.
+    </p>
 
-    <p>If you didn’t notify <%= @nano_element.inci_name %> using CPNP before 1 January 2021 you must wait 6 months from the date you notified it in GB before you can place products containing <%= @nano_element.inci_name %> on the market.</p>
+    <p>
+      If you didn’t notify <%= @nano_element.inci_name %> using CPNP before
+      <span class="no-wrap"><%= display_full_month_date(EU_EXIT_DATE) %></span>
+      you must wait 6 months from the date you notified it in GB before you can place products
+      containing <%= @nano_element.inci_name %> on the market.
+    </p>
 
     <%= form_with model: @nano_element, url: wizard_path, method: :put do |form| %>
       <%= govukButton text: "Continue" %>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/when_products_containing_nanomaterial_can_be_placed_on_market.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/when_products_containing_nanomaterial_can_be_placed_on_market.html.erb
@@ -10,11 +10,11 @@
 
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p>The date depends on whether or not you notified the nanomaterial using CPNP before October 31, 2019 (Brexit).</p>
+    <p>The date depends on whether or not you notified the nanomaterial using CPNP before 1 January 2021.</p>
 
-    <p>If you notified <%= @nano_element.inci_name %> using CPNP before October 31 2019 (Brexit), and notified it in the UK before 29 January 2020 you must wait 7 months from the original EU notification before you can place products containing <%= @nano_element.inci_name %> on the market.</p>
+    <p>If you notified <%= @nano_element.inci_name %> using CPNP before 1 January 2021, and notified it in GB before 31 March 2021 you must wait 7 months from the original EU notification before you can place products containing <%= @nano_element.inci_name %> on the market.</p>
 
-    <p>If you didn’t notify <%= @nano_element.inci_name %> using CPNP before Brexit you must wait 6 months from the date you notified it in the UK before you can place products containing <%= @nano_element.inci_name %> on the market.</p>
+    <p>If you didn’t notify <%= @nano_element.inci_name %> using CPNP before 1 January 2021 you must wait 6 months from the date you notified it in GB before you can place products containing <%= @nano_element.inci_name %> on the market.</p>
 
     <%= form_with model: @nano_element, url: wizard_path, method: :put do |form| %>
       <%= govukButton text: "Continue" %>

--- a/cosmetics-web/spec/controllers/nanomaterial_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/nanomaterial_build_controller_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :c
         expect(response).to redirect_to(responsible_person_notification_component_nanomaterial_build_path(responsible_person, notification, component, nano_element1, :confirm_usage))
       end
 
-      it "redirects to the non-standard nonomaterial notified path when confirm_restrictions is 'no'" do
+      it "redirects to the 'nanomaterial must be listed' error page when confirm_restrictions is 'no'" do
         post(:update, params: confirm_restrictions_params.merge(nano_element: { confirm_restrictions: "no" }))
-        expect(response).to redirect_to(responsible_person_notification_component_nanomaterial_build_path(responsible_person, notification, component, nano_element1, :non_standard_nanomaterial_notified))
+        expect(response).to redirect_to(responsible_person_notification_component_nanomaterial_build_path(responsible_person, notification, component, nano_element1, :must_be_listed))
       end
 
       it "sets error when no option is selected" do

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -60,11 +60,37 @@ RSpec.describe NanoElement, type: :model do
     end
   end
 
+  describe "#non_standard_single_purpose?" do
+    it "is true when the only purpose is 'other'" do
+      nano_element.purposes = %w[other]
+
+      expect(nano_element).to be_non_standard_single_purpose
+    end
+
+    it "is false when has multiple purposes including 'other'" do
+      nano_element.purposes = %w[colorant other]
+
+      expect(nano_element).not_to be_non_standard_single_purpose
+    end
+
+    it "is false when purposes do not include 'other'" do
+      nano_element.purposes = %w[colorant preservative uv_filter]
+
+      expect(nano_element).not_to be_non_standard_single_purpose
+    end
+  end
+
   describe "#standard?" do
-    it "is true when purposes includes 'other'" do
+    it "is true when purposes does not include 'other'" do
       nano_element.purposes = %w[colorant]
 
       expect(nano_element).to be_standard
+    end
+
+    it "is false when purposes includes 'other'" do
+      nano_element.purposes = %w[other]
+
+      expect(nano_element).not_to be_standard
     end
   end
 

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -60,26 +60,6 @@ RSpec.describe NanoElement, type: :model do
     end
   end
 
-  describe "#non_standard_single_purpose?" do
-    it "is true when the only purpose is 'other'" do
-      nano_element.purposes = %w[other]
-
-      expect(nano_element).to be_non_standard_single_purpose
-    end
-
-    it "is false when has multiple purposes including 'other'" do
-      nano_element.purposes = %w[colorant other]
-
-      expect(nano_element).not_to be_non_standard_single_purpose
-    end
-
-    it "is false when purposes do not include 'other'" do
-      nano_element.purposes = %w[colorant preservative uv_filter]
-
-      expect(nano_element).not_to be_non_standard_single_purpose
-    end
-  end
-
   describe "#standard?" do
     it "is true when purposes does not include 'other'" do
       nano_element.purposes = %w[colorant]


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-985)

Product nanomaterials flow got multiple tweaks:

### When a nanomaterial combines standard and non-standard purposes: 
**Original flow**: The steps on the flow asking about regulation listing and conformance with restrictions from the standard purposes Annexes get bypassed.
**New flow**: User goes through both steps instead of landing directly into the question about having submitted a notification about the nanomaterial since the end of the transition period.

### User cannot continue with the product notification process if the nanomaterial:
- is not listed in the annexes for its standard purposes.
- is not conforming with the restrictions defined in the annexes for its standard purposes.

### Wording/dates changes:
References to "Brexit" and "GB" have been replaced with the date of the end of the transition period (1 Jan 20201) and "UK" in:
- "When you can place products containing nanomaterial on the market" page.
- "Have you submitted a notification about the nanomaterial since the end of the transition period" step.

### Links changes:
- Link about how to notify nanomaterials guiding in "you cannot notify products until you have notified the nanomaterial" page now opens in a new tab instead of redirecting the current page.
- Included a link to go back to the notifications dashboard in all the flow "ending error pages".

![image](https://user-images.githubusercontent.com/1227578/106580377-c0f8bc80-6539-11eb-9625-4e52cdfd4386.png)

