### PR TITLE
Disable Scout APM and its env vars

### DIFF
--- a/cosmetics-web/config/scout_apm.yml
+++ b/cosmetics-web/config/scout_apm.yml
@@ -18,7 +18,7 @@ common: &defaults
   # monitor: Enable Scout APM or not
   # - Default: none
   # - Valid Options: true, false
-  monitor: true
+  monitor: false
 
 production:
   <<: *defaults

--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -24,7 +24,7 @@ applications:
     - cosmetics-notify-env
     - cosmetics-sidekiq-env
     - cosmetics-puma-env
-    - cosmetics-scout-env
+    # - cosmetics-scout-env
     - antivirus-auth-env
   path: .
   processes:


### PR DESCRIPTION
 While investigating why some instance keeps crashing in Production and blocking the deployment for the environment, noticed there are still some references in the logs for Scout monitoring.
Scout shouldn't be running as we suspect is the cause of the instance not passing the health check due to timeout.

![image](https://user-images.githubusercontent.com/1227578/106918962-98bbba00-6701-11eb-92e6-61550a10ce7e.png)

