### PR TITLE
Tweak Puma production concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
         SUBMIT_HOST: staging-submit.cosmetic-product-notifications.service.gov.uk
         SEARCH_HOST: staging-search.cosmetic-product-notifications.service.gov.uk
         WEB_INSTANCES: 2
-        WEB_MAX_THREADS: 1
+        WEB_MAX_THREADS: 4
         WORKER_MAX_THREADS: 10
         WORKER_INSTANCES: 2
         CF_USERNAME: ${{ secrets.PaaSUsernameStaging }}
@@ -97,7 +97,7 @@ jobs:
         SUBMIT_HOST: submit.cosmetic-product-notifications.service.gov.uk
         SEARCH_HOST: search.cosmetic-product-notifications.service.gov.uk
         WEB_INSTANCES: 8
-        WEB_MAX_THREADS: 1
+        WEB_MAX_THREADS: 4
         WORKER_MAX_THREADS: 10
         WORKER_INSTANCES: 4
         CF_USERNAME: ${{ secrets.PaaSUsernameProduction }}

--- a/cosmetics-web/config/database.yml
+++ b/cosmetics-web/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   host: db
   username: postgres
   password:
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 1 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 1).to_i * ENV.fetch("WEB_CONCURRENCY", 1).to_i %>
 
 development:
   <<: *default

--- a/cosmetics-web/config/puma.rb
+++ b/cosmetics-web/config/puma.rb
@@ -25,7 +25,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 8 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
Achieve the same concurrency by reducing puma workers and increasing puma threads.

We're attempting to reduce the app start time since now is timing out while starting up Puma and we suspect may be related by having 8 puma workers.

Our CF instances have 2 CPU cores x 2 Thread per core. It is usually recommended to adjust the number of Puma workers to match the number of CPU cores. Following that "rule" probably we should AIM for 3-4 workers maximum.