### PR TITLE
Fix Production Rails booting time issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
         SUBMIT_HOST: staging-submit.cosmetic-product-notifications.service.gov.uk
         SEARCH_HOST: staging-search.cosmetic-product-notifications.service.gov.uk
         WEB_INSTANCES: 2
-        WEB_MAX_THREADS: 4
+        WEB_MAX_THREADS: 1
         WORKER_MAX_THREADS: 10
         WORKER_INSTANCES: 2
         CF_USERNAME: ${{ secrets.PaaSUsernameStaging }}
@@ -97,7 +97,7 @@ jobs:
         SUBMIT_HOST: submit.cosmetic-product-notifications.service.gov.uk
         SEARCH_HOST: search.cosmetic-product-notifications.service.gov.uk
         WEB_INSTANCES: 8
-        WEB_MAX_THREADS: 4
+        WEB_MAX_THREADS: 1
         WORKER_MAX_THREADS: 10
         WORKER_INSTANCES: 4
         CF_USERNAME: ${{ secrets.PaaSUsernameProduction }}

--- a/cosmetics-web/config/database.yml
+++ b/cosmetics-web/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   host: db
   username: postgres
   password:
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 1).to_i * ENV.fetch("WEB_CONCURRENCY", 1).to_i %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 1 } %>
 
 development:
   <<: *default

--- a/cosmetics-web/config/environments/production.rb
+++ b/cosmetics-web/config/environments/production.rb
@@ -81,19 +81,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  # Index all relevant records with elasticsearch
-  config.after_initialize do
-    unless Sidekiq.server?
-      ActiveRecord::Base.descendants.each do |model|
-        if model.respond_to?(:__elasticsearch__) && !model.superclass.respond_to?(:__elasticsearch__)
-          if model.respond_to?(:elasticsearch)
-            model.elasticsearch.import force: true
-          else
-            model.import force: true
-          end
-        end
-      end
-    end
-  end
 end

--- a/cosmetics-web/config/puma.rb
+++ b/cosmetics-web/config/puma.rb
@@ -25,7 +25,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 8 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
By removing Elastic Search indexing on prod application boot.

The production start time of rails has become  slower until the point of reaching the timeout for the health checks
and causing deployments to fail.

After tracing a Rails console start, was discovered that the long boot time (a couple of minutes at this point) was caused by ES indexing over a DB that keeps increasing in size.

Reverting Puma concurrency tweaks as Puma config had nothing to do with the boot time issues.