### PR TITLE
Re-enable Scout

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -27,7 +27,7 @@ gem "rails", "~> 5.2.3"
 gem "request_store", "~> 1.5.0"
 gem "rest-client", "~> 2.1.0"
 gem "rubyzip", ">= 1.2.1"
-# gem "scout_apm" # Temporally disabled due to poor start time issues
+gem "scout_apm"
 gem "sentry-raven", "~> 3.1"
 gem "sidekiq", "~> 5.2.7"
 gem "sidekiq-cron", "~> 1.1.0"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -348,6 +348,8 @@ GEM
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
+    scout_apm (4.0.3)
+      parser
     sentry-raven (3.1.1)
       faraday (>= 1.0)
     sidekiq (5.2.9)
@@ -487,6 +489,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.42.0)
   ruby-debug-ide (~> 0.7.0)
   rubyzip (>= 1.2.1)
+  scout_apm
   sentry-raven (~> 3.1)
   sidekiq (~> 5.2.7)
   sidekiq-cron (~> 1.1.0)


### PR DESCRIPTION
It was disabled as we thought it was causing slow app startup, but we resolved the issue. It became clear that this was unrelated to Scout.
