### PR TITLE
Allow imported components to have same name

### DIFF
--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -38,7 +38,7 @@ class Component < ApplicationRecord
   # Currently two components with no name are immediately created for
   # a notification when the user indicates that it is a kit/multi-component,
   # so the uniquness validation has to allow non-unique null values.
-  validates :name, uniqueness: { scope: :notification_id, allow_nil: true, case_sensitive: false }, unless: -> { @skip_name_uniqueness_on_import }
+  validates :name, uniqueness: { scope: :notification_id, allow_nil: true, case_sensitive: false }, unless: -> { notification.via_zip_file? }
 
   validates :special_applicator, presence: true, on: :select_special_applicator_type
 

--- a/cosmetics-web/app/services/cpnp_parser.rb
+++ b/cosmetics-web/app/services/cpnp_parser.rb
@@ -72,7 +72,6 @@ class CpnpParser
                                 ph: ph_answer(component_node),
                                 minimum_ph: minimum_ph(component_node) || component_ph(component_node),
                                 maximum_ph: maximum_ph(component_node) || component_ph(component_node))
-      component.skip_name_uniqueness_on_import = true
       component
     end
   end

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Component, type: :model do
   describe "Notification Validation" do
     context "when notification is missing" do
       specify do
-        component = described_class.new(name: "Component X", notification: nil)
-        expect(component).to be_invalid
+        component = described_class.new(name: "component x", notification: nil)
+        expect { component.valid? }.to raise_error
       end
     end
   end
@@ -41,10 +41,6 @@ RSpec.describe Component, type: :model do
         expect(component.errors[:name]).to eql(["You’ve already told us about an item called ‘Component X’"])
       end
 
-      it "is valid when :skip_uniqueness_on_import is set to true" do
-        component.skip_name_uniqueness_on_import = true
-        expect(component).to be_valid
-      end
     end
 
     context "when there is already a component with the same name but using uppercase for the same notification" do
@@ -63,9 +59,29 @@ RSpec.describe Component, type: :model do
         expect(component.errors[:name]).to eql(["You’ve already told us about an item called ‘Component X’"])
       end
 
-      it "is valid when :skip_uniqueness_on_import is set to true" do
-        component.skip_name_uniqueness_on_import = true
-        expect(component).to be_valid
+      context "when component was imported" do
+        let(:notification) { create(:notification, :via_zip_file) }
+
+        it "is valid when :skip_uniqueness_on_import is set to true" do
+          expect(component).to be_valid
+        end
+      end
+    end
+
+    context "when component was imported" do
+      let(:notification) { create(:notification, :via_zip_file) }
+
+      let(:component1) { build(:component, name: 'Some component', notification: notification) }
+      let(:component2) { build(:component, name: 'Some component', notification: notification) }
+
+      before do
+        component1.save(validate: false)
+        component2.save(validate: false)
+      end
+
+      it "does not check name validation" do
+        expect(component1).to be_valid
+        expect(component2).to be_valid
       end
     end
 

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Component, type: :model do
     context "when notification is missing" do
       specify do
         component = described_class.new(name: "component x", notification: nil)
-        expect { component.valid? }.to raise_error
+        expect { component.valid? }.to raise_error NoMethodError
       end
     end
   end
@@ -40,7 +40,6 @@ RSpec.describe Component, type: :model do
         component.valid?
         expect(component.errors[:name]).to eql(["You’ve already told us about an item called ‘Component X’"])
       end
-
     end
 
     context "when there is already a component with the same name but using uppercase for the same notification" do
@@ -71,8 +70,8 @@ RSpec.describe Component, type: :model do
     context "when component was imported" do
       let(:notification) { create(:notification, :via_zip_file) }
 
-      let(:component1) { build(:component, name: 'Some component', notification: notification) }
-      let(:component2) { build(:component, name: 'Some component', notification: notification) }
+      let(:component1) { build(:component, name: "Some component", notification: notification) }
+      let(:component2) { build(:component, name: "Some component", notification: notification) }
 
       before do
         component1.save(validate: false)


### PR DESCRIPTION
Solves the bug with a looping formulation file. https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-1099