### PR TITLE
Fix float precision issue on validation

### DIFF
--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -211,7 +211,7 @@ private
   end
 
   def difference_between_maximum_and_minimum_ph
-    if (maximum_ph - minimum_ph) > 1.0
+    if (maximum_ph - minimum_ph).round(2) > 1.0
       errors.add(:maximum_ph, "The maximum pH cannot be more than 1 higher than the minimum pH")
     end
   end


### PR DESCRIPTION
The difference between float numbers had a precision issue that caused
the result failing the comparison when it shouldn't.

Eg: 8.3 - 7.3 => 1.0000000000000009

Rounding the result to avoid this.
