### PR TITLE
Fix: Error when Trigger Question has empty elements

### DIFF
--- a/cosmetics-web/app/helpers/trigger_rules_helper.rb
+++ b/cosmetics-web/app/helpers/trigger_rules_helper.rb
@@ -21,11 +21,13 @@ module TriggerRulesHelper
   end
 
   def format_trigger_question_elements(trigger_question_elements)
-    trigger_question_elements.group_by(&:answer_order).map do |_answer_order, elements|
-      {
-        inci_name: elements.first.answer,
-        quantity: display_concentration(elements.last.answer),
-      }
+    trigger_question_elements.group_by(&:answer_order).filter_map do |_answer_order, elements|
+      if elements.first.answer.present? && elements.last.answer.present?
+        {
+          inci_name: elements.first.answer,
+          quantity: display_concentration(elements.last.answer),
+        }
+      end
     end
   end
 


### PR DESCRIPTION
Fixes the second issue raised on [Jira ticket 1095](https://regulatorydelivery.atlassian.net/browse/COSBETA-1095)
Some CPNP export files contain Trigger Questions with empty elements (no name, no value).
The file import works ok, but then, when trying to display them, the service attempts to format the answers/values and blows up.
