### PR TITLE
Fix undefined constant on invitation expired page

### DIFF
--- a/cosmetics-web/app/views/users/expired_invitation.html.erb
+++ b/cosmetics-web/app/views/users/expired_invitation.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l"><%= page_title %></h1>
 
-    <p>Invitations are valid for <%= User::INVITATION_EXPIRATION_DAYS %> days. Ask the person who invited you to resend the invite or <%= mail_to t(:enquiries_email), "email OPSS", class: "govuk-link" %> for support.</p>
+    <p>Invitations are valid for <%= SearchUser::INVITATION_EXPIRATION_DAYS %> days. Ask the person who invited you to resend the invite or <%= mail_to t(:enquiries_email), "email OPSS", class: "govuk-link" %> for support.</p>
   </div>
 </div>
 


### PR DESCRIPTION
[Bugtracking issue](https://sentry.io/organizations/beis/issues/2234638125/?project=1398436)

Users being redirected to the "Invitation Expired" page when following an expired link for registering a Search User are landing into a service exception.

The page is meant for Search users, and the constant is defined in the SearchUser model.
It was causing an exception when attempting to access it from the User model where the constant is not defined.
