### PR TITLE
Upgrade Cloud Foundry Ruby buildpack to v1.8.32

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Nodejs
       uses: actions/setup-node@v1
       with:
-        node-version: 10.22.x
+        node-version: 10.24.x
     - uses: actions/cache@v1
       with:
         path: cosmetics-web/node_modules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v1
       with:
-        node-version: 10.22.x
+        node-version: 10.24.x
     # required to compile pg ruby gem
     - name: install PostgreSQL client
       run: sudo apt-get install libpq-dev

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -510,4 +510,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.1.4
+   2.2.11

--- a/cosmetics-web/manifest.review.yml
+++ b/cosmetics-web/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((cosmetics-instance-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.26
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.32
   path: .
   routes:
     - route: ((search-host))

--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.26
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.32
   routes:
     - route: ((search-host))
     - route: ((submit-host))

--- a/cosmetics-web/package.json
+++ b/cosmetics-web/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "license": "MIT",
   "engines": {
-    "node": "10.22.x",
+    "node": "10.24.x",
     "yarn": "1.22.x"
   },
   "dependencies": {


### PR DESCRIPTION
- Bundler 2.2.11
- Node 10.24.0
- Rubygems 3.2.11

https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.26