### PR TITLE
BugFix: Active Record user associations for User destroy callbacks

### DIFF
--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -9,7 +9,7 @@ class SearchUser < User
 
   belongs_to :organisation
 
-  has_one :user_attributes, dependent: :destroy
+  has_one :user_attributes, dependent: :destroy, foreign_key: :user_id, inverse_of: :user
   attribute :skip_password_validation, :boolean, default: false
 
   enum role: {

--- a/cosmetics-web/app/models/submit_user.rb
+++ b/cosmetics-web/app/models/submit_user.rb
@@ -8,12 +8,12 @@ class SubmitUser < User
 
   belongs_to :organisation
 
-  has_many :notification_files, dependent: :destroy
+  has_many :notification_files, dependent: :destroy, foreign_key: :user_id, inverse_of: :user
   has_many :responsible_person_users, dependent: :destroy, foreign_key: :user_id, inverse_of: :user
   has_many :responsible_persons, through: :responsible_person_users
-  has_many :pending_responsible_person_users, dependent: :destroy, foreign_key: :creator_id, inverse_of: :inviting_user
+  has_many :pending_responsible_person_users, dependent: :destroy, foreign_key: :inviting_user_id, inverse_of: :inviting_user
 
-  has_one :user_attributes, dependent: :destroy
+  has_one :user_attributes, dependent: :destroy, foreign_key: :user_id, inverse_of: :user
   validates :mobile_number, presence: true
   validates :mobile_number,
             phone: { message: :invalid, allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },


### PR DESCRIPTION
When [testing the deletion of users in staging](https://regulatorydelivery.atlassian.net/browse/COSBETA-1033) found multiple ActiveRecord issues with foreign keys while trying to run the `user.destroy` callbacks.

Errors:
```
# Notification Files association
ActiveRecord::StatementInvalid (PG::UndefinedColumn: ERROR:  column notification_files.submit_user_id does not exist)
LINE 1: ...fication_files".* FROM "notification_files" WHERE "notificat...
                                                             ^
: SELECT "notification_files".* FROM "notification_files" WHERE "notification_files"."submit_user_id" = $1

# Pending Responsible Person Users association
ActiveRecord::StatementInvalid (PG::UndefinedColumn: ERROR:  column pending_responsible_person_users.creator_id does not exist)
LINE 1: ...".* FROM "pending_responsible_person_users" WHERE "pending_r...
                                                             ^
: SELECT "pending_responsible_person_users".* FROM "pending_responsible_person_users" WHERE "pending_responsible_person_users"."creator_id" = $1

# Pending User Attributes association
ActiveRecord::StatementInvalid (PG::UndefinedColumn: ERROR:  column user_attributes.submit_user_id does not exist)
LINE 1: ... "user_attributes".* FROM "user_attributes" WHERE "user_attr...
                                                             ^
: SELECT  "user_attributes".* FROM "user_attributes" WHERE "user_attributes"."submit_user_id" = $1 LIMIT $2
```
Now that `User` has been split into `SubmitUser` and `SearchUser`, some ActiveRecord associations need to have an explicit foreign key as the FK name cannot be automatically be inferred from the association name.

ActiveRecord automatically assumes associations from SubmitUser will have `model.submit_user_id` ass foreign key, but this is not the case (FK is `model.user_id`), so we need to specify the FK name in the association declaration.

Adding `inverse_of:` will allow AR to recognise the bi-directional association with custom FK.

After these changes, I was able to successfully call destroy over both Submit and Search users in my local environment.
