### PR TITLE
Remove different behaviour for pre/post EU exit notifications

### DIFF
--- a/cosmetics-web/app/controllers/concerns/manual_notification_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/manual_notification_concern.rb
@@ -56,11 +56,6 @@ module ManualNotificationConcern
     end
   end
 
-  def after_eu_exit_steps
-    # If you want your controller to allow different after_eu steps, override this
-    []
-  end
-
   def model
     # If you want your controller to allow different after_eu steps, override this
     raise "model method should be overridden"

--- a/cosmetics-web/app/controllers/concerns/manual_notification_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/manual_notification_concern.rb
@@ -13,24 +13,6 @@ module ManualNotificationConcern
     end
   end
 
-  def skip_step?(step = @step)
-    after_eu_exit_steps.include?(step) && notification.was_notified_before_eu_exit?
-  end
-
-  def previous_step(current_step = nil)
-    step = super(current_step)
-    return previous_step(step) if skip_step?(step)
-
-    step
-  end
-
-  def next_step(current_step = nil)
-    step = super(current_step)
-    return next_step(step) if skip_step?(step)
-
-    step
-  end
-
   def yes_no_param(param)
     params.dig(model.model_name.param_key, param)
   end

--- a/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
@@ -2,25 +2,27 @@ class ResponsiblePersons::AdditionalInformationController < SubmitApplicationCon
   before_action :set_notification, only: %i[index]
 
   def index
-    if @notification.nano_material_required?
+    if @notification.images_missing_or_with_virus?
+      return redirect_to new_responsible_person_notification_product_image_upload_path(responsible_person, @notification)
+    elsif @notification.nano_material_required?
       component = @notification.components.order(:id).find(&:nano_material_required?)
       nano_element = component.nano_material.nano_elements.order(:id).find(&:required?)
-      return redirect_to new_responsible_person_notification_component_nanomaterial_build_path(@notification.responsible_person, @notification, component, nano_element)
+      return redirect_to new_responsible_person_notification_component_nanomaterial_build_path(responsible_person, @notification, component, nano_element)
     elsif @notification.formulation_required?
       component = @notification.components.order(:id).find(&:formulation_required?)
-      return redirect_to new_responsible_person_notification_component_formulation_path(@notification.responsible_person, @notification, component)
+      return redirect_to new_responsible_person_notification_component_formulation_path(responsible_person, @notification, component)
     else
       @notification.formulation_file_uploaded!
     end
 
-    if @notification.images_missing_or_with_virus?
-      return redirect_to new_responsible_person_notification_product_image_upload_path(@notification.responsible_person, @notification)
-    end
-
-    redirect_to edit_responsible_person_notification_path(@notification.responsible_person, @notification)
+    redirect_to edit_responsible_person_notification_path(responsible_person, @notification)
   end
 
 private
+
+  def responsible_person
+    @notification&.responsible_person
+  end
 
   def set_notification
     @notification = Notification.find_by reference_number: params[:notification_reference_number]

--- a/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
@@ -13,7 +13,7 @@ class ResponsiblePersons::AdditionalInformationController < SubmitApplicationCon
       @notification.formulation_file_uploaded!
     end
 
-    if @notification.required_images_missing_or_with_virus?
+    if @notification.images_missing_or_with_virus?
       return redirect_to new_responsible_person_notification_product_image_upload_path(@notification.responsible_person, @notification)
     end
 

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -339,10 +339,6 @@ private
     @component.cmrs.destroy_all
   end
 
-  def after_eu_exit_steps
-    %i[contains_cmrs add_cmrs contains_special_applicator select_special_applicator_type]
-  end
-
   def model
     @component
   end

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/component_build_controller.rb
@@ -37,11 +37,6 @@ class ResponsiblePersons::Wizard::ComponentBuildController < SubmitApplicationCo
       create_required_cmrs
     when :list_nanomaterials
       setup_nano_elements
-    when :select_formulation_type
-      if @component.notification.was_notified_before_eu_exit?
-        @component.update(notification_type: "predefined")
-        jump_to(:select_frame_formulation)
-      end
     end
     render_wizard
   end
@@ -282,7 +277,7 @@ private
     end
 
     @component.update!(contains_poisonous_ingredients: params[:component][:contains_poisonous_ingredients])
-    if @component.contains_poisonous_ingredients? && @component.notification.was_notified_after_eu_exit?
+    if @component.contains_poisonous_ingredients?
       redirect_to responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :upload_formulation)
     else
       redirect_to finish_wizard_path
@@ -292,10 +287,7 @@ private
   def render_upload_formulation
     formulation_file = params.dig(:component, :formulation_file)
 
-    if @component.notification.was_notified_before_eu_exit?
-      @component.formulation_file.attach(formulation_file) if formulation_file.present?
-      redirect_to edit_responsible_person_notification_path(@component.notification.responsible_person, @component.notification)
-    elsif formulation_file.present?
+    if formulation_file.present?
       @component.formulation_file.attach(formulation_file)
       if @component.valid?
         redirect_to finish_wizard_path

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -220,10 +220,6 @@ private
     end
   end
 
-  def after_eu_exit_steps
-    %i[for_children_under_three]
-  end
-
   def model
     @notification
   end

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -18,17 +18,6 @@ class ResponsiblePersons::Wizard::NotificationBuildController < SubmitApplicatio
   before_action :set_countries, only: %i[show update]
 
   def show
-    if step == :add_product_image && @notification.was_notified_before_eu_exit?
-      if @notification.is_multicomponent?
-        return redirect_to responsible_person_notification_build_path(
-          @notification.responsible_person,
-          @notification,
-          :is_mixed,
-        )
-      else
-        return redirect_to new_responsible_person_notification_component_build_path(@notification.responsible_person, @notification, @notification.components.first)
-      end
-    end
     render_wizard
   end
 
@@ -67,7 +56,6 @@ class ResponsiblePersons::Wizard::NotificationBuildController < SubmitApplicatio
 
   def previous_wizard_path
     previous_step = get_previous_step
-    previous_step = previous_step(previous_step) if skip_step?(previous_step)
 
     if step == :add_product_name
       last_step = if request.referer&.end_with? "do_you_have_files_from_eu_notification"
@@ -214,7 +202,7 @@ private
     when :for_children_under_three
       :add_internal_reference
     when :is_mixed
-      @notification.was_notified_before_eu_exit? ? :single_or_multi_component : :add_product_image
+      :add_product_image
     when :ph_range
       :is_hair_dye
     when :add_new_component

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/trigger_questions_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/trigger_questions_controller.rb
@@ -79,15 +79,4 @@ private
   def ph_param
     { ph: params.fetch(:component, {})[:ph] }
   end
-
-  def previous_wizard_path
-    notification = @component.notification
-    if step == :select_ph_range && notification.was_notified_before_eu_exit?
-      responsible_person_notification_component_build_path(
-        notification.responsible_person, notification, @component, :contains_poisonous_ingredients
-      )
-    else
-      super
-    end
-  end
 end

--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -6,14 +6,12 @@ module ComponentBuildHelper
 
   def previous_wizard_path
     previous_step = get_previous_step
-    previous_step = previous_step(previous_step) if skip_step?(previous_step)
     notification = @component.notification
 
     if step == :add_component_name
       responsible_person_notification_build_path(notification.responsible_person, notification, :add_new_component)
     elsif step == :number_of_shades && !notification.is_multicomponent?
-      last_step = notification.was_notified_before_eu_exit ? :single_or_multi_component : :add_product_image
-      responsible_person_notification_build_path(notification.responsible_person, notification, last_step)
+      responsible_person_notification_build_path(notification.responsible_person, notification, :add_product_image)
     elsif step == :select_category && @category.present?
       wizard_path(:select_category, category: Component.get_parent_category(@category))
     elsif step == :select_category && @component&.nano_material.present?
@@ -22,12 +20,8 @@ module ComponentBuildHelper
       responsible_person_notification_component_nanomaterial_build_path(notification.responsible_person, notification, @component, last_nanoelement, nanoelement_step)
     elsif step == :select_formulation_type
       wizard_path(:select_category, category: @component.sub_category)
-    elsif step == :upload_formulation && @component.notification.was_notified_before_eu_exit?
-      edit_responsible_person_notification_path(notification.responsible_person, notification)
     elsif step == :upload_formulation && @component.predefined?
       wizard_path(:contains_poisonous_ingredients)
-    elsif step == :select_frame_formulation && @component.notification.was_notified_before_eu_exit?
-      wizard_path(:select_category, category: @component.sub_category)
     elsif previous_step.present?
       responsible_person_notification_component_build_path(notification.responsible_person, notification, @component, previous_step)
     else

--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -118,8 +118,6 @@ class Component < ApplicationRecord
   end
 
   def formulation_required?
-    return false if notification.was_notified_before_eu_exit?
-
     if range?
       !formulation_file.attached? && range_formulas&.empty?
     elsif exact?

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -129,7 +129,7 @@ class Notification < ApplicationRecord
   end
 
   def missing_information?
-    nano_material_required? || formulation_required? || required_images_missing_or_not_passed_antivirus_check?
+    nano_material_required? || formulation_required? || images_missing_or_not_passed_antivirus_check?
   end
 
   def nano_material_required?
@@ -148,20 +148,14 @@ class Notification < ApplicationRecord
     components.length > 1
   end
 
-  def was_notified_after_eu_exit?
-    !was_notified_before_eu_exit?
-  end
-
-  alias_method :requires_images?, :was_notified_after_eu_exit?
-
   # If any image is waiting for the antivirus check or it got a virus alert this method will be "true"
-  def required_images_missing_or_not_passed_antivirus_check?
-    requires_images? && (image_uploads.empty? || !all_images_passed_anti_virus_check?)
+  def images_missing_or_not_passed_antivirus_check?
+    image_uploads.empty? || !all_images_passed_anti_virus_check?
   end
 
   # Only will return "true" when there are no images or any image got an explicit antivirus alert
-  def required_images_missing_or_with_virus?
-    requires_images? && (image_uploads.empty? || images_failed_anti_virus_check?)
+  def images_missing_or_with_virus?
+    image_uploads.empty? || images_failed_anti_virus_check?
   end
 
   def get_valid_multicomponents

--- a/cosmetics-web/app/views/notifications/_product_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_product_details.html.erb
@@ -12,7 +12,7 @@
         <td class="govuk-table__cell"><%= notification.industry_reference %></td>
       </tr>
     <% end %>
-    <% if notification. was_notified_after_eu_exit? %>
+    <% unless notification.under_three_years.nil? %>
       <tr class="govuk-table__row">
         <th class="govuk-table__header">For children under 3</th>
         <td class="govuk-table__cell">

--- a/cosmetics-web/spec/controllers/component_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/component_build_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ResponsiblePersons::Wizard::ComponentBuildController, type: :cont
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:component) { create(:component, notification: notification, notification_type: component_type) }
   let(:notification) { create(:notification, responsible_person: responsible_person) }
-  let(:pre_eu_exit_notification) { create(:notification, :pre_brexit, components: [component], responsible_person: responsible_person) }
   let(:component_type) { nil }
 
   let(:params) do
@@ -265,17 +264,6 @@ RSpec.describe ResponsiblePersons::Wizard::ComponentBuildController, type: :cont
           expect(response.status).to be(200)
           expect(assigns(:component).errors[:contains_poisonous_ingredients]).to include("Select yes if the product contains any of these ingredients")
         end
-      end
-    end
-
-    context "when notified pre EU-exit" do
-      before do
-        params.merge!(notification_reference_number: pre_eu_exit_notification.reference_number)
-      end
-
-      it "redirects to contains_nanomaterials if pre-eu-exit" do
-        post(:update, params: params.merge(id: :add_physical_form, component: { physical_form: "loose powder" }))
-        expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, pre_eu_exit_notification, component, :contains_nanomaterials))
       end
     end
   end

--- a/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
@@ -166,18 +166,10 @@ RSpec.describe ResponsiblePersons::Wizard::NotificationBuildController, :with_st
         end
       end
 
-      context "when the product was notified pre-Brexit and has 2 valid component" do
-        let(:completed_notification) { create(:notification, :pre_brexit, responsible_person: responsible_person, components: [create(:component, name: "Component 1"), create(:component, name: "Component 2")]) }
-
-        it "redirects to the add 'check your answers' page" do
-          expect(response.location).to include("/responsible_persons/#{responsible_person.id}/notifications/#{completed_notification.reference_number}/build/wicked_finish")
-        end
-      end
-
-      context "when the product was notified post-Brexit and has 2 valid component" do
+      context "when the product has 2 valid component" do
         let(:completed_notification) { create(:notification, responsible_person: responsible_person, components: [create(:component, name: "Component 1"), create(:component, name: "Component 2")]) }
 
-        it "redirects to the add product image page" do
+        it "redirects to the wizard finish" do
           expect(response.status).to eq(302)
           expect(response.location).to include("/responsible_persons/#{responsible_person.id}/notifications/#{completed_notification.reference_number}/build/wicked_finish")
         end

--- a/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe ResponsiblePersons::Wizard::NotificationBuildController, :with_stubbed_antivirus, type: :controller do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:notification) { create(:notification, responsible_person: responsible_person) }
-  let(:pre_eu_exit_notification) { create(:notification, :pre_brexit, responsible_person: responsible_person) }
-
   let(:image_file) { fixture_file_upload("testImage.png", "image/png") }
   let(:text_file) { fixture_file_upload("testText.txt", "application/text") }
 

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -33,14 +33,6 @@ FactoryBot.define do
       ph_max_value { 8 }
     end
 
-    trait :pre_brexit do
-      was_notified_before_eu_exit { true }
-    end
-
-    trait :post_brexit do
-      was_notified_before_eu_exit { false }
-    end
-
     trait :manual do
       cpnp_reference { nil }
     end

--- a/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
+++ b/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
@@ -117,14 +117,14 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_to_see_incomplete_notification_with_eu_reference_number "10000098"
     click_link "Add missing information"
 
-    expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
-    expect_back_link_to_incomplete_notifications_page
-    upload_formulation_file
-
     expect(page.current_path).to end_with("/product_image_upload/new")
     expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
     expect(page).to have_h1("Upload an image of the product label")
     upload_product_label
+
+    expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
+    expect_back_link_to_incomplete_notifications_page
+    upload_formulation_file
 
     expect_to_be_on__check_your_answers_page(product_name: "Beautify Facial Night Cream")
     expect_back_link_to_incomplete_notifications_page
@@ -168,14 +168,14 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_to_see_incomplete_notification_with_eu_reference_number "10000098"
     click_link "Add missing information"
 
-    expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
-    expect_back_link_to_incomplete_notifications_page
-    upload_formulation_file
-
     expect(page.current_path).to end_with("/product_image_upload/new")
     expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
     expect(page).to have_h1("Upload an image of the product label")
     upload_product_label
+
+    expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
+    expect_back_link_to_incomplete_notifications_page
+    upload_formulation_file
 
     expect_to_be_on__check_your_answers_page(product_name: "Beautify Facial Night Cream")
     expect_check_your_answers_page_to_contain(
@@ -218,6 +218,11 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_to_see_incomplete_notification_with_eu_reference_number "1006034"
     click_link "Add missing information"
 
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload an image of the product label")
+    upload_product_label
+
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
     expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
@@ -233,11 +238,6 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
     expect_back_link_to_incomplete_notifications_page
     upload_formulation_file
-
-    expect(page.current_path).to end_with("/product_image_upload/new")
-    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
-    expect(page).to have_h1("Upload an image of the product label")
-    upload_product_label
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft shocking green hair dye")
     expect_back_link_to_incomplete_notifications_page
@@ -271,6 +271,11 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
 
     expect_to_see_incomplete_notification_with_eu_reference_number "100608777"
     click_link "Add missing information"
+
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload images of the item labels")
+    upload_product_label
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
     expect_back_link_to_incomplete_notifications_page
@@ -315,11 +320,6 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
     expect_back_link_to_incomplete_notifications_page
     upload_formulation_file
-
-    expect(page.current_path).to end_with("/product_image_upload/new")
-    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
-    expect(page).to have_h1("Upload images of the item labels")
-    upload_product_label
 
     expect_to_be_on__check_your_answers_page(product_name: "Multi-Item-RangeDoc_pHRange_ExactDoc_Nano")
     expect_back_link_to_incomplete_notifications_page
@@ -377,6 +377,11 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
 
     expect_to_see_incomplete_notification_with_eu_reference_number "1006080"
     click_link "Add missing information"
+
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload images of the item labels")
+    upload_product_label
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
     expect_back_link_to_incomplete_notifications_page
@@ -465,6 +470,11 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
 
     expect_to_see_incomplete_notification_with_eu_reference_number "1006079"
     click_link "Add missing information"
+
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload images of the item labels")
+    upload_product_label
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
     expect_back_link_to_incomplete_notifications_page

--- a/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
+++ b/cosmetics-web/spec/features/zip_file_upload_notifications_spec.rb
@@ -26,7 +26,12 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit responsible_person_notifications_path(responsible_person)
 
     expect_to_see_incomplete_notification_with_eu_reference_number "1000094"
-    click_link "Confirm and notify"
+    click_link "Add missing information"
+
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload an image of the product label")
+    upload_product_label
 
     expect_to_be_on__check_your_answers_page(product_name: "CTPA moisture conditioner")
     expect_check_your_answers_page_to_contain(
@@ -65,7 +70,12 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit responsible_person_notifications_path(responsible_person)
 
     expect_to_see_incomplete_notification_with_eu_reference_number "1005901"
-    click_link "Confirm and notify"
+    click_link "Add missing information"
+
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload an image of the product label")
+    upload_product_label
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft skin whitener")
     expect_check_your_answers_page_to_contain(
@@ -156,7 +166,16 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     visit responsible_person_notifications_path(responsible_person)
 
     expect_to_see_incomplete_notification_with_eu_reference_number "10000098"
-    click_link "Confirm and notify"
+    click_link "Add missing information"
+
+    expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
+    expect_back_link_to_incomplete_notifications_page
+    upload_formulation_file
+
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload an image of the product label")
+    upload_product_label
 
     expect_to_be_on__check_your_answers_page(product_name: "Beautify Facial Night Cream")
     expect_check_your_answers_page_to_contain(
@@ -210,6 +229,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
     expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "TRIS-BIPHENYL TRIAZINE / TRIS-BIPHENYL TRIAZINE (NANO)"
+
+    expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
+    expect_back_link_to_incomplete_notifications_page
+    upload_formulation_file
+
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload an image of the product label")
+    upload_product_label
 
     expect_to_be_on__check_your_answers_page(product_name: "SkinSoft shocking green hair dye")
     expect_back_link_to_incomplete_notifications_page
@@ -268,6 +296,10 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
 
+    expect_to_be_on__upload_formulation_document_page("Concentration ranges of the ingredients")
+    expect_back_link_to_incomplete_notifications_page
+    upload_formulation_file
+
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
     expect_back_link_to_incomplete_notifications_page
     answer_what_is_purpose_of_nanomaterial_with "Colourant", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
@@ -279,6 +311,15 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
     expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+
+    expect_to_be_on__upload_formulation_document_page("Exact concentrations of the ingredients")
+    expect_back_link_to_incomplete_notifications_page
+    upload_formulation_file
+
+    expect(page.current_path).to end_with("/product_image_upload/new")
+    expect(page).to have_link("Back", href: /responsible_persons\/#{responsible_person.id}\/notifications\/\d+\/edit/)
+    expect(page).to have_h1("Upload images of the item labels")
+    upload_product_label
 
     expect_to_be_on__check_your_answers_page(product_name: "Multi-Item-RangeDoc_pHRange_ExactDoc_Nano")
     expect_back_link_to_incomplete_notifications_page
@@ -360,6 +401,10 @@ RSpec.feature "ZIP file upload notifications", :with_stubbed_antivirus, type: :f
     expect_to_be_on__does_nanomaterial_conform_to_restrictions_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
     expect_back_link_to_is_nanomaterial_listed_in_ec_regulation_page
     answer_does_nanomaterial_conform_to_restrictions_with "Yes", nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
+
+    expect_to_be_on__upload_formulation_document_page("Concentration ranges of the ingredients")
+    expect_back_link_to_incomplete_notifications_page
+    upload_formulation_file
 
     expect_to_be_on__what_is_the_purpose_of_nanomaterial_page nanomaterial_name: "METHYLENE BIS-BENZOTRIAZOLYL TETRAMETHYLBUTYLPHENOL (NANO)"
     expect_back_link_to_incomplete_notifications_page

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -40,43 +40,35 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#images_missing_or_with_virus?" do
-    context "when notifiying pre EU exit with no images uploaded yet" do
-      let(:notification) { build_stubbed(:draft_notification, :pre_brexit) }
+    context "when notifiying with no images uploaded yet" do
+      let(:notification) { build_stubbed(:draft_notification) }
 
       it "requires images" do
         expect(notification.images_missing_or_with_virus?).to be true
       end
     end
 
-    context "when notifiying post EU exit with no images uploaded yet" do
-      let(:notification) { build_stubbed(:draft_notification, :post_brexit) }
-
-      it "requires images" do
-        expect(notification.images_missing_or_with_virus?).to be true
-      end
-    end
-
-    context "when notifiying post EU exit with 1 image uploaded but not virus-scanned" do
+    context "when notifiying with 1 image uploaded but not virus-scanned" do
       let(:image_upload) { build_stubbed(:image_upload) }
-      let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
+      let(:notification) { build_stubbed(:draft_notification, image_uploads: [image_upload]) }
 
       it "does not require images" do
         expect(notification.images_missing_or_with_virus?).to be false
       end
     end
 
-    context "when notifiying post EU exit with 1 image uploaded and flagged by the antivirus" do
+    context "when notifiying with 1 image uploaded and flagged by the antivirus" do
       let(:image_upload) { build_stubbed(:image_upload, :uploaded_and_virus_identified) }
-      let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
+      let(:notification) { build_stubbed(:draft_notification, image_uploads: [image_upload]) }
 
       it "requires images" do
         expect(notification.images_missing_or_with_virus?).to be true
       end
     end
 
-    context "when notifiying post EU exit with 1 image uploaded and virus-scanned" do
+    context "when notifiying with 1 image uploaded and virus-scanned" do
       let(:image_upload) { build_stubbed(:image_upload, :uploaded_and_virus_scanned) }
-      let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
+      let(:notification) { build_stubbed(:draft_notification, image_uploads: [image_upload]) }
 
       it "does not require images" do
         expect(notification.images_missing_or_with_virus?).to be false
@@ -85,43 +77,35 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#images_missing_or_not_passed_antivirus_check?" do
-    context "when notifiying pre EU exit with no images uploaded yet" do
-      let(:notification) { build_stubbed(:draft_notification, :pre_brexit) }
+    context "when notifiying with no images uploaded yet" do
+      let(:notification) { build_stubbed(:draft_notification) }
 
       it "requires images" do
         expect(notification.images_missing_or_not_passed_antivirus_check?).to be true
       end
     end
 
-    context "when notifiying post EU exit with no images uploaded yet" do
-      let(:notification) { build_stubbed(:draft_notification, :post_brexit) }
-
-      it "requires images" do
-        expect(notification.images_missing_or_not_passed_antivirus_check?).to be true
-      end
-    end
-
-    context "when notifiying post EU exit with 1 image uploaded but not virus-scanned" do
+    context "when notifiying with 1 image uploaded but not virus-scanned" do
       let(:image_upload) { build_stubbed(:image_upload) }
-      let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
+      let(:notification) { build_stubbed(:draft_notification, image_uploads: [image_upload]) }
 
       it "does not require images" do
         expect(notification.images_missing_or_not_passed_antivirus_check?).to be true
       end
     end
 
-    context "when notifiying post EU exit with 1 image uploaded and flagged by the antivirus" do
+    context "when notifiying with 1 image uploaded and flagged by the antivirus" do
       let(:image_upload) { build_stubbed(:image_upload, :uploaded_and_virus_identified) }
-      let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
+      let(:notification) { build_stubbed(:draft_notification, image_uploads: [image_upload]) }
 
       it "requires images" do
         expect(notification.images_missing_or_not_passed_antivirus_check?).to be true
       end
     end
 
-    context "when notifiying post EU exit with 1 image uploaded and virus-scanned" do
+    context "when notifiying with 1 image uploaded and virus-scanned" do
       let(:image_upload) { build_stubbed(:image_upload, :uploaded_and_virus_scanned) }
-      let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
+      let(:notification) { build_stubbed(:draft_notification, image_uploads: [image_upload]) }
 
       it "does not require images" do
         expect(notification.images_missing_or_not_passed_antivirus_check?).to be false
@@ -178,7 +162,7 @@ RSpec.describe Notification, type: :model do
 
     context "when no information is missing" do
       let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned) }
-      let(:notification) { build(:draft_notification, :pre_brexit, image_uploads: [image_upload], components: [component]) }
+      let(:notification) { build(:draft_notification, image_uploads: [image_upload], components: [component]) }
 
       it "can submit a notification" do
         expect(notification).to be_may_submit_notification
@@ -186,7 +170,7 @@ RSpec.describe Notification, type: :model do
     end
 
     context "when information is missing" do
-      let(:notification) { build(:draft_notification, :post_brexit, components: [component]) }
+      let(:notification) { build(:draft_notification, components: [component]) }
 
       it "can not submit a notification" do
         expect(notification).not_to be_may_submit_notification

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -39,12 +39,12 @@ RSpec.describe Notification, type: :model do
     end
   end
 
-  describe "#required_images_missing_or_with_virus?" do
-    context "when notifiying pre EU exit" do
+  describe "#images_missing_or_with_virus?" do
+    context "when notifiying pre EU exit with no images uploaded yet" do
       let(:notification) { build_stubbed(:draft_notification, :pre_brexit) }
 
-      it "does not require images" do
-        expect(notification.required_images_missing_or_with_virus?).to be false
+      it "requires images" do
+        expect(notification.images_missing_or_with_virus?).to be true
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Notification, type: :model do
       let(:notification) { build_stubbed(:draft_notification, :post_brexit) }
 
       it "requires images" do
-        expect(notification.required_images_missing_or_with_virus?).to be true
+        expect(notification.images_missing_or_with_virus?).to be true
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Notification, type: :model do
       let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
 
       it "does not require images" do
-        expect(notification.required_images_missing_or_with_virus?).to be false
+        expect(notification.images_missing_or_with_virus?).to be false
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Notification, type: :model do
       let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
 
       it "requires images" do
-        expect(notification.required_images_missing_or_with_virus?).to be true
+        expect(notification.images_missing_or_with_virus?).to be true
       end
     end
 
@@ -79,17 +79,17 @@ RSpec.describe Notification, type: :model do
       let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
 
       it "does not require images" do
-        expect(notification.required_images_missing_or_with_virus?).to be false
+        expect(notification.images_missing_or_with_virus?).to be false
       end
     end
   end
 
-  describe "#required_images_missing_or_not_passed_antivirus_check?" do
-    context "when notifiying pre EU exit" do
+  describe "#images_missing_or_not_passed_antivirus_check?" do
+    context "when notifiying pre EU exit with no images uploaded yet" do
       let(:notification) { build_stubbed(:draft_notification, :pre_brexit) }
 
-      it "does not require images" do
-        expect(notification.required_images_missing_or_not_passed_antivirus_check?).to be false
+      it "requires images" do
+        expect(notification.images_missing_or_not_passed_antivirus_check?).to be true
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe Notification, type: :model do
       let(:notification) { build_stubbed(:draft_notification, :post_brexit) }
 
       it "requires images" do
-        expect(notification.required_images_missing_or_not_passed_antivirus_check?).to be true
+        expect(notification.images_missing_or_not_passed_antivirus_check?).to be true
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe Notification, type: :model do
       let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
 
       it "does not require images" do
-        expect(notification.required_images_missing_or_not_passed_antivirus_check?).to be true
+        expect(notification.images_missing_or_not_passed_antivirus_check?).to be true
       end
     end
 
@@ -115,7 +115,7 @@ RSpec.describe Notification, type: :model do
       let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
 
       it "requires images" do
-        expect(notification.required_images_missing_or_not_passed_antivirus_check?).to be true
+        expect(notification.images_missing_or_not_passed_antivirus_check?).to be true
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe Notification, type: :model do
       let(:notification) { build_stubbed(:draft_notification, :post_brexit, image_uploads: [image_upload]) }
 
       it "does not require images" do
-        expect(notification.required_images_missing_or_not_passed_antivirus_check?).to be false
+        expect(notification.images_missing_or_not_passed_antivirus_check?).to be false
       end
     end
   end
@@ -135,7 +135,7 @@ RSpec.describe Notification, type: :model do
     before do
       allow(notification).to receive(:nano_material_required?).and_return(true)
       allow(notification).to receive(:formulation_required?).and_return(true)
-      allow(notification).to receive(:required_images_missing_or_not_passed_antivirus_check?).and_return(true)
+      allow(notification).to receive(:images_missing_or_not_passed_antivirus_check?).and_return(true)
     end
 
     it "has no missing information" do
@@ -155,7 +155,7 @@ RSpec.describe Notification, type: :model do
     end
 
     it "does not need a product image" do
-      allow(notification).to receive(:required_images_missing_or_not_passed_antivirus_check?).and_return(false)
+      allow(notification).to receive(:images_missing_or_not_passed_antivirus_check?).and_return(false)
 
       expect(notification).to be_missing_information
     end
@@ -164,7 +164,7 @@ RSpec.describe Notification, type: :model do
       it "has no missing information" do
         allow(notification).to receive(:nano_material_required?).and_return(false)
         allow(notification).to receive(:formulation_required?).and_return(false)
-        allow(notification).to receive(:required_images_missing_or_not_passed_antivirus_check?).and_return(false)
+        allow(notification).to receive(:images_missing_or_not_passed_antivirus_check?).and_return(false)
 
         expect(notification).not_to be_missing_information
       end

--- a/cosmetics-web/spec/requests/check_your_answers_page_spec.rb
+++ b/cosmetics-web/spec/requests/check_your_answers_page_spec.rb
@@ -59,53 +59,31 @@ RSpec.describe "Check your answers page", type: :request do
       end
     end
 
-    context "when the notification was post-Brexit" do
-      let(:notification) { create(:notification, :post_brexit, responsible_person: responsible_person) }
+    context "when the notification there is a single component with no pH range needed" do
+      let(:notification) { create(:notification, responsible_person: responsible_person) }
       let!(:component) { create(:component, notification: notification) }
 
-      before do
-        get edit_responsible_person_notification_path(params)
-      end
-
       it "includes a back link to the pH question" do
+        get edit_responsible_person_notification_path(params)
         expect(response.body).to have_back_link_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/components/#{component.id}/trigger_question/select_ph_range")
       end
     end
 
-    context "when the notification was pre-Brexit and there was a single component with the no pH range needed" do
-      let(:notification) { create(:notification, :pre_brexit, responsible_person: responsible_person) }
-      let!(:component) { create(:component, notification: notification) }
-
-      before do
-        get edit_responsible_person_notification_path(params)
-      end
-
-      it "includes a back link to the pH question" do
-        expect(response.body).to have_back_link_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/components/#{component.id}/trigger_question/select_ph_range")
-      end
-    end
-
-    context "when the notification was pre-Brexit and there was a single component with a specific pH range entered" do
-      let(:notification) { create(:notification, :pre_brexit, responsible_person: responsible_person) }
+    context "when there is a single component with a specific pH range entered" do
+      let(:notification) { create(:notification, responsible_person: responsible_person) }
       let!(:component) { create(:component, notification: notification, minimum_ph: 2.5, maximum_ph: 2.9) }
 
-      before do
-        get edit_responsible_person_notification_path(params)
-      end
-
       it "includes a back link to the pH range" do
+        get edit_responsible_person_notification_path(params)
         expect(response.body).to have_back_link_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/components/#{component.id}/trigger_question/ph")
       end
     end
 
-    context "when the notification was pre-Brexit and there were multiple components" do
-      let(:notification) { create(:notification, :pre_brexit, responsible_person: responsible_person, components: [create(:component), create(:component)]) }
-
-      before do
-        get edit_responsible_person_notification_path(params)
-      end
+    context "when there were multiple components" do
+      let(:notification) { create(:notification, responsible_person: responsible_person, components: [create(:component), create(:component)]) }
 
       it "includes a back link to list of components page" do
+        get edit_responsible_person_notification_path(params)
         expect(response.body).to have_back_link_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/build/add_new_component")
       end
     end
@@ -113,11 +91,8 @@ RSpec.describe "Check your answers page", type: :request do
     context "when the notification used a ZIP file from CPNP" do
       let(:notification) { create(:notification, :via_zip_file, responsible_person: responsible_person) }
 
-      before do
-        get edit_responsible_person_notification_path(params)
-      end
-
       it "includes a back link to incomplete notifications page" do
+        get edit_responsible_person_notification_path(params)
         expect(response.body).to have_back_link_to("/responsible_persons/#{responsible_person.id}/notifications\#incomplete")
       end
     end

--- a/cosmetics-web/spec/requests/nanomaterial_within_product_requests_spec.rb
+++ b/cosmetics-web/spec/requests/nanomaterial_within_product_requests_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe "Nanomaterial usage within product notifications", type: :request
   end
 
   describe "PUT #confirm_usage" do
-    context "when the notification was via ZIP file upload, pre-Brexit, and formulation included" do
+    context "when the notification was via ZIP file upload and formulation included" do
       let(:notification) do
         create(:notification,
-               :via_zip_file, :pre_brexit,
+               :via_zip_file,
                responsible_person: responsible_person)
       end
 
@@ -34,30 +34,10 @@ RSpec.describe "Nanomaterial usage within product notifications", type: :request
       end
     end
 
-    context "when the notification was via ZIP file upload, pre-Brexit, using exact, and formulation missing" do
+    context "when the notification was via ZIP file upload, using exact, and formulation missing" do
       let(:notification) do
         create(:notification,
-               :via_zip_file, :pre_brexit,
-               responsible_person: responsible_person)
-      end
-
-      let(:component) { create(:component, :using_exact, notification: notification) }
-      let(:nano_material) { create(:nano_material, component: component) }
-      let(:nano_element) { create(:nano_element, nano_material: nano_material) }
-
-      before do
-        put "/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/components/#{component.id}/nanomaterials/#{nano_element.id}/build/confirm_usage", params: { nano_element: { confirm_usage: "yes" } }
-      end
-
-      it "redirects to the Upload formulation page" do
-        expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
-      end
-    end
-
-    context "when the notification was via ZIP file upload, post-Brexit, using exact, and formulation missing" do
-      let(:notification) do
-        create(:notification,
-               :via_zip_file, :post_brexit,
+               :via_zip_file,
                responsible_person: responsible_person)
       end
 
@@ -76,7 +56,7 @@ RSpec.describe "Nanomaterial usage within product notifications", type: :request
 
     context "when the notification was manual" do
       let(:notification) do
-        create(:notification, :manual, :pre_brexit,
+        create(:notification, :manual,
                responsible_person: responsible_person)
       end
 
@@ -95,7 +75,7 @@ RSpec.describe "Nanomaterial usage within product notifications", type: :request
 
     context "when there is another nanomaterial to confirm usage for" do
       let(:notification) do
-        create(:notification, :via_zip_file, :pre_brexit,
+        create(:notification, :via_zip_file,
                responsible_person: responsible_person)
       end
 

--- a/cosmetics-web/spec/requests/trigger_questions_requests_spec.rb
+++ b/cosmetics-web/spec/requests/trigger_questions_requests_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Trigger questions", type: :request do
   include RSpecHtmlMatchers
 
   let!(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
-  let!(:notification) { create(:notification, responsible_person: responsible_person) }
+  let!(:notification) { create(:notification, responsible_person: responsible_person, state: :components_complete) }
   let(:component) { create(:predefined_component, notification: notification) }
 
   before do
@@ -106,22 +106,12 @@ RSpec.describe "Trigger questions", type: :request do
           expect(component.reload.ph).to eql("not_applicable")
         end
 
-        context "when the notification was first notified pre-Brexit" do
-          let(:notification) { create(:notification, :pre_brexit, responsible_person: responsible_person, state: "components_complete") }
-
-          it "redirects to the add check your answers page" do
-            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
-          end
-
-          it "updates the notification state to draft_complete" do
-            expect(notification.reload.state).to eql("draft_complete")
-          end
+        it "updates the notification state to draft_complete" do
+          expect(notification.reload.state).to eql("draft_complete")
         end
 
-        context "when the notification was first notified post-Brexit" do
-          it "redirects to the add check your answers page" do
-            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
-          end
+        it "redirects to the add check your answers page" do
+          expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
         end
       end
 
@@ -134,18 +124,8 @@ RSpec.describe "Trigger questions", type: :request do
           expect(component.reload.ph).to eql("between_3_and_10")
         end
 
-        context "when the notification was first notified pre-Brexit" do
-          let(:notification) { create(:notification, :pre_brexit, responsible_person: responsible_person) }
-
-          it "redirects to the add check your answers page" do
-            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
-          end
-        end
-
-        context "when the notification was first notified post-Brexit" do
-          it "redirects to the add check your answers page" do
-            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
-          end
+        it "redirects to the add check your answers page" do
+          expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
         end
       end
 
@@ -206,22 +186,12 @@ RSpec.describe "Trigger questions", type: :request do
           expect(component.reload.maximum_ph).to be(2.3)
         end
 
-        context "when the notification was first notified pre-Brexit" do
-          let(:notification) { create(:notification, :pre_brexit, responsible_person: responsible_person, state: "components_complete") }
-
-          it "redirects to the add check your answers page" do
-            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
-          end
-
-          it "updates the notification state to draft_complete" do
-            expect(notification.reload.state).to eql("draft_complete")
-          end
+        it "redirects to the add check your answers page" do
+          expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
         end
 
-        context "when the notification was first notified post-Brexit" do
-          it "redirects to the add check your answers page" do
-            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
-          end
+        it "updates the notification state to draft_complete" do
+          expect(notification.reload.state).to eql("draft_complete")
         end
       end
     end

--- a/cosmetics-web/spec/services/cpnp_notification_importer_spec.rb
+++ b/cosmetics-web/spec/services/cpnp_notification_importer_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe CpnpNotificationImporter do
   let(:cpnp_parser_multi_component_exact_formula) { create_cpnp_parser("testMultiComponentExactFormula.zip") }
   let(:cpnp_parser_manual_ranges_trigger_rules) { create_cpnp_parser("testManualRangesTriggerRules.zip") }
   let(:cpnp_parser_nano_materials_cmr) { create_cpnp_parser("testWithNanomaterialsAndCmrs.zip") }
-  let(:cpnp_parser_formulation_not_required) { create_cpnp_parser("testFormulationRequiredExportFile.zip") }
-  let(:cpnp_parser_formulation_required) { create_cpnp_parser("testFormulationRequiredExportFilePostExit.zip") }
+  let(:cpnp_parser_formulation_required) { create_cpnp_parser("testFormulationRequiredExportFile.zip") }
   let(:cpnp_parser_before_exit) { create_cpnp_parser("testFormulationRequiredExportFile.zip") }
   let(:cpnp_parser_after_exit) { create_cpnp_parser("testFormulationRequiredExportFilePostExit.zip") }
   let(:cpnp_parser_different_language) { create_cpnp_parser("testDifferentLanguage.zip") }
@@ -160,15 +159,6 @@ RSpec.describe CpnpNotificationImporter do
 
     it "creates a notification in the draft_complete state if no formulation information is needed" do
       exporter_instance = described_class.new(cpnp_parser_basic, responsible_person)
-      exporter_instance.create!
-
-      notification = Notification.order(created_at: :asc).last
-
-      expect(notification.state).to eq("draft_complete")
-    end
-
-    it "creates a notification in the notification_file_imported state if formulation information is not required" do
-      exporter_instance = described_class.new(cpnp_parser_formulation_not_required, responsible_person)
       exporter_instance.create!
 
       notification = Notification.order(created_at: :asc).last


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1117)

This is a following from https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/pull/2037 where we unified the pre-post EU exit manual flows into a single flow with the same steps and removed the pre-post EU exit question.

### What does this PR bring?
While the previous ticket removed the question in the manual flow and defaulted all the manual notifications to post EU exit, this PR effectively **removes the logic branching that causes different flows/behaviour for pre and post EU exit notifications**.\

It mainly affects the ZIP notifications flow.

Removes code, makes the codebase simpler and its maintainers happier :)