### PR TITLE
Add Component name to formulations page on multi-component notifications

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/new.html.erb
@@ -14,10 +14,11 @@
   </div>
 
   <div class="govuk-grid-row">
+    <% name = @component.name if @component.notification.is_multicomponent? %>
     <% if @component.exact? %>
-      <%= render 'responsible_persons/wizard/component_build/exact_concentration' %>
+      <%= render 'responsible_persons/wizard/component_build/exact_concentration', name: name %>
     <% elsif @component.range? %>
-      <%= render 'responsible_persons/wizard/component_build/ranges_concentration' %>
+      <%= render 'responsible_persons/wizard/component_build/ranges_concentration', name: name %>
     <% else %>
       <p>This can be either as ranges or the exact concentration.</p>
       <p>For each ingredient give the International Nomenclature of Cosmetic Ingredients (INCI) name.</p>

--- a/cosmetics-web/app/views/responsible_persons/wizard/component_build/_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/component_build/_exact_concentration.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">
-    Exact concentrations of the ingredients
+    Exact concentrations of the ingredients <%= "in #{local_assigns[:name]}" if local_assigns[:name].present? %>
   </h1>
   <p class="govuk-!-margin-bottom-3">To tell us about the exact concentrations, you need to upload a PDF which lists the ingredients in the product.</p>
   <h2 class="govuk-heading-m">

--- a/cosmetics-web/app/views/responsible_persons/wizard/component_build/_ranges_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/component_build/_ranges_concentration.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">
-    Concentration ranges of the ingredients
+    Concentration ranges of the ingredients <%= "in #{local_assigns[:name]}" if local_assigns[:name].present? %>
   </h1>
   <p class="govuk-!-margin-bottom-3">To tell us about the concentration ranges, you need to upload a PDF which lists the ingredients in the product.</p>
   <h2 class="govuk-heading-m">

--- a/cosmetics-web/app/views/responsible_persons/wizard/component_build/upload_formulation.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/component_build/upload_formulation.html.erb
@@ -7,11 +7,11 @@
 
 <div class="govuk-grid-row">
   <%= error_summary_for(@component) %>
-
+  <% name = @component.name if @component.notification.is_multicomponent? %>
   <% if @component.exact? %>
-    <%= render 'exact_concentration' %>
+    <%= render 'exact_concentration', name: name %>
   <% elsif @component.range? %>
-    <%= render 'ranges_concentration' %>
+    <%= render 'ranges_concentration', name: name %>
   <% elsif @component.predefined? %>
     <%= render 'frame_formulation_poisonous_ingredients' %>
   <% else %>


### PR DESCRIPTION
For multicomponent notifications, the page will show the name of the component we're uploading the formulation for.

<img src="https://user-images.githubusercontent.com/1227578/112666459-1e332f00-8e54-11eb-8ad0-ec62b7591ce1.png" width=40% height=40%>

<img src="https://user-images.githubusercontent.com/1227578/112666654-50449100-8e54-11eb-80fd-60dc28043f7e.png" width=40% height=40%>


