### PR TITLE
Reduce RSpec output noise

### DIFF
--- a/cosmetics-web/app/controllers/my_account_password_controller.rb
+++ b/cosmetics-web/app/controllers/my_account_password_controller.rb
@@ -15,7 +15,7 @@ class MyAccountPasswordController < ApplicationController
     @user.password = dig_params(:password)
 
     if @user.save
-      sign_in(@user, bypass: true)
+      bypass_sign_in(@user)
       redirect_to my_account_path, confirmation: "Password changed successfully"
     else
       render "my_account/password"

--- a/cosmetics-web/spec/jobs/notification_file_processor_job_spec.rb
+++ b/cosmetics-web/spec/jobs/notification_file_processor_job_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe NotificationFileProcessorJob, :with_stubbed_antivirus, :without_d
     it "does not remove the notification file" do
       expect {
         notification_file.reload
-      }.not_to raise_error(ActiveRecord::RecordNotFound)
+      }.not_to raise_error
     end
 
     it "adds an error to the file" do

--- a/cosmetics-web/spec/rails_helper.rb
+++ b/cosmetics-web/spec/rails_helper.rb
@@ -11,6 +11,10 @@ require "policy_helpers"
 # require "support/antivirus"
 # require "support/mailer"
 
+# Quiet Sidekiq's logging in test suite
+require "sidekiq/testing"
+Sidekiq.logger.level = Logger::FATAL
+
 require "simplecov"
 require "coveralls"
 require "simplecov-lcov"


### PR DESCRIPTION
Our RSpec runs output is quite noisy. 
This PR brings some changes to clean it up:
- Suppress Sidekiq log output on specs.
- Upgrade from deprecated Devise option.
- Remove warning on false positives for expectations on errors not being raised.

### After
<img src="https://user-images.githubusercontent.com/1227578/112853048-63e63680-90a4-11eb-9101-462c7a5bcbb0.png" width=70% height=70%>

### Before
<img src="https://user-images.githubusercontent.com/1227578/112853312-a1e35a80-90a4-11eb-9854-c57b97476c1d.png" width=70% height=70%>
<img src="https://user-images.githubusercontent.com/1227578/112853417-bcb5cf00-90a4-11eb-9e67-2f6f8b83fb24.png" width=70% height=70%>
<img src="https://user-images.githubusercontent.com/1227578/112853447-c50e0a00-90a4-11eb-8e06-39eccd7998a7.png" width=70% height=70%>
<img src="https://user-images.githubusercontent.com/1227578/112853477-cccdae80-90a4-11eb-8465-1710a0422b40.png" width=70% height=70%>


