### PR TITLE
Fix 7 day window to delete notification after submission

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -4,7 +4,11 @@ ruby "~> 2.7"
 
 gem "will_paginate", "3.2.1" # Must be laoded before elasticsearch gems
 
-gem "aasm", "~> 5.0.6"
+# Needed a feature added into AASM master branch but still not tagged with a new version.
+# Needed feature: record auto-generated timestamps in DB when reaching a state.
+# Commit: https://github.com/aasm/aasm/commit/143eedcd65922f6388b4706c2395c89cf5913dc5
+# TODO: Switch back to AASM version once new version gets released after 5.1.1 (current latest version)
+gem "aasm", github: "aasm", ref: "252ade3"
 gem "active_hash", "~> 2.2.1"
 gem "activerecord-pg_enum"
 gem "aws-sdk-s3", "~> 1.60.1"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -5,11 +5,17 @@ GIT
   specs:
     govuk-design-system-rails (0.5.0)
 
+GIT
+  remote: https://github.com/aasm/aasm.git
+  revision: 252ade3a20dd86abed3ec76b965f85da530e2611
+  ref: 252ade3
+  specs:
+    aasm (5.1.1)
+      concurrent-ruby (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    aasm (5.0.8)
-      concurrent-ruby (~> 1.0)
     actioncable (5.2.5)
       actionpack (= 5.2.5)
       nio4r (~> 2.0)
@@ -476,7 +482,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aasm (~> 5.0.6)
+  aasm!
   active_hash (~> 2.2.1)
   activerecord-pg_enum
   aws-sdk-s3 (~> 1.60.1)

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -62,7 +62,7 @@ class Notification < ApplicationRecord
       },
     )
   end
-  aasm whiny_transitions: false, column: :state do
+  aasm whiny_transitions: false, timestamps: true, column: :state do
     state :empty, initial: true
     state :product_name_added
     state :components_complete

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -181,7 +181,7 @@ class Notification < ApplicationRecord
   end
 
   def can_be_deleted?
-    !notification_complete? || created_at > Notification::DELETION_PERIOD_DAYS.days.ago
+    !notification_complete? || notification_complete_at > Notification::DELETION_PERIOD_DAYS.days.ago
   end
 
 private

--- a/cosmetics-web/app/views/application/_registered_product.html.erb
+++ b/cosmetics-web/app/views/application/_registered_product.html.erb
@@ -12,7 +12,7 @@
     <dl>
       <div class="govuk-clearfix">
         <dt>First notified in GB:</dt>
-        <dd class="tabular-data"><%= display_date notification.updated_at %></dd>
+        <dd class="tabular-data"><%= display_date notification.notification_complete_at %></dd>
       </div>
       <div class="govuk-clearfix">
         <dt>UK cosmetic product number:</dt>

--- a/cosmetics-web/db/migrate/20210330090803_add_notification_complete_at_to_notifications.rb
+++ b/cosmetics-web/db/migrate/20210330090803_add_notification_complete_at_to_notifications.rb
@@ -1,0 +1,16 @@
+class AddNotificationCompleteAtToNotifications < ActiveRecord::Migration[5.2]
+  # rubocop:disable Rails/ApplicationRecord
+  class Notification < ActiveRecord::Base; end
+  # rubocop:enable Rails/ApplicationRecord
+  def up
+    add_column :notifications, :notification_complete_at, :datetime, null: true
+    Notification.reset_column_information
+    Notification.where(state: :notification_complete).in_batches(of: 10_000) do |relation|
+      relation.update_all("notification_complete_at = updated_at")
+    end
+  end
+
+  def down
+    remove_column :notifications, :notification_complete_at
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_12_135950) do
+ActiveRecord::Schema.define(version: 2021_03_30_090803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -180,6 +180,7 @@ ActiveRecord::Schema.define(version: 2021_02_12_135950) do
     t.boolean "components_are_mixed"
     t.decimal "ph_min_value"
     t.decimal "ph_max_value"
+    t.datetime "notification_complete_at"
     t.index ["cpnp_reference", "responsible_person_id"], name: "index_notifications_on_cpnp_reference_and_rp_id", unique: true
     t.index ["reference_number"], name: "index_notifications_on_reference_number", unique: true
     t.index ["responsible_person_id"], name: "index_notifications_on_responsible_person_id"

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
@@ -163,16 +163,23 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
 
   describe "POST /confirm" do
     let(:draft_notification) { create(:draft_notification, responsible_person: responsible_person) }
+    let(:params) { { responsible_person_id: responsible_person.id, reference_number: draft_notification.reference_number } }
 
     it "assigns the correct notification" do
-      post :confirm, params: { responsible_person_id: responsible_person.id, reference_number: draft_notification.reference_number }
+      post :confirm, params: params
       expect(assigns(:notification)).to eq(draft_notification)
     end
 
     it "marks the notification as complete" do
       attach_image_to_draft_with_metadata(safe: true)
-      post :confirm, params: { responsible_person_id: responsible_person.id, reference_number: draft_notification.reference_number }
+      post :confirm, params: params
       expect(draft_notification.reload.state).to eq("notification_complete")
+    end
+
+    it "populates the completion timestamp" do
+      attach_image_to_draft_with_metadata(safe: true)
+      post :confirm, params: params
+      expect(draft_notification.reload.notification_complete_at).not_to be_nil
     end
   end
 

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -16,9 +16,7 @@ FactoryBot.define do
       state { :notification_file_imported }
     end
 
-    factory :registered_notification do
-      state { :notification_complete }
-    end
+    factory :registered_notification, traits: [:registered]
 
     trait :imported do
       import_country { "country:FR" }
@@ -26,6 +24,7 @@ FactoryBot.define do
 
     trait :registered do
       state { :notification_complete }
+      notification_complete_at { Time.zone.now }
     end
 
     trait :ph_values do

--- a/cosmetics-web/spec/features/notifications_deleting_spec.rb
+++ b/cosmetics-web/spec/features/notifications_deleting_spec.rb
@@ -37,4 +37,14 @@ RSpec.describe "Notifications delete", type: :feature do
     log = NotificationDeleteLog.first
     expect(log.notification_product_name).to eq notification.product_name
   end
+
+  scenario "not being able to delete a submitted notification outside its deletion window" do
+    notification = create(:registered_notification,
+                          responsible_person: responsible_person,
+                          notification_complete_at: 1.month.ago)
+    visit "/responsible_persons/#{responsible_person.id}/notifications"
+    click_on "Notified (1)"
+    click_on notification.product_name
+    expect(page).not_to have_link("Delete this cosmetic product notification")
+  end
 end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -207,4 +207,25 @@ RSpec.describe Notification, type: :model do
       end
     end
   end
+
+  describe "#can_be_deleted?" do
+    it "can be deleted if the notification is not complete" do
+      notification = build_stubbed(:draft_notification)
+      expect(notification.can_be_deleted?).to eq true
+    end
+
+    context "when the notification is complete" do
+      let(:notification) { build_stubbed(:registered_notification) }
+
+      it "can be deleted if the notification was completed within the allowed deletion window" do
+        notification.notification_complete_at = Time.zone.now
+        expect(notification.can_be_deleted?).to eq true
+      end
+
+      it "can't be deleted if the notification was completed outside the allowed deletion window" do
+        notification.notification_complete_at = (described_class::DELETION_PERIOD_DAYS + 1).days.ago
+        expect(notification.can_be_deleted?).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add a timestamp to the "Notification complete" state on the notification state machine.

It does:
- Add a field to DB that matches the state in the state machine.
- Backfills the field for all the already completed notifications.
  As the notifications cannot be edited once completed/submitted, the
  updated_at timestamp is used for the backfill.
- Sets AASM option to automatically set the timestamp when the
  Notification transitions to the "notification_complete" state.
