### PR TITLE
Fix analyzer exception when missing blob attachment

### DIFF
--- a/cosmetics-web/app/helpers/analyzer_helper.rb
+++ b/cosmetics-web/app/helpers/analyzer_helper.rb
@@ -1,5 +1,8 @@
 module AnalyzerHelper
   def get_notification_file_from_blob(blob)
-    ::NotificationFile.find_by(id: blob.attachments.first.record_id)
+    record_id = blob&.attachments&.first&.record_id
+    return if record_id.blank?
+
+    ::NotificationFile.find_by(id: record_id)
   end
 end


### PR DESCRIPTION
Related bug: https://sentry.io/organizations/beis/issues/2299104977/

There are some cases where the blob reaches the ActiveStorage analyzer not having an attachment associated.

There is code guarding in further steps for the case where the Notification File hasn't been found. But the issue is being triggered
on the notification file search before this stage, so we need to guard against it.

Seems this situation of "Blob without attachment" occurs when the blob has been removed from DB but is still on memory for ActiveStorage analyzer purposes.
I guess this because I searched some of the ActiveStorage::Blob causing the exceptions and none of them were found in DB.
