### PR TITLE
BugFix: CPNP importer with missing parsing date

### DIFF
--- a/cosmetics-web/app/services/cpnp_notification_importer.rb
+++ b/cosmetics-web/app/services/cpnp_notification_importer.rb
@@ -42,7 +42,7 @@ private
       components_are_mixed: @cpnp_parser.components_are_mixed,
       ph_min_value: @cpnp_parser.ph_min_value,
       ph_max_value: @cpnp_parser.ph_max_value,
-      was_notified_before_eu_exit: (@cpnp_parser.cpnp_notification_date < EU_EXIT_DATE),
+      was_notified_before_eu_exit: @cpnp_parser.cpnp_notification_date&.<(EU_EXIT_DATE),
     }
   end
 

--- a/cosmetics-web/app/services/cpnp_notification_importer.rb
+++ b/cosmetics-web/app/services/cpnp_notification_importer.rb
@@ -1,7 +1,11 @@
 class CpnpNotificationImporter
   class DuplicateNotificationError < FileUploadError; end
   class NotificationValidationError < FileUploadError; end
-  class DraftNotificationError < StandardError; end
+  class DraftNotificationError < StandardError
+    def message
+      "DraftNotificationError - Draft notification uploaded"
+    end
+  end
 
   def initialize(cpnp_parser, responsible_person)
     @cpnp_parser = cpnp_parser
@@ -9,34 +13,32 @@ class CpnpNotificationImporter
   end
 
   def create!
-    if @cpnp_parser.notification_status == "DR"
-      raise DraftNotificationError, "DraftNotificationError - Draft notification uploaded"
-    else
-      notification = ::Notification.new(product_name: @cpnp_parser.product_name,
-                                        shades: @cpnp_parser.shades,
-                                        components: @cpnp_parser.components,
-                                        cpnp_reference: @cpnp_parser.cpnp_reference,
-                                        industry_reference: @cpnp_parser.industry_reference,
-                                        cpnp_notification_date: @cpnp_parser.cpnp_notification_date,
-                                        responsible_person: @responsible_person,
-                                        under_three_years: @cpnp_parser.under_three_years,
-                                        still_on_the_market: @cpnp_parser.still_on_the_market,
-                                        components_are_mixed: @cpnp_parser.components_are_mixed,
-                                        ph_min_value: @cpnp_parser.ph_min_value,
-                                        ph_max_value: @cpnp_parser.ph_max_value,
-                                        was_notified_before_eu_exit: (@cpnp_parser.cpnp_notification_date < EU_EXIT_DATE))
+    raise DraftNotificationError if @cpnp_parser.notification_status == "DR"
 
-      notification.notification_file_parsed
-      notification.save(context: :file_upload)
-      if notification.errors.messages.present?
-        if notification.errors.messages[:cpnp_reference].include? Notification.duplicate_notification_message
-          raise DuplicateNotificationError, "DuplicateNotificationError - A notification for this product already
-            exists for this responsible person (CPNP reference no. #{notification.cpnp_reference})"
-        else
-          raise NotificationValidationError, "NotificationValidationError - #{notification.errors.messages}"
-        end
+    notification = ::Notification.new(product_name: @cpnp_parser.product_name,
+                                      shades: @cpnp_parser.shades,
+                                      components: @cpnp_parser.components,
+                                      cpnp_reference: @cpnp_parser.cpnp_reference,
+                                      industry_reference: @cpnp_parser.industry_reference,
+                                      cpnp_notification_date: @cpnp_parser.cpnp_notification_date,
+                                      responsible_person: @responsible_person,
+                                      under_three_years: @cpnp_parser.under_three_years,
+                                      still_on_the_market: @cpnp_parser.still_on_the_market,
+                                      components_are_mixed: @cpnp_parser.components_are_mixed,
+                                      ph_min_value: @cpnp_parser.ph_min_value,
+                                      ph_max_value: @cpnp_parser.ph_max_value,
+                                      was_notified_before_eu_exit: (@cpnp_parser.cpnp_notification_date < EU_EXIT_DATE))
+
+    notification.notification_file_parsed
+    notification.save(context: :file_upload)
+    if notification.errors.messages.present?
+      if notification.errors.messages[:cpnp_reference].include? Notification.duplicate_notification_message
+        raise DuplicateNotificationError, "DuplicateNotificationError - A notification for this product already
+          exists for this responsible person (CPNP reference no. #{notification.cpnp_reference})"
+      else
+        raise NotificationValidationError, "NotificationValidationError - #{notification.errors.messages}"
       end
-      notification
     end
+    notification
   end
 end

--- a/cosmetics-web/spec/services/cpnp_notification_importer_spec.rb
+++ b/cosmetics-web/spec/services/cpnp_notification_importer_spec.rb
@@ -272,6 +272,15 @@ RSpec.describe CpnpNotificationImporter do
         expect(notification.components.first.maximum_ph).to eq(2.0)
       end
     end
+
+    it "importing a draft notification does not create the notification but raises an exception" do
+      allow(cpnp_parser_basic).to receive(:notification_status).and_return("DR")
+      exporter = described_class.new(cpnp_parser_basic, responsible_person)
+
+      expect { exporter.create! }.to not_change(Notification, :count)
+                                 .and raise_error(described_class::DraftNotificationError,
+                                                  "DraftNotificationError - Draft notification uploaded")
+    end
   end
 
   def create_cpnp_parser(filename = "testExportFile.zip")

--- a/cosmetics-web/spec/services/cpnp_notification_importer_spec.rb
+++ b/cosmetics-web/spec/services/cpnp_notification_importer_spec.rb
@@ -193,6 +193,13 @@ RSpec.describe CpnpNotificationImporter do
       expect(notification.was_notified_before_eu_exit).to be_falsey
     end
 
+    it "notifications where the notification date hasn't been parsed are defaulted not to be notified before EU exit" do
+      allow(cpnp_parser_basic).to receive(:cpnp_notification_date).and_return(nil)
+      notification = described_class.new(cpnp_parser_basic, responsible_person).create!
+
+      expect(notification.was_notified_before_eu_exit?).to eq false
+    end
+
     it "creates a notification with the first language's name if there is no english name" do
       exporter_instance = described_class.new(cpnp_parser_different_language, responsible_person)
       exporter_instance.create!


### PR DESCRIPTION
Bug: https://sentry.io/organizations/beis/issues/2306373786/

#### Bugfix: Default for cpnp_notification_date missing
When the `cpnp_notification_date` is missing in the parser, the importer is raising an exception as it tries to compare a "nil" value against a date.

To resolve this, the comparison will only happen if cpnp_notification_date is present, defaulting to a false value for `Notification#was_notified_before_eu_exit` if not.


Also done some minor refactors on the Importer class.