### PR TITLE
Fix flaky test on pH backlink

### DIFF
--- a/cosmetics-web/spec/features/manual_notifications_spec.rb
+++ b/cosmetics-web/spec/features/manual_notifications_spec.rb
@@ -623,7 +623,7 @@ RSpec.describe "Manual notifications", :with_stubbed_antivirus, type: :feature d
 
     expect_to_be_on__what_is_ph_range_of_product_page
     expect_back_link_to_poisonous_ingredients_page
-    answer_what_is_ph_range_of_product_with "It does not have a pH"
+    answer_what_is_ph_range_of_product_with "The minimum pH is 3 or higher, and the maximum pH is 10 or lower"
 
     expect_to_be_on__kit_items_page
     expect_back_link_to_what_is_ph_range_of_product_page


### PR DESCRIPTION
The step asserting over the backlink for the last PH page step regularly fails when the PH selection was "does not have a pH".

Changing the pH range selection to "between 3 and 10 pH". That selection uses the same back-link in the next step, but without failing in some of the test runs.