### PR TITLE
Add "set up of authenticator app" to guidance pages

### DIFF
--- a/cosmetics-web/app/controllers/guidance_controller.rb
+++ b/cosmetics-web/app/controllers/guidance_controller.rb
@@ -4,4 +4,6 @@ class GuidanceController < PubliclyAccessibleController
   def how_to_notify_nanomaterials; end
 
   def how_to_prepare_images_for_notification; end
+
+  def how_to_set_up_authenticator_app; end
 end

--- a/cosmetics-web/app/views/guidance/how_to_set_up_authenticator_app.html.erb
+++ b/cosmetics-web/app/views/guidance/how_to_set_up_authenticator_app.html.erb
@@ -1,0 +1,51 @@
+<% title = "Set up your authenticator app" %>
+
+<% content_for :page_title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= title %></h1>
+
+    <p>
+      This guidance describes how to set up an authenticator app on your device as a form of
+      two‑factor authentication (2FA) and why this is important.
+    </p>
+
+    <h2 class="govuk-heading-m">Download your authenticator app</h2>
+
+    <p>
+      You can download an authenticator app on any smart device, such as a smart phone or tablet.
+      Examples of authenticator apps are the
+      <%= link_to "Google Authenticator", "https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en", target: :_blank %>
+      and
+      <%= link_to "Microsoft Authenticator", "https://www.microsoft.com/en-us/account/authenticator", target: :_blank %>.
+    </p>
+
+    <h2 class="govuk-heading-m">Use your authenticator app to register on the service</h2>
+
+    <p>
+      Once your authenticator app is installed on your device, you will then need to open it
+      and scan the QR code or manually enter the supplied code.
+    </p>
+
+    <p>
+      Your authenticator app will then be set up for the service. A six-digit passcode will appear
+      in the authenticator app, this passcode can then be entered on the service.
+      You will now be able to use your authenticator app to login to your account.
+    </p>
+
+    <h2 class="govuk-heading-m">Advantages of an authenticator app for 2FA</h2>
+
+    <p>
+      2FA provides a way to ensure that you are the person you claim to be when accessing services,
+      it prevents unauthorised people from accessing your account.
+      This second method of authentication is done through something which only you will have access to.
+    </p>
+
+    <p>
+      Whilst 2FA passcodes can be received by text, the main advantage of using an authenticator app
+      for 2FA is that you do not need a mobile phone signal to receive passcodes.
+      Authenticator apps are also more secure, as passcodes sent by text are at higher risk of being intercepted.
+    </p>
+  </div>
+</div>

--- a/cosmetics-web/app/views/layouts/_footer.html.erb
+++ b/cosmetics-web/app/views/layouts/_footer.html.erb
@@ -15,6 +15,10 @@
           <li class="govuk-footer__list-item">
             <%= link_to "How to prepare images for notification", how_to_prepare_images_for_notification_path, class: "govuk-footer__link", target: :_blank  %>
           </li>
+          </li>
+          <li class="govuk-footer__list-item">
+            <%= link_to "Set up your authenticator app", how_to_set_up_authenticator_app_path, class: "govuk-footer__link", target: :_blank  %>
+          </li>
         </ul>
       </div>
     </div>

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -174,6 +174,7 @@ Rails.application.routes.draw do
   namespace :guidance, as: "" do
     get :how_to_notify_nanomaterials, path: "how-to-notify-nanomaterials"
     get :how_to_prepare_images_for_notification, path: "how-to-prepare-images-for-notification"
+    get :how_to_set_up_authenticator_app, path: "how-to-set-up-authenticator-app"
   end
 
   namespace :help, as: "" do

--- a/cosmetics-web/spec/requests/guidance_pages_spec.rb
+++ b/cosmetics-web/spec/requests/guidance_pages_spec.rb
@@ -38,4 +38,22 @@ RSpec.describe "Guidance pages", type: :request do
       expect(response.body).to have_tag("h1", text: /\AHow to prepare images for notification/)
     end
   end
+
+  describe "'Set up your authentication app'" do
+    before do
+      get "/guidance/how-to-set-up-authenticator-app"
+    end
+
+    it "is successful" do
+      expect(response.code).to eql("200")
+    end
+
+    it "has a page title" do
+      expect(response.body).to have_tag("title", text: /\ASet up your authenticator app/)
+    end
+
+    it "has a page heading" do
+      expect(response.body).to have_tag("h1", text: /\ASet up your authenticator app/)
+    end
+  end
 end


### PR DESCRIPTION
[Jira Ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1118)
Not much to say, we're adding a guidance page for the authenticator app set up.

### Screenshots
<img src="https://user-images.githubusercontent.com/1227578/114551208-fcf77e80-9c5a-11eb-883c-40130a1195ef.png" width=30% height=30%>
<img src="https://user-images.githubusercontent.com/1227578/114549185-9cffd880-9c58-11eb-96de-6eaa8a6b8e9e.png" width=50% height=50%>
