### PR TITLE
Secondary authentication: Remove 2FA method memorisation from session. Fix previous 2FA session polluting Registration

### DIFF
--- a/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
@@ -15,7 +15,7 @@ module SecondaryAuthenticationConcern
       redirect_to(registration_new_account_security_path)
     elsif !secondary_authentication_present_in_session? || user.mobile_number_pending_verification?
       session[:secondary_authentication_redirect_to] = redirect_to
-      session[:secondary_authentication_user_id] = user_id_for_secondary_authentication
+      session[:secondary_authentication_user_id] = user.id
       session[:secondary_authentication_notice] = notice
       session[:secondary_authentication_confirmation] = confirmation
       if use_sms_authentication?

--- a/cosmetics-web/app/controllers/registration/new_accounts_controller.rb
+++ b/cosmetics-web/app/controllers/registration/new_accounts_controller.rb
@@ -5,6 +5,7 @@ module Registration
     skip_before_action :require_secondary_authentication
 
     def new
+      sign_out
       @new_account_form = NewAccountForm.new
     end
 

--- a/cosmetics-web/app/controllers/secondary_authentication/app_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentication/app_controller.rb
@@ -8,13 +8,9 @@ module SecondaryAuthentication
 
     def new
       user_id = session[:secondary_authentication_user_id]
-      return redirect_to(root_path) unless user_id
+      return redirect_to(root_path) unless user_id && app_authentication_available?
 
-      if user_needs_to_choose_secondary_authentication_method?
-        redirect_to new_secondary_authentication_method_path
-      else
-        @form = AppAuthForm.new(user_id: user_id)
-      end
+      @form = AppAuthForm.new(user_id: user_id)
     end
 
     def create
@@ -22,7 +18,6 @@ module SecondaryAuthentication
         set_secondary_authentication_cookie(Time.zone.now.to_i)
         form.user.update!(last_totp_at: form.last_totp_at)
         session[:secondary_authentication_user_id] = nil
-        session[:secondary_authentication_method] = nil
         redirect_to_saved_path
       else
         render :new

--- a/cosmetics-web/app/controllers/secondary_authentication/method_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentication/method_controller.rb
@@ -17,7 +17,6 @@ module SecondaryAuthentication
 
     def create
       if form.valid?
-        session[:secondary_authentication_method] = form.authentication_method
         redirect_to authentication_method_path(form.authentication_method)
       else
         render :new

--- a/cosmetics-web/app/controllers/secondary_authentication/sms/resend_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentication/sms/resend_controller.rb
@@ -41,11 +41,7 @@ module SecondaryAuthentication
       end
 
       def user_with_secondary_authentication_request
-        if current_user && current_user.id == session[:secondary_authentication_user_id]
-          current_user
-        else
-          User.find_by(id: session[:secondary_authentication_user_id])
-        end
+        User.find_by(id: session[:secondary_authentication_user_id])
       end
 
       def mobile_number_param

--- a/cosmetics-web/spec/requests/secondary_authentication/user_requests_new_secondary_authentication_sms_code_spec.rb
+++ b/cosmetics-web/spec/requests/secondary_authentication/user_requests_new_secondary_authentication_sms_code_spec.rb
@@ -1,20 +1,24 @@
 require "rails_helper"
 
 RSpec.describe "User requests new secondary authentication sms code", type: :request, with_stubbed_notify: true, with_2fa: true do
+  let(:user_session) { {} }
+
   before do
     configure_requests_for_submit_domain
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ApplicationController).to receive(:session).and_return(user_session)
+    # rubocop:enable RSpec/AnyInstance
   end
 
   describe "viewing the form" do
-    subject(:request_code) { get new_secondary_authentication_sms_resend_path }
-
-    context "with an user session" do
-      let(:user) { create(:submit_user, :with_responsible_person, :with_sms_secondary_authentication) }
-
-      before do
-        sign_in(user)
+    RSpec.shared_examples "redirect to homepage" do
+      it "redirects the user to the homepage" do
+        request_code
+        expect(response).to redirect_to(root_path)
       end
+    end
 
+    RSpec.shared_examples "allow access" do
       it "loads the resend secondary authentication code page", :aggregate_failures do
         request_code
 
@@ -23,16 +27,45 @@ RSpec.describe "User requests new secondary authentication sms code", type: :req
       end
     end
 
-    context "without an user session" do
-      it "redirects the user to the homepage" do
-        request_code
-        expect(response).to redirect_to(root_path)
+    subject(:request_code) { get new_secondary_authentication_sms_resend_path }
+
+    let(:user) { create(:submit_user, :with_responsible_person, :with_sms_secondary_authentication) }
+
+    context "when signed in without having requested 2FA" do
+      before do
+        sign_in(user)
       end
+
+      include_examples "redirect to homepage"
+    end
+
+    context "when neither signed in nor having requested 2FA" do
+      include_examples "redirect to homepage"
+    end
+
+    context "when not signed in but having requested 2FA" do
+      let(:user_session) { { secondary_authentication_user_id: user.id } }
+
+      include_examples "allow access"
+    end
+
+    context "when signed in and having requested 2FA" do
+      let(:user_session) { { secondary_authentication_user_id: user.id } }
+
+      before do
+        sign_in(user)
+      end
+
+      include_examples "allow access"
     end
   end
 
   describe "submitting the request" do
-    context "without an user session" do
+    subject(:request_code) { post new_secondary_authentication_sms_resend_path }
+
+    let(:user) { create(:submit_user, :with_responsible_person, :with_sms_secondary_authentication) }
+
+    RSpec.shared_examples "deny access" do
       it "shows an access denied error", :aggregate_failures do
         post secondary_authentication_sms_resend_path
 
@@ -41,15 +74,7 @@ RSpec.describe "User requests new secondary authentication sms code", type: :req
       end
     end
 
-    context "with an user session" do
-      subject(:request_code) { post new_secondary_authentication_sms_resend_path }
-
-      let(:user) { create(:submit_user, :with_responsible_person, :with_sms_secondary_authentication) }
-
-      before do
-        sign_in(user)
-      end
-
+    RSpec.shared_examples "resend code" do
       it "generates a new secondary authentication code for the user" do
         expect {
           request_code
@@ -74,19 +99,7 @@ RSpec.describe "User requests new secondary authentication sms code", type: :req
       end
     end
 
-    context "with an user session corresponding to an user who haven't verified their mobile number" do
-      subject(:request_code) do
-        post new_secondary_authentication_sms_resend_path, params: { submit_user: { mobile_number: mobile_number } }
-      end
-
-      let(:user) do
-        create(:submit_user, :with_responsible_person, :with_sms_secondary_authentication, mobile_number_verified: false)
-      end
-
-      before do
-        sign_in(user)
-      end
-
+    RSpec.shared_examples "resend code and update mobile number" do
       context "when a mobile number is not provided" do
         let(:mobile_number) { "" }
 
@@ -156,7 +169,7 @@ RSpec.describe "User requests new secondary authentication sms code", type: :req
           follow_redirect!
 
           expect(notify_stub).to have_received(:send_sms).with(
-            hash_including(phone_number: user.mobile_number, personalisation: { code: user.reload.direct_otp }),
+            hash_including(phone_number: mobile_number, personalisation: { code: user.reload.direct_otp }),
           )
         end
 
@@ -165,6 +178,62 @@ RSpec.describe "User requests new secondary authentication sms code", type: :req
 
           expect(response).to redirect_to(new_secondary_authentication_sms_path)
         end
+      end
+    end
+
+    context "when neither signed in nor having requested 2FA" do
+      include_examples "deny access"
+    end
+
+    context "when signed in without having requested 2FA" do
+      before do
+        sign_in(user)
+      end
+
+      include_examples "deny access"
+    end
+
+    context "when not signed in but having requested 2FA" do
+      let(:user_session) { { secondary_authentication_user_id: user.id } }
+
+      context "when user has a verified mobile number" do
+        include_examples "resend code"
+      end
+
+      context "when user haven't verified their mobile number" do
+        subject(:request_code) do
+          post new_secondary_authentication_sms_resend_path, params: { submit_user: { mobile_number: mobile_number } }
+        end
+
+        let(:user) do
+          create(:submit_user, :with_responsible_person, :with_sms_secondary_authentication, mobile_number_verified: false)
+        end
+
+        include_examples "resend code and update mobile number"
+      end
+    end
+
+    context "when user is signed in and have requested 2FA" do
+      let(:user_session) { { secondary_authentication_user_id: user.id } }
+
+      before do
+        sign_in(user)
+      end
+
+      context "when user has a verified mobile number" do
+        include_examples "resend code"
+      end
+
+      context "when user haven't verified their mobile number" do
+        subject(:request_code) do
+          post new_secondary_authentication_sms_resend_path, params: { submit_user: { mobile_number: mobile_number } }
+        end
+
+        let(:user) do
+          create(:submit_user, :with_responsible_person, :with_sms_secondary_authentication, mobile_number_verified: false)
+        end
+
+        include_examples "resend code and update mobile number"
       end
     end
   end


### PR DESCRIPTION
[Fixes COSBETA-1128](https://regulatorydelivery.atlassian.net/browse/COSBETA-1128)

**TLDR:** There were two issues causing the previous user 2FA session to take over a new user session. One was the storing of the 2FA method selection into the session (that was unnecessary) and the second was the fact that the user session wasn't being wiped when creating a new user.

## Overview
- Remove usage of the user session for recording the secondary authentication methods selection when multiple options are available.
- Enforce the secondary authentication to have been triggered as a condition to allow access to "Resend secondary authentication SMS code".
- **Bugfix**: Cleans previous user session when initiating new user registration.

## Description

When the user has multiple methods configured for secondary authentication, they need to choose which method to use when secondary authentication is prompted.

The method selection was being set/read at the user session.

There were some situations where when abandoning the flow when prompted for 2FA and then initiating a different flow that triggered a 2FA required action, caused the previous method selection, being used instead of prompting the user again for selecting a method.

This can be avoided and simplified by removing the use of session to store the method selection and just trust in the correct redirection happening when the user selects a method.

So every time the user needs to fill 2FA it gets sent to the method selection page and this form sends it to the SMS or APP authentication page.

### Bugfix description
Users partially signed in but not having completed the secondary authentication can reach the service landing page and click on the "Create an account" link. This causes issues as the previous user ID is kept in the user session for secondary authentication purposes and overrides 2FA configuration from the newly created user.
To avoid that, when the user registration page is reached, we wipe any previous user session.
