### PR TITLE
Updates to account registration pages

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/account_wizard/create_or_join_existing.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/create_or_join_existing.html.erb
@@ -11,7 +11,8 @@
         <h1 class="govuk-heading-l">Does anyone in your organisation have an account to submit cosmetic product notifications in the UK?</h1>
 
         <p class="govuk-!-margin-bottom-2">
-          This is a different service to the EU Cosmetic product notification portal (CPNP). You will need a new account if you or your organisation have not created an account since Brexit.
+          This is a different service to the EU Cosmetic Products Notification Portal (CPNP).
+          You will need a new account if you or your organisation have not created an account since <%= display_full_month_date(EU_EXIT_DATE) %>.
         </p>
       <% end %>
       <% if error_message %>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/overview.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/overview.html.erb
@@ -6,7 +6,7 @@
     <p>A Responsible Person may be the manufacturer, importer or distributor of the cosmetic product. They can also be a third party such as a specialist consultancy, as long as they’ve been given permission by the manufacturer or importer. The Responsible Person can be a company, limited liability partnership (LLP) or an individual. They must be based in the UK.</p>
 
     <p>
-      <%= link_to "Read about the legal obligations of a Responsible Person", 'https://www.gov.uk/government/publications/uk-product-safety-and-metrology-guidance-in-a-no-deal-scenario', class: "govuk-link", target: :_blank %>
+      <%= link_to "Read about the legal obligations of a Responsible Person", 'https://www.gov.uk/government/publications/cosmetic-products-enforcement-regulations-2013', class: "govuk-link", target: :_blank %>
     </p>
     <%= govukButton text: "Continue", href: next_wizard_path %>
   </div>

--- a/cosmetics-web/app/views/responsible_persons/contact_persons/_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/contact_persons/_form.html.erb
@@ -6,7 +6,7 @@
 
       <h1 class="govuk-heading-l">Contact person for <%= @responsible_person.name %></h1>
 
-      <p>A contact person must provide information when the National Poison Information Service or market surveillance authorities (for example, Trading Standards officers) ask for it.</p>
+      <p>A contact person must provide information when the National Poisons Information Service (NPIS) or market surveillance authorities (for example, Trading Standards officers) ask for it.</p>
 
       <%= render "form_components/govuk_input", form: form, key: :name,
               label: { text: "Full name" } %>


### PR DESCRIPTION
Minor content changes:
- Regulations link changed.
- Replaced 'Brexit' with EU exit date.
- Couple of acronym wording changes.

![Screenshot from 2021-04-19 16-41-52](https://user-images.githubusercontent.com/1227578/115266306-02a80500-a130-11eb-9824-b0ff6ba3d2a3.png)
![Screenshot from 2021-04-19 16-55-41](https://user-images.githubusercontent.com/1227578/115266482-266b4b00-a130-11eb-8441-150cf151f3f6.png)
