### PR TITLE
Fix email change confirmation sending old token

### DIFF
--- a/cosmetics-web/app/controllers/my_account/email_controller.rb
+++ b/cosmetics-web/app/controllers/my_account/email_controller.rb
@@ -18,7 +18,7 @@ module MyAccount
 
       ActiveRecord::Base.transaction do
         @user.save!
-        @user.send_new_email_confirmation_email
+        @user.reload.send_new_email_confirmation_email
         render "users/check_your_email/show"
       end
     rescue StandardError


### PR DESCRIPTION
[Bug ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1133)

When the user:
- already had a new email confirmation token.
- attempts again to change their email.

The change email address confirmation email sent uses the previous confirmation token stored in DB instead of the one generated for the new request. 
This results in an "Email can not be changed. Confirmation token invalid" error when the user follows the link from the confirmation email.

To avoid that, we're refreshing the user in memory before dispatching the confirmation email.
