### PR TITLE
Search user bulk inviter tweaks

### DIFF
--- a/cosmetics-web/app/services/invite_search_user.rb
+++ b/cosmetics-web/app/services/invite_search_user.rb
@@ -26,7 +26,7 @@ private
 
   def send_invite
     if user.account_security_completed?
-      Rails.logger.info "[InviteSearchUser] #{user.email} is already registered in the service and cannot be re-invited."
+      Rails.logger.info "[InviteSearchUser] User with id: #{user.id} is already registered in the service and cannot be re-invited."
     else
       if !user.invitation_token || (user.invited_at < 1.hour.ago)
         user.update! invitation_token: (user.invitation_token || SecureRandom.hex(15)), invited_at: Time.zone.now

--- a/cosmetics-web/app/services/one_off/email.rb
+++ b/cosmetics-web/app/services/one_off/email.rb
@@ -1,7 +1,7 @@
 module OneOff
   class Email
     def initialize(email)
-      @email = email
+      @email = email.strip
       extract_names
     end
 

--- a/cosmetics-web/spec/services/invite_search_user_spec.rb
+++ b/cosmetics-web/spec/services/invite_search_user_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe InviteSearchUser, :with_stubbed_mailer do
           user.reload
         }.to not_change { user.invited_at.round }.and not_change(user, :invitation_token)
       end
+
+      it "registers the issue in the log" do
+        allow(Rails.logger).to receive(:info)
+        inviter.call
+        expect(Rails.logger).to have_received(:info).with("[InviteSearchUser] #{user.email} is already registered in the service and cannot be re-invited.")
+      end
     end
   end
 

--- a/cosmetics-web/spec/services/invite_search_user_spec.rb
+++ b/cosmetics-web/spec/services/invite_search_user_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe InviteSearchUser, :with_stubbed_mailer do
       it "registers the issue in the log" do
         allow(Rails.logger).to receive(:info)
         inviter.call
-        expect(Rails.logger).to have_received(:info).with("[InviteSearchUser] #{user.email} is already registered in the service and cannot be re-invited.")
+        expect(Rails.logger).to have_received(:info).with("[InviteSearchUser] User with id: #{user.id} is already registered in the service and cannot be re-invited.")
       end
     end
   end


### PR DESCRIPTION
This PR does:
1. Fix an issue when parsing emails from the CSV file for the bulk inviter.
2. Logs when trying to invite an email address corresponding to a registered user.


### Bug explanation
The emails parsed from the CSV file contain "end of line" symbols, like `user@example.org\n`.

This causes issues when attempting to re-invite users: 
- The user inviter attempts to find an existent user by email using `user@example.org\n`. 
- Does not find it because of the end of line difference, as the existent user email is `user@example.org`.
- The service attempts to create a new user with `user@example.org\n` but fails validation.
- Service fails and does not send the invitation.
