### PR TITLE
Bugfix: New email confirmation link using outdated token

### DIFF
--- a/cosmetics-web/app/controllers/my_account/email_controller.rb
+++ b/cosmetics-web/app/controllers/my_account/email_controller.rb
@@ -14,19 +14,14 @@ module MyAccount
         return render :edit
       end
 
-      @user.new_email = dig_params(:new_email)
-
-      ActiveRecord::Base.transaction do
-        @user.save!
-        @user.reload.send_new_email_confirmation_email
-        render "users/check_your_email/show"
-      end
+      @user.new_email_pending_confirmation!(dig_params(:new_email))
+      render "users/check_your_email/show"
     rescue StandardError
       render :edit
     end
 
     def confirm
-      User.new_email!(params[:confirmation_token])
+      User.confirm_new_email!(params[:confirmation_token])
       redirect_to my_account_path, confirmation: "Email changed successfully"
     rescue ArgumentError
       redirect_to my_account_path, alert: "Email can not be changed, confirmation token is incorrect. Please try again."

--- a/cosmetics-web/app/models/concerns/new_email_concern.rb
+++ b/cosmetics-web/app/models/concerns/new_email_concern.rb
@@ -2,12 +2,11 @@ module NewEmailConcern
   extend ActiveSupport::Concern
 
   def new_email_pending_confirmation!(email)
-    ActiveRecord::Base.transaction do
-      self.new_email_confirmation_token = SecureRandom.uuid
-      self.new_email_confirmation_token_expires_at = Time.zone.now + User::NEW_EMAIL_TOKEN_VALID_FOR.seconds
-      self.new_email = email
-      save!
-    end
+    update!(
+      new_email: email,
+      new_email_confirmation_token: SecureRandom.uuid,
+      new_email_confirmation_token_expires_at: Time.zone.now + User::NEW_EMAIL_TOKEN_VALID_FOR.seconds,
+    )
     send_new_email_confirmation_email
   end
 
@@ -16,13 +15,12 @@ module NewEmailConcern
       user = User.where("new_email_confirmation_token_expires_at > ?", Time.zone.now).find_by! new_email_confirmation_token: token
 
       old_email = user.email
-      ActiveRecord::Base.transaction do
-        user.email = user.new_email
-        user.new_email = nil
-        user.new_email_confirmation_token = nil
-        user.new_email_confirmation_token_expires_at = nil
-        user.save!
-      end
+      user.update!(
+        email: user.new_email,
+        new_email: nil,
+        new_email_confirmation_token: nil,
+        new_email_confirmation_token_expires_at: nil,
+      )
       NotifyMailer.get_mailer(user).update_email_address_notification_email(user, old_email).deliver_later
     rescue ActiveRecord::RecordNotFound
       raise ArgumentError

--- a/cosmetics-web/app/models/concerns/new_email_concern.rb
+++ b/cosmetics-web/app/models/concerns/new_email_concern.rb
@@ -1,17 +1,18 @@
 module NewEmailConcern
   extend ActiveSupport::Concern
 
-  def new_email=(email)
-    if email.present?
-      token = SecureRandom.uuid
-      self.new_email_confirmation_token = token
+  def new_email_pending_confirmation!(email)
+    ActiveRecord::Base.transaction do
+      self.new_email_confirmation_token = SecureRandom.uuid
       self.new_email_confirmation_token_expires_at = Time.zone.now + User::NEW_EMAIL_TOKEN_VALID_FOR.seconds
+      self.new_email = email
+      save!
+      send_new_email_confirmation_email
     end
-    super(email)
   end
 
   class_methods do
-    def new_email!(token)
+    def confirm_new_email!(token)
       user = User.where("new_email_confirmation_token_expires_at > ?", Time.zone.now).find_by! new_email_confirmation_token: token
 
       old_email = user.email

--- a/cosmetics-web/app/models/concerns/new_email_concern.rb
+++ b/cosmetics-web/app/models/concerns/new_email_concern.rb
@@ -7,8 +7,8 @@ module NewEmailConcern
       self.new_email_confirmation_token_expires_at = Time.zone.now + User::NEW_EMAIL_TOKEN_VALID_FOR.seconds
       self.new_email = email
       save!
-      send_new_email_confirmation_email
     end
+    send_new_email_confirmation_email
   end
 
   class_methods do
@@ -16,14 +16,14 @@ module NewEmailConcern
       user = User.where("new_email_confirmation_token_expires_at > ?", Time.zone.now).find_by! new_email_confirmation_token: token
 
       old_email = user.email
-      user.email = user.new_email
-      user.new_email = nil
-      user.new_email_confirmation_token = nil
-      user.new_email_confirmation_token_expires_at = nil
       ActiveRecord::Base.transaction do
+        user.email = user.new_email
+        user.new_email = nil
+        user.new_email_confirmation_token = nil
+        user.new_email_confirmation_token_expires_at = nil
         user.save!
-        NotifyMailer.get_mailer(user).update_email_address_notification_email(user, old_email).deliver_later
       end
+      NotifyMailer.get_mailer(user).update_email_address_notification_email(user, old_email).deliver_later
     rescue ActiveRecord::RecordNotFound
       raise ArgumentError
     end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1133)

### BUG:
Users are requesting to change their email and receiving confirmation links with invalid tokens.

These tokens seem to be the previous token that was changed with the new email request. So, instead of receiving the newly generated token, users receive the token that was previously set and is no longer valid.

### CAUSE OF THE BUG:
Change of token and mailer sending the new email confirmation link was under the same DB transaction block.

### EXPLANATION:
When code is wrapped into an Active Record transaction block, changes are not written in DB until the full transaction block has been run successfully.

This means that when the mailer is called inside the transaction, even when the `#save!` has been called, the DB value has not been updated as the transaction has not finished.

When this happens, the mailer retrieves the new email confirmation token from DB and gets the previous token instead of the updated value, as the update in DB happens when the transaction block ends.