### PR TITLE
Bugfix: Broken product image thumbnails in notification pages for search users

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ In Cosmetics, only routes which are being used are:
 /rails/active_storage/disk/:encoded_key/*filename(.:format)                                         active_storage/disk#show
 /rails/active_storage/disk/:encoded_token(.:format)                                                 active_storage/disk#update
 /rails/active_storage/direct_uploads(.:format)                                                      active_storage/direct_uploads#create
+/rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)      active_storage/representations/proxy#show
 ```
 
 `active_storage/blobs/proxy#show` has added protection - only owners and search users can access files.
@@ -169,7 +170,6 @@ And those routes are explicitly disabled in application:
 /rails/active_storage/blobs/redirect/:signed_id/*filename(.:format)                                 active_storage/blobs/redirect#show
 /rails/active_storage/blobs/:signed_id/*filename(.:format)                                          active_storage/blobs/redirect#show
 /rails/active_storage/representations/redirect/:signed_blob_id/:variation_key/*filename(.:format)   active_storage/representations/redirect#show
-/rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)      active_storage/representations/proxy#show
 /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)            active_storage/representations/redirect#show
 ```
 

--- a/cosmetics-web/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/cosmetics-web/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -7,8 +7,7 @@
 class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
   include ActiveStorage::SetHeaders
-  include Pundit
-  include DomainConcern
+  include ActiveStorageAccessProtectionConcern
 
   before_action :authorize_blob
 
@@ -16,23 +15,6 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
     http_cache_forever public: true do
       set_content_headers_from @blob
       stream @blob
-    end
-  end
-
-private
-
-  def pundit_user
-    current_submit_user
-  end
-
-  def authorize_blob
-    if submit_domain?
-      raise Pundit::NotAuthorizedError unless submit_user_signed_in?
-
-      rp = @blob.attachments.first.record.notification.responsible_person
-      authorize rp, :show?
-    else
-      raise Pundit::NotAuthorizedError unless search_user_signed_in?
     end
   end
 end

--- a/cosmetics-web/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/cosmetics-web/app/controllers/active_storage/representations/proxy_controller.rb
@@ -1,10 +1,29 @@
 # frozen_string_literal: true
 
-# Overrides original Rails implementation to disable route:
+# Proxy files through application. This avoids having a redirect and makes files easier to cache.
+# Overrides Rails Controller to enforce access protection beyond the security-through-obscurity
+# factor of the signed blob and variation reference.
+# Only owners and search users have access to files.
+#
+# This route is used for images thumbnails
 # /rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)
-# We use "rails storage proxy" through ActiveStorage::Blobs::ProxyController
 class ActiveStorage::Representations::ProxyController < ActiveStorage::BaseController
+  include ActiveStorage::SetBlob
+  include ActiveStorage::SetHeaders
+  include ActiveStorageAccessProtectionConcern
+
+  before_action :authorize_blob
+
   def show
-    redirect_to "/"
+    http_cache_forever public: true do
+      set_content_headers_from representation.image
+      stream representation
+    end
+  end
+
+private
+
+  def representation
+    @representation ||= @blob.representation(params[:variation_key]).processed
   end
 end

--- a/cosmetics-web/app/controllers/concerns/active_storage_access_protection_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/active_storage_access_protection_concern.rb
@@ -1,0 +1,20 @@
+module ActiveStorageAccessProtectionConcern
+  extend ActiveSupport::Concern
+  include Pundit
+  include DomainConcern
+
+  def pundit_user
+    current_submit_user
+  end
+
+  def authorize_blob
+    if submit_domain?
+      raise Pundit::NotAuthorizedError unless submit_user_signed_in?
+
+      rp = @blob.attachments.first.record.notification.responsible_person
+      authorize rp, :show?
+    else
+      raise Pundit::NotAuthorizedError unless search_user_signed_in?
+    end
+  end
+end

--- a/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.erb
@@ -20,9 +20,9 @@
     <% @notification.image_uploads.each do |image| %>
       <% if image.passed_antivirus_check? %>
         <% if image.file.variable? %>
-          <%= link_to image_tag(image.file.variant(resize: "450x450")), url_for(image.file) %>
+          <%= link_to image_tag(url_for(image.file.variant(resize: "450x450"))), url_for(image.file) %>
         <% elsif image.file.previewable? %>
-          <%= link_to image_tag(image.file.preview(resize: "450x450")), url_for(image.file) %>
+          <%= link_to image_tag(url_for(image.file.preview(resize: "450x450"))), url_for(image.file) %>
         <% else %>
           <h2 class="govuk-heading-l govuk-!-margin-bottom-1">Product image</h2>
           <%= link_to image.filename, url_for(image.file), class: "govuk-body-m" %>

--- a/cosmetics-web/spec/requests/assets_security_spec.rb
+++ b/cosmetics-web/spec/requests/assets_security_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Asset security", type: :request do
 
   let(:notification) { create(:notification, responsible_person: responsible_person) }
   let(:image_upload) { create(:image_upload, filename: "fooFile", notification: notification) }
+  let(:signed_id) { image_upload.file.signed_id }
 
   before do
     image_upload
@@ -26,7 +27,7 @@ RSpec.describe "Asset security", type: :request do
     context "when using representations redirect controller" do
       # /rails/active_storage/representations/redirect/:signed_blob_id/:variation_key/*filename(.:format)   active_storage/representations/redirect#show
       # /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)            active_storage/representations/redirect#show
-      let(:redirect_url) { rails_blob_representation_path(image_upload.file, filename: "fooFile", variation_key: "fooVariation") }
+      let(:redirect_url) { rails_blob_representation_path(signed_id, filename: "fooFile", variation_key: "fooVariation") }
 
       it "redirects" do
         get redirect_url
@@ -34,15 +35,101 @@ RSpec.describe "Asset security", type: :request do
         expect(response).to redirect_to("/")
       end
     end
+  end
 
-    context "when using representations proxy controller" do
-      # /rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)      active_storage/representations/proxy#show
-      let(:redirect_url) { rails_blob_representation_proxy_path(image_upload.file, filename: "fooFile", variation_key: "fooVariation") }
+  context "when using representations proxy controller" do
+    # /rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)      active_storage/representations/proxy#show
+    let(:image_upload) do
+      create(:image_upload,
+             file: Rack::Test::UploadedFile.new("spec/fixtures/files/testImage.png", "image/png"),
+             notification: notification)
+    end
+    let(:image_variant) { image_upload.file.variant(resize_to_limit: [100, 100]) }
+    let(:asset_url) do
+      rails_blob_representation_proxy_path(image_variant.blob.signed_id,
+                                           filename: image_variant.blob.filename,
+                                           variation_key: image_variant.variation.key)
+    end
 
-      it "redirects" do
-        get redirect_url
+    context "when user is submit user" do
+      let(:other_responsible_person) { create(:responsible_person, :with_a_contact_person) }
 
-        expect(response).to redirect_to("/")
+      let(:submitted_nanomaterial_notification) { create(:nanomaterial_notification, :submitted, responsible_person: responsible_person) }
+
+      before do
+        configure_requests_for_submit_domain
+      end
+
+      context "when user is not logged in" do
+        it "raises exception" do
+          expect {
+            get asset_url
+          }.to raise_error(Pundit::NotAuthorizedError)
+        end
+      end
+
+      context "when logged as responsible person that is notification owner" do
+        before do
+          sign_in_as_member_of_responsible_person(responsible_person)
+        end
+
+        after do
+          sign_out(:submit_user)
+        end
+
+        it "returns file" do
+          get asset_url
+          expect(response.content_type).to eq("image/png")
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when logged as different responsible person" do
+        before do
+          sign_in_as_member_of_responsible_person(other_responsible_person)
+        end
+
+        after do
+          sign_out(:submit_user)
+        end
+
+        it "raises authorization error" do
+          expect {
+            get asset_url
+          }.to raise_error(Pundit::NotAuthorizedError)
+        end
+      end
+    end
+
+    context "when user is search user" do
+      let(:search_user) { create(:poison_centre_user) }
+
+      before do
+        configure_requests_for_search_domain
+      end
+
+      context "when user is not logged in" do
+        it "redirects" do
+          expect {
+            get asset_url
+          }.to raise_error(Pundit::NotAuthorizedError)
+        end
+      end
+
+      context "when user is logged in" do
+        before do
+          sign_in search_user
+        end
+
+        after do
+          sign_out(:search_user)
+        end
+
+        it "returns file" do
+          get asset_url
+          expect(response.content_type).to eq("image/png")
+          expect(response.status).to eq(200)
+        end
       end
     end
   end


### PR DESCRIPTION
[Ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1154)

Image thumbnails were broken for search users due to the active storage route being disabled (re-routed to "/").

Enabled the route and overwrote the ActiveStorage representations proxy controller to add an access policy to the images.

### Before fix
<img src="https://user-images.githubusercontent.com/1227578/120452188-f0a1bf00-c389-11eb-82e7-55005dfd723e.png" width=40% height=40%>

### After fix
<img src="https://user-images.githubusercontent.com/1227578/120451937-c18b4d80-c389-11eb-853d-9804f32062d3.png" width=40% height=40%>
