### PR TITLE
Paginate registered notifications by completion

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -107,6 +107,7 @@ private
     @responsible_person.notifications
       .completed
       .paginate(page: params[:notified], per_page: page_size)
+      .order(notification_complete_at: :desc)
   end
 
   def add_image_upload_errors


### PR DESCRIPTION
The default pagination order based on "created_at" causes notifications that
were created days ago but completed recently not be displayed as the first
pagination results.

We want to order the results by the completion date/time. So the user will
be shown what notifications were notified most recently.

Example of affected results:

### Default order
![Screenshot from 2021-06-03 15-41-36](https://user-images.githubusercontent.com/1227578/120664406-ce3f9c80-c482-11eb-9e93-4f9e4078fce5.png)

### Ordering by completion date/time
![Screenshot from 2021-06-03 15-41-15](https://user-images.githubusercontent.com/1227578/120664433-d3045080-c482-11eb-986e-034552459029.png)
