### PR TITLE
Fix flaky back link test

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -65,7 +65,7 @@ class ResponsiblePersons::Wizard::NotificationBuildController < SubmitApplicatio
                   end
       responsible_person_add_notification_path(@notification.responsible_person, last_step)
     elsif step == :add_new_component && @notification.state == "draft_complete"
-      last_component = @notification.components.last
+      last_component = @notification.components.complete.last
       last_step = last_component.ph_range_not_required? ? :select_ph_range : :ph
       responsible_person_notification_component_trigger_question_path(@notification.responsible_person, @notification, last_component, last_step)
     elsif previous_step.present?

--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -29,6 +29,8 @@ class Component < ApplicationRecord
   accepts_nested_attributes_for :cmrs, reject_if: proc { |attributes| %i[name ec_number cas_number].all? { |key| attributes[key].blank? } }
   accepts_nested_attributes_for :nano_material
 
+  scope :complete, -> { where(state: "component_complete") }
+
   validates :physical_form, presence: {
     on: :add_physical_form,
     message: lambda do |object, _|


### PR DESCRIPTION
We have a flaky spec caused by the backlink to the last component question pointing to the wrong PH page.

When running the feature specs, the Notification last component is sometimes in an "empty" state, while the completed component is not the last anymore.

Because of that, the wizard page, after adding a component, incorrectly builds the backlink.

To fix this, the backlink on that wizard page uses the last "completed" component.