### PR TITLE
Faster CSV generation

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -5,9 +5,6 @@ ruby "~> 2.7"
 gem "will_paginate", "3.2.1" # Must be laoded before elasticsearch gems
 
 # Needed a feature added into AASM master branch but still not tagged with a new version.
-# Needed feature: record auto-generated timestamps in DB when reaching a state.
-# Commit: https://github.com/aasm/aasm/commit/143eedcd65922f6388b4706c2395c89cf5913dc5
-# TODO: Switch back to AASM version once new version gets released after 5.1.1 (current latest version)
 gem "aasm", "5.2.0"
 gem "active_hash", "~> 2.2.1"
 gem "activerecord-pg_enum"

--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -8,7 +8,7 @@ gem "will_paginate", "3.2.1" # Must be laoded before elasticsearch gems
 # Needed feature: record auto-generated timestamps in DB when reaching a state.
 # Commit: https://github.com/aasm/aasm/commit/143eedcd65922f6388b4706c2395c89cf5913dc5
 # TODO: Switch back to AASM version once new version gets released after 5.1.1 (current latest version)
-gem "aasm", github: "aasm", ref: "252ade3"
+gem "aasm", "5.2.0"
 gem "active_hash", "~> 2.2.1"
 gem "activerecord-pg_enum"
 gem "aws-sdk-s3", "~> 1.60.1"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -5,17 +5,11 @@ GIT
   specs:
     govuk-design-system-rails (0.7.2)
 
-GIT
-  remote: https://github.com/aasm/aasm.git
-  revision: 252ade3a20dd86abed3ec76b965f85da530e2611
-  ref: 252ade3
-  specs:
-    aasm (5.1.1)
-      concurrent-ruby (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.2.0)
+      concurrent-ruby (~> 1.0)
     actioncable (6.1.3.2)
       actionpack (= 6.1.3.2)
       activesupport (= 6.1.3.2)
@@ -527,7 +521,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aasm!
+  aasm (= 5.2.0)
   active_hash (~> 2.2.1)
   activerecord-pg_enum
   aws-sdk-s3 (~> 1.60.1)

--- a/cosmetics-web/app/decorators/notification_decorator.rb
+++ b/cosmetics-web/app/decorators/notification_decorator.rb
@@ -12,8 +12,6 @@ class NotificationDecorator
 private
 
   def categories_to_csv
-    @notification.components.map { |component|
-      [component.root_category, component.sub_category, component.sub_sub_category].map(&:to_s).map(&:humanize)
-    }.flatten
+    @notification.csv_cache&.flatten || []
   end
 end

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -108,11 +108,7 @@ class Notification < ApplicationRecord
       transitions from: :notification_file_imported, to: :draft_complete, guard: :formulation_present?
     end
 
-    event :submit_notification, after: :cache_categories_for_csv! do
-      after do
-        cache_categories_for_csv!
-      end
-
+    event :submit_notification, after: :cache_categories_for_csv! do   
       transitions from: :draft_complete, to: :notification_complete,
                   after: proc { __elasticsearch__.index_document } do
         guard do

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -108,7 +108,7 @@ class Notification < ApplicationRecord
       transitions from: :notification_file_imported, to: :draft_complete, guard: :formulation_present?
     end
 
-    event :submit_notification, after: :cache_categories_for_csv! do   
+    event :submit_notification, after: :cache_categories_for_csv! do
       transitions from: :draft_complete, to: :notification_complete,
                   after: proc { __elasticsearch__.index_document } do
         guard do
@@ -203,14 +203,10 @@ class Notification < ApplicationRecord
 
   delegate :count, to: :components, prefix: true
 
-  def cache_categories_for_csv
+  def cache_categories_for_csv!
     self.csv_cache = components.map do |component|
       [component.root_category, component.sub_category, component.sub_sub_category].map(&:to_s).map(&:humanize)
     end
-  end
-
-  def cache_categories_for_csv!
-    cache_categories_for_csv
     save!
   end
 

--- a/cosmetics-web/db/migrate/20210604114734_add_csv_cache_to_notifications.rb
+++ b/cosmetics-web/db/migrate/20210604114734_add_csv_cache_to_notifications.rb
@@ -1,0 +1,7 @@
+class AddCsvCacheToNotifications < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_column :notifications, :csv_cache, :json
+    end
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_103858) do
+ActiveRecord::Schema.define(version: 2021_06_04_114734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -190,6 +190,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_103858) do
     t.decimal "ph_min_value"
     t.decimal "ph_max_value"
     t.datetime "notification_complete_at"
+    t.json "csv_cache"
     t.index ["cpnp_reference", "responsible_person_id"], name: "index_notifications_on_cpnp_reference_and_rp_id", unique: true
     t.index ["reference_number"], name: "index_notifications_on_reference_number", unique: true
     t.index ["responsible_person_id"], name: "index_notifications_on_responsible_person_id"

--- a/cosmetics-web/spec/decorators/notifications_decorator_spec.rb
+++ b/cosmetics-web/spec/decorators/notifications_decorator_spec.rb
@@ -1,16 +1,7 @@
 require "rails_helper"
 
 RSpec.describe NotificationsDecorator do
-  before { travel_to(Time.zone.local(2021, 2, 20, 13)) }
-
   let(:date) { Time.zone.local(2020, 9, 22, 13) }
-
-  let(:notification1) { create(:notification, :with_component, product_name: "Product 1", reference_number: 111) }
-  let(:notification2) { create(:notification, :with_component, :via_zip_file, product_name: "Product 2", reference_number: 222) }
-  let(:notification3) { create(:notification, :with_components, :via_zip_file, product_name: "Product 3", reference_number: 333, cpnp_notification_date: date, industry_reference: "foo bar") }
-
-  let(:notifications) { [notification1, notification2, notification3] }
-
   let(:expected_csv) do
     <<~CSV
       Product name,UK cosmetic product number,Notification date,EU Reference number,EU Notification date,Internal reference,Number of items,Item 1 Level 1 category,Item 1 Level 2 category,Item 1 Level 3 category,Item 2 Level 1 category,Item 2 Level 2 category,Item 2 Level 3 category
@@ -18,6 +9,17 @@ RSpec.describe NotificationsDecorator do
       Product 2,UKCP-00000222,2021-02-20 13:00:00 +0000,123456789,,,1,Hair and scalp products,Hair colouring products,Nonoxidative hair colour products
       Product 3,UKCP-00000333,2021-02-20 13:00:00 +0000,123456789,2020-09-22 13:00:00 +0100,foo bar,2,Hair and scalp products,Hair colouring products,Nonoxidative hair colour products,Hair and scalp products,Hair colouring products,Nonoxidative hair colour products
     CSV
+  end
+
+  let(:notification1) { create(:notification, :with_component, product_name: "Product 1", reference_number: 111) }
+  let(:notification2) { create(:notification, :with_component, :via_zip_file, product_name: "Product 2", reference_number: 222) }
+  let(:notification3) { create(:notification, :with_components, :via_zip_file, product_name: "Product 3", reference_number: 333, cpnp_notification_date: date, industry_reference: "foo bar") }
+
+  let(:notifications) { [notification1, notification2, notification3] }
+
+  before do
+    travel_to(Time.zone.local(2021, 2, 20, 13))
+    notifications.each(&:cache_categories_for_csv!)
   end
 
   describe "#to_csv" do

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
       notification_complete_at { Time.zone.now }
     end
 
+    trait :draft_complete do
+      state { :draft_complete }
+    end
+
     trait :ph_values do
       ph_min_value { 4 }
       ph_max_value { 8 }

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Notification, type: :model do
+RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
   before do
     notification = described_class.create
     allow(notification)
@@ -226,6 +226,29 @@ RSpec.describe Notification, type: :model do
         notification.notification_complete_at = (described_class::DELETION_PERIOD_DAYS + 1).days.ago
         expect(notification.can_be_deleted?).to eq false
       end
+    end
+  end
+
+  describe "#cache_categories_for_csv" do
+    let(:notification) { create(:notification, :with_components) }
+
+    it "is saved properly" do
+      notification.cache_categories_for_csv
+      expect(notification.csv_cache).to eq [["Hair and scalp products", "Hair colouring products", "Nonoxidative hair colour products"], ["Hair and scalp products", "Hair colouring products", "Nonoxidative hair colour products"]]
+    end
+  end
+
+  describe "notification submision" do
+    let(:notification) { create(:notification, :draft_complete, :with_components) }
+    let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned, notification: notification) }
+
+    before do
+      image_upload
+      notification.submit_notification!
+    end
+
+    it "caches categories" do
+      expect(notification.reload.csv_cache).to eq [["Hair and scalp products", "Hair colouring products", "Nonoxidative hair colour products"], ["Hair and scalp products", "Hair colouring products", "Nonoxidative hair colour products"]]
     end
   end
 end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -229,12 +229,12 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
     end
   end
 
-  describe "#cache_categories_for_csv" do
+  describe "#cache_categories_for_csv!" do
     let(:notification) { create(:notification, :with_components) }
 
     it "is saved properly" do
-      notification.cache_categories_for_csv
-      expect(notification.csv_cache).to eq [["Hair and scalp products", "Hair colouring products", "Nonoxidative hair colour products"], ["Hair and scalp products", "Hair colouring products", "Nonoxidative hair colour products"]]
+      notification.cache_categories_for_csv!
+      expect(notification.reload.csv_cache).to eq [["Hair and scalp products", "Hair colouring products", "Nonoxidative hair colour products"], ["Hair and scalp products", "Hair colouring products", "Nonoxidative hair colour products"]]
     end
   end
 


### PR DESCRIPTION
Cache categories in `Notification` so they are being generated faster. After deployment, `#cache_categories_for_csv!` needs to be called on each completed notification.