### PR TITLE
Fix errors when sending confirmation email to invited Submit users who didn't finish their account setup

### DIFF
--- a/cosmetics-web/app/controllers/users/passwords_controller.rb
+++ b/cosmetics-web/app/controllers/users/passwords_controller.rb
@@ -68,7 +68,13 @@ module Users
       user.confirmed_at = nil
       user.account_security_completed = false
       user.save(validate: false)
-      user.resend_account_setup_link
+      if (invitation = PendingResponsiblePersonUser.where(email_address: user.email).last)
+        SubmitNotifyMailer.send_responsible_person_invite_email(
+          invitation.responsible_person, invitation, invitation.inviting_user.name
+        ).deliver_later
+      else
+        user.resend_account_setup_link
+      end
       redirect_to check_your_email_path
     end
 

--- a/cosmetics-web/app/controllers/users/passwords_controller.rb
+++ b/cosmetics-web/app/controllers/users/passwords_controller.rb
@@ -69,6 +69,7 @@ module Users
       user.account_security_completed = false
       user.save(validate: false)
       if (invitation = PendingResponsiblePersonUser.where(email_address: user.email).last)
+        invitation.refresh_token_expiration!
         SubmitNotifyMailer.send_responsible_person_invite_email(
           invitation.responsible_person, invitation, invitation.inviting_user.name
         ).deliver_later

--- a/cosmetics-web/app/controllers/users/passwords_controller.rb
+++ b/cosmetics-web/app/controllers/users/passwords_controller.rb
@@ -68,6 +68,10 @@ module Users
       user.confirmed_at = nil
       user.account_security_completed = false
       user.save(validate: false)
+      # TODO: Remove this branch based on pending invitations once invitations
+      # contain user name (pending feature).
+      # Once that happens logic can default to resending the account setup link
+      # as done with user who registered without an invitation.
       if (invitation = PendingResponsiblePersonUser.where(email_address: user.email).last)
         invitation.refresh_token_expiration!
         SubmitNotifyMailer.send_responsible_person_invite_email(

--- a/cosmetics-web/app/forms/registration/new_account_form.rb
+++ b/cosmetics-web/app/forms/registration/new_account_form.rb
@@ -10,11 +10,15 @@ module Registration
 
     def save
       return false unless valid?
-      return true if user_exists?
 
-      user = SubmitUser.new(name: full_name, email: email)
-      user.save(validate: false)
-      user
+      if (user = SubmitUser.find_by(email: email))
+        send_link(user)
+        true
+      else
+        user = SubmitUser.new(name: full_name, email: email)
+        user.save(validate: false)
+        user
+      end
     end
 
     def [](field)
@@ -23,16 +27,20 @@ module Registration
 
   private
 
-    def user_exists?
-      if (user = SubmitUser.find_by(email: email))
-        if user.confirmed?
-          SubmitNotifyMailer.send_account_already_exists(user).deliver_later
-        else
-          user.resend_confirmation_instructions
-        end
-        true
+    def send_link(user)
+      if user.confirmed?
+        SubmitNotifyMailer.send_account_already_exists(user).deliver_later
+      # TODO: Remove this branch based on pending invitations once invitations
+      # contain user name (pending feature).
+      # Once that happens logic can default to resending the account setup link
+      # as done with user who registered without an invitation.
+      elsif (invitation = PendingResponsiblePersonUser.where(email_address: user.email).last)
+        invitation.refresh_token_expiration!
+        SubmitNotifyMailer.send_responsible_person_invite_email(
+          invitation.responsible_person, invitation, invitation.inviting_user.name
+        ).deliver_later
       else
-        false
+        user.resend_confirmation_instructions
       end
     end
   end

--- a/cosmetics-web/spec/features/account/forgotten_password_spec.rb
+++ b/cosmetics-web/spec/features/account/forgotten_password_spec.rb
@@ -223,6 +223,58 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
         end
       end
     end
+
+    context "when user was invited to a responsible persons and followed the link but haven't completed their registration" do
+      let(:responsible_person) { create(:responsible_person, :with_a_contact_person, name: "Responsible Person") }
+      let(:invitation) do
+        create(:pending_responsible_person_user, email_address: "inviteduser@example.com", responsible_person: responsible_person)
+      end
+
+      scenario "resends the responsible person invitation email and shows the confirmation page" do
+        # Invited user visits the link from the RP invitation email
+        invitation_path = "/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{invitation.invitation_token}"
+        visit invitation_path
+        expect(page).to have_current_path("/account-security")
+        expect(page).to have_css("h1", text: "Create an account")
+        expect(page).to have_field("Full name")
+
+        # User abandons the registration process
+        click_link "Sign out"
+
+        # After a while, user tries to Sign in in the service believing it has an active account on it
+        visit "/sign-in"
+
+        # User attempts to recover their password (that they never did set up)
+        click_link "Forgot your password?"
+
+        expect(page).to have_css("h1", text: "Reset your password")
+        fill_in "Email address", with: "inviteduser@example.com"
+
+        perform_enqueued_jobs do
+          click_on "Send email"
+        end
+
+        # Instead of receiving a reset password email, user receives the invitation email again
+        expect(delivered_emails.size).to eq 1
+        email = delivered_emails.first
+
+        expect(email.recipient).to eq "inviteduser@example.com"
+        expect(email.reference).to eq "Invite user to join responsible person"
+        expect(email.template).to eq mailer::TEMPLATES[:responsible_person_invitation_for_existing_user]
+        expect(email.personalization).to eq(
+          invitation_url: "http://#{ENV.fetch('SUBMIT_HOST')}#{invitation_path}",
+          responsible_person: responsible_person.name,
+          invite_sender: invitation.inviting_user.name,
+        )
+        expect_to_be_on_check_your_email_page
+
+        # Invitation link takes the user to the account completion page
+        visit invitation_path
+        expect(page).to have_current_path("/account-security")
+        expect(page).to have_css("h1", text: "Create an account")
+        expect(page).to have_field("Full name")
+      end
+    end
   end
 
   describe "for search" do


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1174)
[Related error tracking](https://sentry.io/organizations/beis/issues/2441301077/)

### TLDR
Invited Submit users have no name until their complete their account security setup. When trying to send them a confirmation email that depends on the name, the mailer throws an exception.
Fixed by re-sending them the invitation email instead.

### Description
Some Submit invited users who followed the invitation link but didn't complete their registration were attempting to either:
- create a new account.
- reset their password.
Both situations were triggering the "resend user confirmation email" intended for users who initiated the registration but didn't complete their account security setup to be pointed to complete their registration.

This email depends on the user having a "name" attribute. But invited users set this value in their account security page, being empty until they complete this stage.
So when an invited user was triggering the "resend user confirmation", the user has no "name" and the mailer was throwing an exception.

### Solution
For Submit invited incomplete users, we will re-send the latest invitation instead of sending the confirmation email.
This way they will be able to complete their account setup.

### This is a temporal solution
This fix is meant to temporally resolve the bug.
We are planning to start including the user name in the invitations, this will allow us to unify the logic between self-registered and invited Submit users and default both to the confirmation email in order to finish their account setup.
