### PR TITLE
Upgrade ActiveStorage::Blob deprecated method

### DIFF
--- a/cosmetics-web/spec/analyzers/anti_virus_analyzer_spec.rb
+++ b/cosmetics-web/spec/analyzers/anti_virus_analyzer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AntiVirusAnalyzer, type: :analyzer do
     let(:analyzer) { described_class.new(blob) }
     let(:notification_file) { create(:notification_file) }
     let(:blob) do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Rails.root.join("spec/fixtures/files/testImage.png"), "rb"),
         filename: "testImage.png",
         content_type: "image/png",


### PR DESCRIPTION
This method was triggering deprecation warnings during spec runs.

The new method keeps the same interface but ensures the blob instance to be saved before the upload starts to avoid key collisions on uploads.

[Rails doc reference](https://edgeapi.rubyonrails.org/classes/ActiveStorage/Blob.html#method-c-create_after_upload-21)

![Screenshot from 2021-06-09 14-13-25](https://user-images.githubusercontent.com/1227578/121362540-100e8e00-c92e-11eb-97bd-3cfa8f7dd1d6.png)
