### PR TITLE
Do not attempt deployments for dependabot PRs

### DIFF
--- a/cosmetics-web/deploy-github-functions.sh
+++ b/cosmetics-web/deploy-github-functions.sh
@@ -21,6 +21,11 @@ set -e
 gh_deploy_create() {
   environment_name=$1
 
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   deploy_url=$(curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \
@@ -31,14 +36,16 @@ gh_deploy_create() {
     "environment": "'"$environment_name"'",
     "auto_merge": false,
     "required_contexts": []
-    }' | jq -r '.url?') # Gets 'url' field from the response
+    }' | jq -r '.url') # Gets 'url' field from the response
 
-  if [ -z "$deploy_url" ]; then
+  if [[ "$deploy_url" == "null" ]]; then
     echo "Failed to create Github deployment"
+    exit 1
   else
     # Need to be shared between steps
     echo "DEPLOY_STATUSES_URL=$deploy_url/statuses" >> $GITHUB_ENV
     echo "Github deployment created: $deploy_url"
+    exit 0
   fi
 }
 
@@ -58,6 +65,11 @@ gh_deploy_create() {
 gh_deploy_initiate() {
   environment_name=$1
   log_url=$2
+
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
 
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
@@ -91,6 +103,11 @@ gh_deploy_success() {
   log_url=$2
   environment_url=$3
 
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \
@@ -120,6 +137,12 @@ gh_deploy_success() {
 gh_deploy_failure() {
   environment_name=$1
   log_url=$2
+
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \
@@ -147,6 +170,12 @@ gh_deploy_failure() {
 #
 gh_deploy_deactivate() {
   deploy_id=$1
+
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set"
+    exit 1
+  fi
+
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.ant-man-preview+json" \


### PR DESCRIPTION
Brought from [PSD](https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/1428)


> "Dependabot PRs no longer have access to GitHub repo secrets, preventing the review application from deploying when Dependabot (or any other third party) opens a PR.
> A user with write access to the repo needs to update the branch to trigger a successful review app deploy.
> 
> This fixes some bugs in the actions script which allowed the action to continue executing after an error had occurred.
> Now the action will fail immediately."

