### PR TITLE
Allow to replace formulation files before completing notifications

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/additional_information_controller.rb
@@ -10,7 +10,7 @@ class ResponsiblePersons::AdditionalInformationController < SubmitApplicationCon
       return redirect_to new_responsible_person_notification_component_nanomaterial_build_path(responsible_person, @notification, component, nano_element)
     elsif @notification.formulation_required?
       component = @notification.components.order(:id).find(&:formulation_required?)
-      return redirect_to new_responsible_person_notification_component_formulation_path(responsible_person, @notification, component)
+      return redirect_to new_responsible_person_notification_component_formulation_file_path(responsible_person, @notification, component)
     else
       @notification.formulation_file_uploaded!
     end

--- a/cosmetics-web/app/controllers/responsible_persons/formulation_upload_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/formulation_upload_controller.rb
@@ -3,6 +3,8 @@ class ResponsiblePersons::FormulationUploadController < SubmitApplicationControl
 
   def new; end
 
+  def edit; end
+
   def create
     if params[:formulation_file].present?
       file_upload = params[:formulation_file]
@@ -19,6 +21,31 @@ class ResponsiblePersons::FormulationUploadController < SubmitApplicationControl
       add_error "No file selected"
       render :new
     end
+  end
+
+  def update
+    if params[:formulation_file].present?
+      file_upload = params[:formulation_file]
+      @component.formulation_file.attach(file_upload)
+
+      if @component.save
+        redirect_to edit_responsible_person_notification_path(@responsible_person, @notification)
+      else
+        @component.formulation_file.purge
+        @component.errors.messages[:formulation_file].map(&method(:add_error))
+        render :edit
+      end
+    elsif @component.formulation_file.attached?
+      redirect_to edit_responsible_person_notification_path(@responsible_person, @notification)
+    else
+      add_error "No file selected"
+      render :edit
+    end
+  end
+
+  def destroy
+    @component.formulation_file.purge
+    redirect_to action: :edit, host: ENV["SUBMIT_HOST"]
   end
 
 private

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/nanomaterial_build_controller.rb
@@ -72,7 +72,7 @@ class ResponsiblePersons::Wizard::NanomaterialBuildController < SubmitApplicatio
     elsif @component.notification.via_zip_file?
 
       if @component.formulation_required?
-        new_responsible_person_notification_component_formulation_path(@component.notification.responsible_person, @component.notification, @component)
+        new_responsible_person_notification_component_formulation_file_path(@component.notification.responsible_person, @component.notification, @component)
       else
         # This calls an :formulation_file_uploaded event on the Notification model,
         # which sets the `state` to `draft_complete`, which is required in order to be able

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -61,6 +61,23 @@
         value: { html: render("notifications/component_details_formulation_ingredients",
                  component: component,
                  allow_edits: allow_edits) },
+        actions: {
+          items: if component.formulation_file.attached? && allow_edits
+                   [
+                     {
+                       href: edit_responsible_person_notification_component_formulation_path(
+                               component.notification.responsible_person,
+                               component.notification,
+                               component
+                             ),
+                       text: "Change",
+                       visuallyHiddenText: "formulation file"
+                     }
+                   ]
+                 else
+                   []
+                 end
+        }
       }
     end,
     {

--- a/cosmetics-web/app/views/notifications/_component_details_formulation_ingredients.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details_formulation_ingredients.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 <% elsif allow_edits %>
   <%= link_to "Add formulation document",
-          new_responsible_person_notification_component_formulation_path(@notification.responsible_person,
+          new_responsible_person_notification_component_formulation__file_path(@notification.responsible_person,
                   @notification, component),
           class: "govuk-link--no-visited-state" %>
 <% else %>

--- a/cosmetics-web/app/views/notifications/_component_details_formulation_ingredients.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details_formulation_ingredients.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 <% elsif allow_edits %>
   <%= link_to "Add formulation document",
-          new_responsible_person_notification_component_formulation__file_path(@notification.responsible_person,
+          new_responsible_person_notification_component_formulation_file_path(@notification.responsible_person,
                   @notification, component),
           class: "govuk-link--no-visited-state" %>
 <% else %>

--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/_head.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/_head.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, "Upload formulation document" %>
+<% content_for :after_header do %>
+  <%= govukBackLink text: "Back", href: back_link %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @error_list.present? %>
+      <%= govukErrorSummary(titleText: "There is a problem", errorList: @error_list) %>
+    <% end %>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/_instructions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/_instructions.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <% name = @component.name if @component.notification.is_multicomponent? %>
+  <% if @component.exact? %>
+    <%= render 'responsible_persons/wizard/component_build/exact_concentration', name: name %>
+  <% elsif @component.range? %>
+    <%= render 'responsible_persons/wizard/component_build/ranges_concentration', name: name %>
+  <% else %>
+    <p>This can be either as ranges or the exact concentration.</p>
+    <p>For each ingredient give the International Nomenclature of Cosmetic Ingredients (INCI) name.</p>
+  <% end %>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/edit.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/edit.html.erb
@@ -32,7 +32,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if !@component.formulation_file.attached? %>
         <div class="govuk-form-group <%= "govuk-form-group--error" if @error_list.present? %>">
-          <%= form.label :formulation_file, "File type can be a ‘pdf’, ‘rtf’ or ‘txt’.", class: "govuk-label" %>
+          <%= form.label :formulation_file, "File type must be a PDF.", class: "govuk-label" %>
 
           <% if @error_list.present? %>
             <span class="govuk-error-message"><%= @error_list.first[:text] %></span>

--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/edit.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/edit.html.erb
@@ -1,0 +1,50 @@
+<%= render(partial: "head",
+           locals: { back_link: edit_responsible_person_notification_path(@responsible_person, @notification) }) %>
+
+
+<%= render "instructions" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @component.formulation_file.attached? %>
+      <% file = @component.formulation_file %>
+      <table class="govuk-table" id="formulation-files-table">
+        <caption class="govuk-table__caption govuk-heading-m">Upload a file</caption>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header govuk-!-width-two-thirds" scope="row">
+              <%= link_to(file.filename, url_for(file), class: "govuk-link govuk-link--no-visited-state") %>
+            </th>
+            <td class="govuk-table__cell">
+              <%= link_to("Remove",
+                          responsible_person_notification_component_formulation_file_path(@responsible_person, @notification, @component, file.id),
+                          method: :delete) %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</div>
+
+<%= form_with url: responsible_person_notification_component_formulation_path(@responsible_person, @notification, @component), method: :put do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if !@component.formulation_file.attached? %>
+        <div class="govuk-form-group <%= "govuk-form-group--error" if @error_list.present? %>">
+          <%= form.label :formulation_file, "File type can be a ‘pdf’, ‘rtf’ or ‘txt’.", class: "govuk-label" %>
+
+          <% if @error_list.present? %>
+            <span class="govuk-error-message"><%= @error_list.first[:text] %></span>
+          <% end %>
+
+          <%= form.file_field :formulation_file, class: "govuk-file-upload", accept: Component.allowed_types.map(&method(:get_filetype_extension)).join(",") %>
+        </div>
+      <% end %>
+
+      <div class="govuk-form-group">
+        <%= govukButton text: "Continue" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/edit.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/edit.html.erb
@@ -9,7 +9,7 @@
     <% if @component.formulation_file.attached? %>
       <% file = @component.formulation_file %>
       <table class="govuk-table" id="formulation-files-table">
-        <caption class="govuk-table__caption govuk-heading-m">Upload a file</caption>
+        <caption class="govuk-table__caption govuk-heading-s">Upload a file</caption>
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
             <th class="govuk-table__header govuk-!-width-two-thirds" scope="row">
@@ -32,7 +32,9 @@
     <div class="govuk-grid-column-two-thirds">
       <% if !@component.formulation_file.attached? %>
         <div class="govuk-form-group <%= "govuk-form-group--error" if @error_list.present? %>">
-          <%= form.label :formulation_file, "File type must be a PDF.", class: "govuk-label" %>
+          <p>File type must be a PDF.</p>
+
+          <%= form.label :formulation_file, "Upload a file", class: "govuk-label govuk-label--s" %>
 
           <% if @error_list.present? %>
             <span class="govuk-error-message"><%= @error_list.first[:text] %></span>

--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/new.html.erb
@@ -7,7 +7,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group <%= "govuk-form-group--error" if @error_list.present? %>">
-        <%= form.label :formulation_file, "File type must be a PDF.", class: "govuk-label" %>
+        <p>File type must be a PDF.</p>
+
+        <%= form.label :formulation_file, "Upload a file", class: "govuk-label govuk-label--s" %>
 
         <% if @error_list.present? %>
           <span class="govuk-error-message"><%= @error_list.first[:text] %></span>

--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/new.html.erb
@@ -1,30 +1,9 @@
-<% content_for :page_title, "Upload formulation document" %>
-<% content_for :after_header do %>
-  <%= govukBackLink text: "Back", href: responsible_person_notifications_path(@responsible_person, anchor: "incomplete") %>
-<% end %>
+<%= render(partial: "head",
+           locals: { back_link: responsible_person_notifications_path(@responsible_person, anchor: "incomplete") }) %>
 
-<%= form_with url: responsible_person_notification_component_formulation_index_path(@responsible_person, @notification, @component), method: :post do |form| %>
+<%= render "instructions" %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @error_list.present? %>
-        <%= govukErrorSummary(titleText: "There is a problem", errorList: @error_list) %>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <% name = @component.name if @component.notification.is_multicomponent? %>
-    <% if @component.exact? %>
-      <%= render 'responsible_persons/wizard/component_build/exact_concentration', name: name %>
-    <% elsif @component.range? %>
-      <%= render 'responsible_persons/wizard/component_build/ranges_concentration', name: name %>
-    <% else %>
-      <p>This can be either as ranges or the exact concentration.</p>
-      <p>For each ingredient give the International Nomenclature of Cosmetic Ingredients (INCI) name.</p>
-    <% end %>
-  </div>
-
+<%= form_with url: responsible_person_notification_component_formulation_file_index_path(@responsible_person, @notification, @component), method: :post do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group <%= "govuk-form-group--error" if @error_list.present? %>">

--- a/cosmetics-web/app/views/responsible_persons/formulation_upload/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/formulation_upload/new.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group <%= "govuk-form-group--error" if @error_list.present? %>">
-        <%= form.label :formulation_file, "File type can be a ‘pdf’, ‘rtf’ or ‘txt’.", class: "govuk-label" %>
+        <%= form.label :formulation_file, "File type must be a PDF.", class: "govuk-label" %>
 
         <% if @error_list.present? %>
           <span class="govuk-error-message"><%= @error_list.first[:text] %></span>

--- a/cosmetics-web/app/views/responsible_persons/wizard/component_build/upload_formulation.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/component_build/upload_formulation.html.erb
@@ -20,6 +20,8 @@
 </div>
 <%= form_with model: @component, url: wizard_path, method: :put do |form| %>
   <div class="govuk-form-group <%= error_group_class(@component)%>">
+      <p>File type must be a PDF.</p>
+
       <%= form.label :formulation_file, "Upload a file", class: "govuk-label govuk-label--s" %>
 
       <% if @component.errors.any? %>

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -144,7 +144,8 @@ Rails.application.routes.draw do
         resources :components do
           resources :build, controller: "responsible_persons/wizard/component_build", only: %i[show update new]
           resources :trigger_question, controller: "responsible_persons/wizard/trigger_questions", only: %i[show update new]
-          resources :formulation, controller: "responsible_persons/formulation_upload", only: %w[new create]
+          resources :formulation_file, controller: "responsible_persons/formulation_upload", only: %i[new create destroy]
+          resource :formulation, controller: "responsible_persons/formulation_upload", only: %i[edit update]
           resources :nanomaterials, param: :nano_element_id do
             resources :build, controller: "responsible_persons/wizard/nanomaterial_build", only: %i[show update new]
           end

--- a/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ResponsiblePersons::AdditionalInformationController, :with_stubbe
       notification = Notification.create(responsible_person_id: responsible_person.id, components: [ranges_component])
       notification.image_uploads.create
       get :index, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }
-      expect(response).to redirect_to(new_responsible_person_notification_component_formulation_path(responsible_person, notification, ranges_component))
+      expect(response).to redirect_to(new_responsible_person_notification_component_formulation_file_path(responsible_person, notification, ranges_component))
     end
 
     context "when the notification is already submitted" do

--- a/cosmetics-web/spec/factories/component.rb
+++ b/cosmetics-web/spec/factories/component.rb
@@ -48,5 +48,9 @@ FactoryBot.define do
         create(:exact_formula, component: component)
       end
     end
+
+    trait :with_formulation_file do
+      formulation_file { Rack::Test::UploadedFile.new("spec/fixtures/files/testPdf.pdf", "application/pdf") }
+    end
   end
 end

--- a/cosmetics-web/spec/requests/nanomaterial_within_product_requests_spec.rb
+++ b/cosmetics-web/spec/requests/nanomaterial_within_product_requests_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Nanomaterial usage within product notifications", type: :request
       end
 
       it "redirects to the Upload formulation page" do
-        expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/components/#{component.id}/formulation/new")
+        expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/components/#{component.id}/formulation_file/new")
       end
     end
 

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -455,7 +455,7 @@ def expect_back_link_to_upload_item_label_page
 end
 
 def expect_to_be_on__upload_formulation_document_page(header_text)
-  expect(page.current_path).to end_with("/formulation/new")
+  expect(page.current_path).to end_with("/formulation_file/new")
   expect(page).to have_h1(header_text)
 end
 


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1183)
Allow changing the component formulation file before completing the notification.

The notification draft prior to confirmation will have a link in each component formulation file that will point to a page where the current file can be removed and a new file uploaded.

