### PR TITLE
Add nanomaterial notifications pages

### DIFF
--- a/cosmetics-web/app/controllers/concerns/active_storage_access_protection_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/active_storage_access_protection_concern.rb
@@ -7,11 +7,17 @@ module ActiveStorageAccessProtectionConcern
     current_submit_user
   end
 
+  # Checks that:
+  # - The current user is a signed in user.
+  # - If Submit user, has view permissions for the Responsible Person associated to the file.
+  # Notice:
+  # Record class must implement (or have a delegation to) "#responsible_person"
+  # to be able to use this concern.
   def authorize_blob
     if submit_domain?
       raise Pundit::NotAuthorizedError unless submit_user_signed_in?
 
-      rp = @blob.attachments.first.record.notification.responsible_person
+      rp = @blob.attachments.first.record.responsible_person
       authorize rp, :show?
     else
       raise Pundit::NotAuthorizedError unless search_user_signed_in?

--- a/cosmetics-web/app/controllers/nanomaterial_notifications_controller.rb
+++ b/cosmetics-web/app/controllers/nanomaterial_notifications_controller.rb
@@ -4,7 +4,7 @@ class NanomaterialNotificationsController < SubmitApplicationController
   before_action :set_responsible_person, only: %w[index new create]
   before_action :validate_responsible_person
 
-  before_action :set_nanomaterial_notification_from_url, only: %i[notified_to_eu update_notified_to_eu upload_file update_file review name update_name submit confirmation_page]
+  before_action :set_nanomaterial_notification_from_url, only: %i[show notified_to_eu update_notified_to_eu upload_file update_file review name update_name submit confirmation_page]
 
   before_action :redirect_to_confirmation_page_if_submitted, only: %i[notified_to_eu update_notified_to_eu upload_file update_file review name update_name submit]
 
@@ -15,6 +15,8 @@ class NanomaterialNotificationsController < SubmitApplicationController
                                     .order(submitted_at: :desc)
                                     .paginate(page: params[:page], per_page: PER_PAGE)
   end
+
+  def show; end
 
   def new
     @nanomaterial_notification = @responsible_person.nanomaterial_notifications.new

--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -18,6 +18,8 @@ class Component < ApplicationRecord
   has_one :nano_material, dependent: :destroy
   has_one_attached :formulation_file
 
+  delegate :responsible_person, to: :notification
+
   enum ph: {
     not_applicable: "not_applicable",
     lower_than_3: "lower_than_3",

--- a/cosmetics-web/app/models/image_upload.rb
+++ b/cosmetics-web/app/models/image_upload.rb
@@ -8,6 +8,8 @@ class ImageUpload < ApplicationRecord
 
   has_one_attached :file
 
+  delegate :responsible_person, to: :notification
+
   def file_exists?
     file.attachment.present?
   end

--- a/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
@@ -29,7 +29,7 @@
       <% @nanomaterial_notifications.each do |notification| %>
         <li>
           <h2 class="govuk-heading-s">
-            <%= notification.name %>
+            <%= link_to(notification.name, nanomaterial_path(notification), class: "govuk-link govuk-link--no-visited-state") %>
           </h2>
           <dl class="govuk-summary-list govuk-summary-list--no-border opss-summary-list opss-summary-list--small">
             <div class="govuk-summary-list__row">

--- a/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
@@ -1,0 +1,54 @@
+<% content_for :page_title, "Nanomaterials" %>
+<% content_for :after_header do %>
+  <%= render "layouts/navbar" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= @nanomaterial_notification.name %>
+    </h1>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <abbr>UK</abbr> nanomaterial number
+        </dt>
+        <dd class="govuk-summary-list__value">
+          UKN-<%= @nanomaterial_notification.id %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Notified in the <abbr>UK</abbr>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= display_full_month_date @nanomaterial_notification.submitted_at %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Notified in the <abbr>EU</abbr>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= if @nanomaterial_notification.eu_notified
+                display_full_month_date @nanomaterial_notification.notified_to_eu_on
+              else
+                "No"
+              end %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <abbr>PDF</abbr> file
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= link_to(url_for(@nanomaterial_notification.file), class: "govuk-link govuk-link--no-visited-state") do %>
+            <span class="opss-download-link-m"></span>
+            <%= @nanomaterial_notification.file.filename %>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Nanomaterials" %>
+<% content_for :page_title, @nanomaterial_notification.name %>
 <% content_for :after_header do %>
   <%= render "layouts/navbar" %>
   <%= govukBackLink text: "Back", href: responsible_person_nanomaterials_path(@responsible_person) %>

--- a/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
@@ -44,7 +44,7 @@
           <abbr>PDF</abbr> file
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= link_to(url_for(@nanomaterial_notification.file), class: "govuk-link govuk-link--no-visited-state") do %>
+          <%= link_to(url_for(@nanomaterial_notification.file), download: true, class: "govuk-link govuk-link--no-visited-state") do %>
             <span class="opss-download-link-m"></span>
             <%= @nanomaterial_notification.file.filename %>
           <% end %>

--- a/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
@@ -1,7 +1,10 @@
 <% content_for :page_title, @nanomaterial_notification.name %>
 <% content_for :after_header do %>
   <%= render "layouts/navbar" %>
-  <%= govukBackLink text: "Back", href: responsible_person_nanomaterials_path(@responsible_person) %>
+  <%= govukBackLink(
+        text: "Back",
+        href: request.referer.presence || responsible_person_nanomaterials_path(@responsible_person)
+      ) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, "Nanomaterials" %>
 <% content_for :after_header do %>
   <%= render "layouts/navbar" %>
+  <%= govukBackLink text: "Back", href: responsible_person_nanomaterials_path(@responsible_person) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/select_type.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/select_type.html.erb
@@ -8,7 +8,7 @@
                             select_responsible_persons_path
                           end
   %>
-  <%= link_to "Back", request.referer.present? ? request.referer : default_back_path, class: "govuk-back-link" %>
+  <%= link_to "Back", request.referer.presence || default_back_path, class: "govuk-back-link" %>
 <% end %>
 
 <%= form_with model: @responsible_person, url: wizard_path, method: :put do |form| %>

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
         get "change", to: "responsible_persons#change"
       end
 
-      resources :nanomaterials, controller: :nanomaterial_notifications, only: %i[index new create], shallow: true do
+      resources :nanomaterials, controller: :nanomaterial_notifications, only: %i[index show new create], shallow: true do
         member do
           get :name
           patch :name, action: "update_name"

--- a/cosmetics-web/spec/factories/nanomaterial_notification.rb
+++ b/cosmetics-web/spec/factories/nanomaterial_notification.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     end
 
     trait :submitted do
+      submittable
       submitted_at { 1.hour.ago }
     end
   end

--- a/cosmetics-web/spec/features/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/features/nanomaterial_notifications_spec.rb
@@ -30,10 +30,19 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     expect(page).to have_text("You’ve told us about My nanomaterial")
     click_link "Return to Nanomaterials"
 
-    expect(page).to have_css("h2", text: "My nanomaterial")
+    id = NanomaterialNotification.last.id
+    expect(page).to have_link("My nanomaterial")
     expect(page).to have_summary_item(key: "Notified in the UK", value: "10 June 2021")
     expect(page).to have_summary_item(key: "Notified in the EU", value: "No")
-    expect(page).to have_summary_item(key: "UK nanomaterial number", value: "UKN-#{NanomaterialNotification.last.id}")
+    expect(page).to have_summary_item(key: "UK nanomaterial number", value: "UKN-#{id}")
+
+    click_link("My nanomaterial")
+    expect(page).to have_current_path("/nanomaterials/#{id}")
+    expect(page).to have_h1("My nanomaterial")
+    expect(page).to have_summary_item(key: "Notified in the UK", value: "10 June 2021")
+    expect(page).to have_summary_item(key: "Notified in the EU", value: "No")
+    expect(page).to have_summary_item(key: "UK nanomaterial number", value: "UKN-#{id}")
+    expect(page).to have_summary_item(key: "PDF file", value: "testPdf.pdf")
   end
 
   scenario "submitting a nanomaterial which was previously notified to the EU", :with_stubbed_antivirus do
@@ -59,9 +68,18 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     expect(page).to have_text("You’ve told us about My EU nanomaterial")
     click_link "Return to Nanomaterials"
 
-    expect(page).to have_css("h2", text: "My EU nanomaterial")
+    id = NanomaterialNotification.last.id
+    expect(page).to have_link("My EU nanomaterial")
     expect(page).to have_summary_item(key: "Notified in the UK", value: "10 June 2021")
     expect(page).to have_summary_item(key: "Notified in the EU", value: "1 February 2017")
-    expect(page).to have_summary_item(key: "UK nanomaterial number", value: "UKN-#{NanomaterialNotification.last.id}")
+    expect(page).to have_summary_item(key: "UK nanomaterial number", value: "UKN-#{id}")
+
+    click_link("My EU nanomaterial")
+    expect(page).to have_current_path("/nanomaterials/#{id}")
+    expect(page).to have_h1("My EU nanomaterial")
+    expect(page).to have_summary_item(key: "Notified in the UK", value: "10 June 2021")
+    expect(page).to have_summary_item(key: "Notified in the EU", value: "1 February 2017")
+    expect(page).to have_summary_item(key: "UK nanomaterial number", value: "UKN-#{id}")
+    expect(page).to have_summary_item(key: "PDF file", value: "testPdf.pdf")
   end
 end

--- a/cosmetics-web/spec/requests/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/requests/nanomaterial_notifications_spec.rb
@@ -55,6 +55,42 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
     end
   end
 
+  describe "GET /nanomaterials/ID" do
+    context "when user is associated with the responsible person" do
+      let(:nanomaterial_notification) do
+        create(:nanomaterial_notification, :submitted, responsible_person: responsible_person)
+      end
+
+      before do
+        get "/nanomaterials/#{nanomaterial_notification.id}"
+      end
+
+      it "is successful" do
+        expect(response.code).to eql("200")
+      end
+
+      it "has the nanomaterial page heading" do
+        expect(response.body).to have_tag("h1", text: /#{nanomaterial_notification.name}/)
+      end
+
+      it "has the nanomaterial page title" do
+        expect(response.body).to have_title(nanomaterial_notification.name)
+      end
+    end
+
+    context "when user attempts to look at a another company’s nanomaterials" do
+      let(:nanomaterial_notification) do
+        create(:nanomaterial_notification, :submitted, responsible_person: other_company)
+      end
+
+      it "raises an a 'Not authorized' error" do
+        expect {
+          get "/nanomaterials/#{nanomaterial_notification.id}"
+        }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+
   describe "GET /responsible_persons/ID/nanomaterials/new" do
     before do
       get "/responsible_persons/#{responsible_person.id}/nanomaterials/new"


### PR DESCRIPTION
For the given nanomaterial notification the page will display:
- Name
- Nanomaterial number
- Date when was notified in the UK
- Date when was notified in the EU (if notified in the EU)
- Link to download PDF file.

## Screenshot
<img src="https://user-images.githubusercontent.com/1227578/125303054-6bb0aa80-e324-11eb-918c-13efc4d3a326.png" width=50% height=50%>