### PR TITLE
Redesign RP enter details page

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -44,7 +44,7 @@ gem "strong_migrations", "~> 0.5.1"
 gem "webpacker", "~> 5.0"
 gem "wicked", "~> 1.3.4"
 
-gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.7.4", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.7.5", require: "govuk_design_system"
 
 group :development, :test do
   gem "brakeman", "~> 4.7.2"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/UKGovernmentBEIS/govuk-design-system-rails
-  revision: e09ab62f769d3e4a581b21bcfef12a31d7207b0e
-  tag: 0.7.4
+  revision: a7a8817be9429dee926a4fe82663713344fc3903
+  tag: 0.7.5
   specs:
-    govuk-design-system-rails (0.7.2)
+    govuk-design-system-rails (0.7.5)
 
 GEM
   remote: https://rubygems.org/

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
@@ -71,7 +71,7 @@
                    form: form,
                    key: :address_line_1,
                    classes: "govuk-!-width-three-quarters",
-                   attributes: { "aria-describedby" => "address-hint"},
+                   described_by: "address-hint",
                    label: { html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>".html_safe }) %>
 
         <%= render("form_components/govuk_input", form: form, key: :address_line_2, classes: "govuk-!-width-three-quarters", label: { text: nil }) %>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
@@ -49,7 +49,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for(@responsible_persons_details_form, url: wizard_path, method: :put) do |form| %>
+    <%= form_for(@responsible_persons_details_form, url: wizard_path, method: :put, html: { novalidate: true }) do |form| %>
       <%= render("form_components/govuk_input",
                  form: form,
                  key: :name,

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
@@ -53,6 +53,7 @@
       <%= render("form_components/govuk_input",
                  form: form,
                  key: :name,
+                 id: "name",
                  classes: "govuk-input govuk-!-width-two-thirds",
                  label: { text: "Name", classes: "govuk-label--s" },
                  hint: { text: "The name of the business, individual or sole trader named as the legal entity of Responsible Person.",
@@ -70,14 +71,21 @@
         <%= render("form_components/govuk_input",
                    form: form,
                    key: :address_line_1,
+                   id: "address_line_1",
                    classes: "govuk-!-width-three-quarters",
                    described_by: "address-hint",
                    label: { html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>".html_safe }) %>
 
-        <%= render("form_components/govuk_input", form: form, key: :address_line_2, classes: "govuk-!-width-three-quarters", label: { text: nil }) %>
-        <%= render "form_components/govuk_input", form: form, key: :city, classes: "govuk-input govuk-!-width-two-thirds", label: { text: "Town or city" } %>
-        <%= render "form_components/govuk_input", form: form, key: :county, classes: "govuk-input govuk-!-width-two-thirds", label: { text: "County" } %>
-        <%= render "form_components/govuk_input", form: form, key: :postal_code, label: { text: "Postcode" }, classes: "govuk-input--width-10" %>
+        <%= render("form_components/govuk_input",
+                   form: form,
+                   key: :address_line_2,
+                   id: "address_line_2",
+                   classes: "govuk-!-width-three-quarters",
+                   label: { html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>".html_safe }) %>
+
+        <%= render "form_components/govuk_input", form: form, key: :city, id: "city", classes: "govuk-input govuk-!-width-two-thirds", label: { text: "Town or city" } %>
+        <%= render "form_components/govuk_input", form: form, key: :county, id: "county", classes: "govuk-input govuk-!-width-two-thirds", label: { text: "County" } %>
+        <%= render "form_components/govuk_input", form: form, key: :postal_code, id: "postal_code", label: { text: "Postcode" }, classes: "govuk-input--width-10" %>
 
         <div class="govuk-form-group">
           <%= govukButton text: "Continue" %>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
@@ -1,35 +1,88 @@
-<% title = "UK Responsible Person details" %>
-<% page_title(title, errors: @responsible_persons_details_form.errors.any?) %>
+<% page_title("UK Responsible Person details", errors: @responsible_persons_details_form.errors.any?) %>
 
 <% content_for :after_header do %>
   <%= link_to "Back", previous_wizard_path, class: "govuk-back-link" %>
 <% end %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= error_summary(@responsible_persons_details_form.errors, %i[name address_line_1 address_line_2 city county postal_code]) %>
 
-<% address_label = @responsible_person.business? ? "UK business address" : "Address" %>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+      <abbr>UK</abbr> Responsible Person details
+    </h1>
+
+    <details class="govuk-details opss-details--sm govuk-!-margin-top-4" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Help with the <abbr>UK</abbr> Responsible Person details
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <p class="govuk-body-s">
+          A Responsible Person can be a business - in the law this is called a 'legal person'.
+          Or a Responsible Person can be a living person - in the law this is called a 'natural person'.
+        </p>
+
+        <p class="govuk-body-s">
+          The Responsible Person - the legal person or natural person - is a legal entity that must be established in the <abbr>UK</abbr>.
+          The address provided must be that of the legal entity named as the Responsible Person.
+          The Responsible Person must provide a <abbr>UK</abbr> address, which cannot be a <abbr title="Post Office">PO</abbr> box or mail forwarding address.
+        </p>
+
+        <p class="govuk-body-s">
+          A Responsible Person is legally bound by the obligations in the Cosmetics Regulation.
+        </p>
+      </div>
+    </details>
+
+    <div class="govuk-warning-text govuk-!-margin-top-7 govuk-!-margin-bottom-6">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        The <abbr>UK</abbr> address provided must not be a <abbr>PO</abbr> box or mail forwarding address. These are not <abbr>UK</abbr> established addresses that comply with the regulation.
+      </strong>
+    </div>
+  </div>
+</div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= error_summary(@responsible_persons_details_form.errors, %i[name address_line_1 address_line_2 city county postal_code]) %>
-
-    <h1 class="govuk-heading-l"><%= title %></h1>
-
     <%= form_for(@responsible_persons_details_form, url: wizard_path, method: :put) do |form| %>
-      <%= render "form_components/govuk_input", form: form, key: :name, label: { text: "Business name" } %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <%= address_label %>
+      <%= render("form_components/govuk_input",
+                 form: form,
+                 key: :name,
+                 classes: "govuk-input govuk-!-width-two-thirds",
+                 label: { text: "Name", classes: "govuk-label--s" },
+                 hint: { text: "The name of the business, individual or sole trader named as the legal entity of Responsible Person.",
+                         classes: "govuk-!-font-size-16 govuk-!-width-three-quarters" }) %>
+      <fieldset class="govuk-fieldset ">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <h2 class="govuk-fieldset__heading">
+            Address
+          </h2>
         </legend>
-      </fieldset>
-      <%= render "form_components/govuk_input", form: form, key: :address_line_1, label: { text: "Building and street" } %>
-      <%= render "form_components/govuk_input", form: form, key: :address_line_2, label: { text: nil } %>
-      <%= render "form_components/govuk_input", form: form, key: :city, label: { text: "Town or city" } %>
-      <%= render "form_components/govuk_input", form: form, key: :county, label: { text: "County" } %>
-      <%= render "form_components/govuk_input", form: form, key: :postal_code, label: { text: "Postcode" }, classes: "govuk-input--width-10" %>
+        <div id="address-hint" class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-6 govuk-!-width-three-quarters">
+          The address of the legal entity named as the Responsible Person.
+        </div>
 
-      <div class="govuk-form-group">
-        <%= govukButton text: "Continue" %>
-      </div>
+        <%= render("form_components/govuk_input",
+                   form: form,
+                   key: :address_line_1,
+                   classes: "govuk-!-width-three-quarters",
+                   attributes: { "aria-describedby" => "address-hint"},
+                   label: { html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>".html_safe }) %>
+
+        <%= render("form_components/govuk_input", form: form, key: :address_line_2, classes: "govuk-!-width-three-quarters", label: { text: nil }) %>
+        <%= render "form_components/govuk_input", form: form, key: :city, classes: "govuk-input govuk-!-width-two-thirds", label: { text: "Town or city" } %>
+        <%= render "form_components/govuk_input", form: form, key: :county, classes: "govuk-input govuk-!-width-two-thirds", label: { text: "County" } %>
+        <%= render "form_components/govuk_input", form: form, key: :postal_code, label: { text: "Postcode" }, classes: "govuk-input--width-10" %>
+
+        <div class="govuk-form-group">
+          <%= govukButton text: "Continue" %>
+        </div>
+      </fieldset>
     <% end %>
   </div>
 </div>

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -200,6 +200,13 @@ en:
             name:
               member_of_rp_with_same_name: "You are already associated with %{value}"
               invited_to_rp_with_same_name: "You have already been invited to join %{value}. Check your email inbox for your invite"
+              blank: "Enter a name"
+            address_line_1:
+              blank: "Enter a building and street"
+            city:
+              blank: "Enter a town or city"
+            postal_code:
+              blank: "Enter a postcode"
         responsible_persons/invite_member_form:
           attributes:
             email:

--- a/cosmetics-web/spec/forms/responsible_persons/details_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/details_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do
       end
 
       it "populates an error message" do
-        expect(form.errors.full_messages_for(:name)).to eq(["Name can not be blank"])
+        expect(form.errors.full_messages_for(:name)).to eq(["Enter a name"])
       end
     end
 
@@ -138,7 +138,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do
       end
 
       it "populates an error message" do
-        expect(form.errors.full_messages).to eq(["Building and street can not be blank"])
+        expect(form.errors.full_messages).to eq(["Enter a building and street"])
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do
       end
 
       it "populates an error message" do
-        expect(form.errors.full_messages).to eq(["Town or city can not be blank"])
+        expect(form.errors.full_messages).to eq(["Enter a town or city"])
       end
     end
 
@@ -194,7 +194,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do
       end
 
       it "populates an error message" do
-        expect(form.errors.full_messages).to eq(["Postcode can not be blank"])
+        expect(form.errors.full_messages).to eq(["Enter a postcode"])
       end
     end
 

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -826,12 +826,12 @@ def fill_in_rp_details
 end
 
 def fill_in_rp_business_details(name: "Auto-test rpuser")
-  fill_in "Business name", with: name
+  fill_in "Name", with: name
   fill_in_rp_details
 end
 
 def fill_in_rp_sole_trader_details(name: "Auto-test rpuser")
-  fill_in "Business name", with: name
+  fill_in "Name", with: name
   fill_in_rp_details
 end
 

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -818,7 +818,7 @@ def select_options_to_create_rp_account
 end
 
 def fill_in_rp_details
-  fill_in "Building and street", with: "Auto-test-address1"
+  fill_in "Building and street", with: "Auto-test-address1", id: "address_line_1"
   fill_in "Town or city", with: "Auto-test city"
   fill_in "County", with: "auto-test-county"
   fill_in "Postcode", with: "b28 9un"


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1227)

Redesign and unify the Responsible Person "enter details" page.
This page now includes a dropdown with information, an alert message and
adds text hints to name and address fields.


![image](https://user-images.githubusercontent.com/1227578/129033537-eb752c80-1afc-4c84-be0b-0e3fe24de4d2.png)
