### PR TITLE
Fix Nanomaterial Notification attachments on seeds

### DIFF
--- a/cosmetics-web/db/seeds.rb
+++ b/cosmetics-web/db/seeds.rb
@@ -111,7 +111,7 @@ ActiveRecord::Base.transaction do
       eu_notified: true,
       notified_to_eu_on: ((Time.zone.now.to_date - i.days) - 3.years),
       submitted_at: (Time.zone.now.to_date - i.days),
-    )
+    ).file.attach(io: File.open("spec/fixtures/files/testPdf.pdf"), filename: "testPdf.pdf", content_type: "application/pdf")
   end
 end
 


### PR DESCRIPTION
[Related error](https://sentry.io/share/issue/4de2c1ac646748ec862be29d4a6b8857/)

Seeded nanomaterial notifications were throwing an exception when attempting to access their individual pages from the nano notifications index page.
This was raised from the PDF file download link generation.

The cause is the lack of actual attachments on the Nanomaterial Notifications seeds. As there is no attachment, the route generation pointing to the attached file blows up.

Resolved by attaching a PDF fixture for each of the seeded Nanomaterial Notifications.