### PR TITLE
Make product page titles reflect the product they are showing

### DIFF
--- a/cosmetics-web/app/views/poison_centres/notifications/show_msa.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_msa.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Product details" %>
+<% content_for :page_title, "Product details: #{@notification.product_name}" %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: poison_centre_notifications_path(search_params) %>
 <% end %>
@@ -12,5 +12,3 @@
     <%= render "notifications/product_details", notification: @notification, allow_edits: false %>
   </div>
 </div>
-
-

--- a/cosmetics-web/app/views/poison_centres/notifications/show_msa.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_msa.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Product details: #{@notification.product_name}" %>
+<% content_for :page_title, safe_join(["Product details: ", @notification.product_name]) %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: poison_centre_notifications_path(search_params) %>
 <% end %>

--- a/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Product details: #{@notification.product_name}" %>
+<% content_for :page_title, safe_join(["Product details: ", @notification.product_name]) %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: poison_centre_notifications_path(notification_search_form: search_params) %>
 <% end %>

--- a/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Product details" %>
+<% content_for :page_title, "Product details: #{@notification.product_name}" %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: poison_centre_notifications_path(notification_search_form: search_params) %>
 <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Product details" %>
+<% content_for :page_title, "Product details: #{@notification.product_name}" %>
 <% content_for :after_header do %>
   <%= link_to "Back", responsible_person_notifications_path(@responsible_person, page: params[:page]), class: "govuk-back-link" %>
 <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Product details: #{@notification.product_name}" %>
+<% content_for :page_title, safe_join(["Product details: ", @notification.product_name]) %>
 <% content_for :after_header do %>
   <%= link_to "Back", responsible_person_notifications_path(@responsible_person, page: params[:page]), class: "govuk-back-link" %>
 <% end %>


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-988

## Description
When searching product notifications and selecting one, every page title was the same regardless of the product selected. This PR includes the product name in the page title, so that the title reflects the content of the page. This is particuarly helpful for users who use a screenreader.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
