### PR TITLE
Reindex Elastic Search for each Review App deploy

### DIFF
--- a/cosmetics-web/lib/tasks/elasticsearch.rake
+++ b/cosmetics-web/lib/tasks/elasticsearch.rake
@@ -1,0 +1,6 @@
+namespace :elastic_search do
+  desc "Reindex Elastic Search"
+  task reindex: :environment do
+    ReindexElasticsearchJob.perform_later
+  end
+end

--- a/cosmetics-web/lib/tasks/elasticsearch.rake
+++ b/cosmetics-web/lib/tasks/elasticsearch.rake
@@ -1,6 +1,6 @@
 namespace :elastic_search do
   desc "Reindex Elastic Search"
   task reindex: :environment do
-    ReindexElasticsearchJob.perform_later
+    ReindexElasticsearchJob.perform_now
   end
 end

--- a/cosmetics-web/manifest.review.yml
+++ b/cosmetics-web/manifest.review.yml
@@ -33,7 +33,7 @@ applications:
     - type: web
       env:
         RAILS_MAX_THREADS: ((web-max-threads))
-      command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate db:seed && bundle exec puma
+      command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate db:seed elastic_search:reindex && bundle exec puma
       instances: 1
       memory: 1G
       disk-quota: 2G


### PR DESCRIPTION
Search Cosmetics on Review Apps is failing to load the notifications page (500 error) due to a missing Elastic Search index.
This forces developers to connect to the review app console and manually reindex ES.

We're automating this to happen on deploy by adding a task triggering the reindex job and calling that task on the review app deploys manifest.

### Before 
![image](https://user-images.githubusercontent.com/1227578/132685928-029653a4-2172-4257-b93c-e409044bd580.png)
### After
![image](https://user-images.githubusercontent.com/1227578/132686028-826b74d0-c489-484c-9de2-716677292f55.png)

