### PR TITLE
Fix add component page back-link raising exceptions

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_build_controller.rb
@@ -64,8 +64,7 @@ class ResponsiblePersons::Wizard::NotificationBuildController < SubmitApplicatio
                     :will_products_be_notified_in_eu
                   end
       responsible_person_add_notification_path(@notification.responsible_person, last_step)
-    elsif step == :add_new_component && @notification.state == "draft_complete"
-      last_component = @notification.components.complete.last
+    elsif step == :add_new_component && @notification.state == "draft_complete" && (last_component = @notification.components.complete.last)
       last_step = last_component.ph_range_not_required? ? :select_ph_range : :ph
       responsible_person_notification_component_trigger_question_path(@notification.responsible_person, @notification, last_component, last_step)
     elsif previous_step.present?


### PR DESCRIPTION
When reaching the page for a draft complete notification but not having
available completed components, the backlink generation was causing
an exception.

There is no point in trying to load the last component trigger
question page when there is no "last component".

Sentry related exceptions [1](https://sentry.io/organizations/beis/issues/2602567600/?project=1398436) and [2](https://sentry.io/organizations/beis/issues/2602567571/?project=1398436)