### PR TITLE
Avoid spam on registration confirmation emails

### DIFF
--- a/cosmetics-web/app/forms/registration/new_account_form.rb
+++ b/cosmetics-web/app/forms/registration/new_account_form.rb
@@ -3,6 +3,8 @@ module Registration
     attribute :full_name
 
     validates_presence_of :full_name
+    validate :full_name_not_spam
+
     include EmailFormValidation
 
     def save
@@ -34,6 +36,17 @@ module Registration
         ).deliver_later
       else
         user.resend_confirmation_instructions
+      end
+    end
+
+    def full_name_not_spam
+      return if full_name.blank?
+
+      %w[: @ /].each do |invalid|
+        if full_name.include? invalid
+          errors.add(:full_name, :invalid)
+          break
+        end
       end
     end
   end

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -182,6 +182,7 @@ en:
           attributes:
             full_name:
               blank: "Enter your full name"
+              invalid: "Enter a valid full name"
         registration/account_security_form:
           attributes:
             app_authentication_code:

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -441,6 +441,21 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     expect(page).to have_css("h1", text: "Submit cosmetic product notifications")
   end
 
+  scenario "spam user attempts to sign up" do
+    visit "/"
+    click_on "Create an account"
+    expect(page).to have_current_path("/create-an-account")
+
+    fill_in "Full name", with: "Hello join http://spam.com"
+    fill_in "Email address", with: "signing_up@example.com"
+    click_button "Continue"
+
+    expect(page).to have_current_path("/create-an-account")
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Enter a valid full name", href: "#full_name")
+    expect(page).to have_css("span#full_name-error", text: "Enter a valid full name")
+  end
+
   def expect_to_be_on_check_your_email_page
     expect(page).to have_css("h1", text: "Check your email")
     expect(page).to have_css(".govuk-body", text: "A message with a confirmation link has been sent to your email address.")


### PR DESCRIPTION
Spammers are using the confirmation emails to send spam to users email addresses. As GOVUK is a trusted address they use the user name to inject spam messages and URLs.

We're blocking certain characters from being used on user names during registration.
