### PR TITLE
Change button text on creating RP Contact Person

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/contact_persons/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/contact_persons/new.html.erb
@@ -23,7 +23,7 @@
             label: { text: "Phone number" }, classes: "govuk-input--width-20" %>
 
       <div class="govuk-form-group">
-        <%= govukButton text: "Continue" %>
+        <%= govukButton text: "Save and continue" %>
       </div>
     </div>
   </div>

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -765,13 +765,13 @@ def fill_in_rp_contact_details
   fill_in "Full name", with: "Auto-test contact person"
   fill_in "Email address", with: "auto-test@foo"
   fill_in "Phone number", with: "wowowow"
-  click_on "Continue"
+  click_on "Save and continue"
   expect(page).to have_text("Enter the email address in the correct format")
   expect(page).to have_text("Enter a valid phone number, like 0344 411 1444 or +44 7700 900 982")
   fill_in "Full name", with: "Auto-test contact person"
   fill_in "Email address", with: "auto-test@exaple.com"
   fill_in "Phone number", with: "07984563072"
-  click_on "Continue"
+  click_on "Save and continue"
 end
 
 def select_rp_business_account_type


### PR DESCRIPTION
## Description
Shows `Save and continue` instead of `Continue` in the Contact Person details page when adding a new Responsible Person.
![image](https://user-images.githubusercontent.com/1227578/140743110-950d1c44-6415-4fc7-9a2e-b033d99edefb.png)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2297-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2297-search-web.london.cloudapps.digital/
