### PR TITLE
Update "cannot notify nanomaterial" pages

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/_cannot_notify.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/_cannot_notify.html.erb
@@ -11,23 +11,31 @@
 
     <%= yield %>
 
-    <h2 class="govuk-heading-m">New ingredients used as colourants, UV-filters, or preservatives</h2>
-    <p>
-      For all new ingredients which are used as colourants, UV-filters, or preservatives, so not listed in Annex 4, 5 or 6, a safety dossier must be submitted to OPSS for safety assessment.
+    <h2 class="govuk-heading-m">New ingredients used as colourants, <abbr title='Ultraviolet'>UV</abbr>-filters, or preservatives</h2>
+
+    <p class="govuk-body">
+      For all new ingredients which are used as colourants, <abbr title='Ultraviolet'>UV</abbr>-filters, or preservatives,
+      so not listed in Annex 4, 5 or 6, a safety dossier must be submitted to <abbr title='Office for Product Safety and Standards'>OPSS</abbr> for safety assessment.
       This also applies to nanomaterials.
     </p>
-    <p>
+
+    <p class="govuk-body">
       There is technical guidance on what needs to be submitted in a safety dossier for nanomaterials and what needs to be submitted in a safety dossier for all other ingredients.
-      There is also a checklist detailing the information required for a safety dossier. Further information can be found
-      <%= link_to "here",
+      There is also a checklist detailing the information required for a safety dossier.
+      Further information about making cosmetic products safe for users can be found on the
+      <%= link_to "guidance page",
                   "https://www.gov.uk/guidance/making-cosmetic-products-available-to-consumers-in-great-britain#making-cosmetic-products-safe-for-users",
-                  class: "govuk-link--no-visited-state",
+                  class: "govuk-link govuk-link--no-visited-state",
                   target: "_blank" %>.
     </p>
-    <p>
-      Safety dossiers must be submitted to the OPSS Safety Assessment inbox: <%= mail_to  "opss.safetyassessment@beis.gov.uk" %>.
+
+    <p class="govuk-body">
+      Safety dossiers must be submitted to the <abbr title='Office for Product Safety and Standards'>OPSS</abbr> Safety Assessment inbox:
+      <%= mail_to "opss.safetyassessment@beis.gov.uk", nil, class: "govuk-link govuk-link--no-visited-state" %>.
     </p>
 
-    <p>Go to <%= link_to "your cosmetic products", responsible_person_notifications_path(current_responsible_person), class: "govuk-link--no-visited-state" %>.</p>
+    <p class="govuk-body">
+      Go to <%= link_to "your cosmetic products", responsible_person_notifications_path(current_responsible_person), class: "govuk-link govuk-link--no-visited-state" %>.
+    </p>
   </div>
 </div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/_cannot_notify.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/_cannot_notify.html.erb
@@ -22,8 +22,8 @@
     <p class="govuk-body">
       There is technical guidance on what needs to be submitted in a safety dossier for nanomaterials and what needs to be submitted in a safety dossier for all other ingredients.
       There is also a checklist detailing the information required for a safety dossier.
-      Further information about making cosmetic products safe for users can be found on the
-      <%= link_to "guidance page",
+      Details of what is required can be found on the
+      <%= link_to "GOV.UK guidance page",
                   "https://www.gov.uk/guidance/making-cosmetic-products-available-to-consumers-in-great-britain#making-cosmetic-products-safe-for-users",
                   class: "govuk-link govuk-link--no-visited-state",
                   target: "_blank" %>.

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/_cannot_notify.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/_cannot_notify.html.erb
@@ -11,11 +11,11 @@
 
     <%= yield %>
 
-    <h2 class="govuk-heading-m">New ingredients used as colourants, <abbr title='Ultraviolet'>UV</abbr>-filters, or preservatives</h2>
+    <h2 class="govuk-heading-m">New ingredients used as colourants, <abbr>UV</abbr>-filters, or preservatives</h2>
 
     <p class="govuk-body">
-      For all new ingredients which are used as colourants, <abbr title='Ultraviolet'>UV</abbr>-filters, or preservatives,
-      so not listed in Annex 4, 5 or 6, a safety dossier must be submitted to <abbr title='Office for Product Safety and Standards'>OPSS</abbr> for safety assessment.
+      For all new ingredients which are used as colourants, <abbr>UV</abbr>-filters, or preservatives,
+      so not listed in Annex 4, 5 or 6, a safety dossier must be submitted to <abbr>OPSS</abbr> (Office for Product Safety and Standards) for safety assessment.
       This also applies to nanomaterials.
     </p>
 
@@ -30,7 +30,7 @@
     </p>
 
     <p class="govuk-body">
-      Safety dossiers must be submitted to the <abbr title='Office for Product Safety and Standards'>OPSS</abbr> Safety Assessment inbox:
+      Safety dossiers must be submitted to the <abbr>OPSS</abbr> Safety Assessment inbox:
       <%= mail_to "opss.safetyassessment@beis.gov.uk", nil, class: "govuk-link govuk-link--no-visited-state" %>.
     </p>
 

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/_cannot_notify.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/_cannot_notify.html.erb
@@ -1,0 +1,33 @@
+<% title = "You cannot currently notify products containing #{@nano_element.inci_name}" %>
+
+<% content_for :page_title, title %>
+<% content_for :after_header do %>
+  <%= govukBackLink text: "Back", href: previous_wizard_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= title %></h1>
+
+    <%= yield %>
+
+    <h2 class="govuk-heading-m">New ingredients used as colourants, UV-filters, or preservatives</h2>
+    <p>
+      For all new ingredients which are used as colourants, UV-filters, or preservatives, so not listed in Annex 4, 5 or 6, a safety dossier must be submitted to OPSS for safety assessment.
+      This also applies to nanomaterials.
+    </p>
+    <p>
+      There is technical guidance on what needs to be submitted in a safety dossier for nanomaterials and what needs to be submitted in a safety dossier for all other ingredients.
+      There is also a checklist detailing the information required for a safety dossier. Further information can be found
+      <%= link_to "here",
+                  "https://www.gov.uk/guidance/making-cosmetic-products-available-to-consumers-in-great-britain#making-cosmetic-products-safe-for-users",
+                  class: "govuk-link--no-visited-state",
+                  target: "_blank" %>.
+    </p>
+    <p>
+      Safety dossiers must be submitted to the OPSS Safety Assessment inbox: <%= mail_to  "opss.safetyassessment@beis.gov.uk" %>.
+    </p>
+
+    <p>Go to <%= link_to "your cosmetic products", responsible_person_notifications_path(current_responsible_person), class: "govuk-link--no-visited-state" %>.</p>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_be_listed.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_be_listed.html.erb
@@ -1,6 +1,6 @@
 <%= render "cannot_notify" do %>
-  <p>
-    If you are using a nanomaterial as a colourant, preservative or UV filter it must be listed in the annexes.
+  <p class="govuk-body">
+    If you are using a nanomaterial as a colourant, preservative or <abbr title='Ultraviolet'>UV</abbr> filter it must be listed in the annexes.
     If this is a new ingredient, follow the guidance below.
   </p>
 <% end %>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_be_listed.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_be_listed.html.erb
@@ -1,6 +1,6 @@
 <%= render "cannot_notify" do %>
   <p class="govuk-body">
-    If you are using a nanomaterial as a colourant, preservative or <abbr title='Ultraviolet'>UV</abbr> filter it must be listed in the annexes.
+    If you are using a nanomaterial as a colourant, preservative or <abbr>UV</abbr> filter it must be listed in the annexes.
     If this is a new ingredient, follow the guidance below.
   </p>
 <% end %>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_be_listed.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_be_listed.html.erb
@@ -1,15 +1,6 @@
-<% title = "You cannot notify products containing #{@nano_element.inci_name}" %>
-
-<% content_for :page_title, title %>
-<% content_for :after_header do %>
-  <%= govukBackLink text: "Back", href: previous_wizard_path %>
+<%= render "cannot_notify" do %>
+  <p>
+    If you are using a nanomaterial as a colourant, preservative or UV filter it must be listed in the annexes.
+    If this is a new ingredient, follow the guidance below.
+  </p>
 <% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= title %></h1>
-
-    <p>If you are using a nanomaterial as a colourant, preservative or UV filter it must be listed in the annexes.</p>
-    <p>Go to <%= link_to "your cosmetic products", responsible_person_notifications_path(current_responsible_person), class: "govuk-link--no-visited-state" %>.</p>
-  </div>
-</div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_conform_to_restrictions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_conform_to_restrictions.html.erb
@@ -1,15 +1,6 @@
-<% title = "You cannot notify products containing #{@nano_element.inci_name}" %>
-
-<% content_for :page_title, title %>
-<% content_for :after_header do %>
-  <%= govukBackLink text: "Back", href: previous_wizard_path %>
+<%= render "cannot_notify" do %>
+  <p>
+    If you are using a nanomaterial as a colourant, preservative or UV filter it must conform to the restrictions set out in the annexes.
+    If this is a new ingredient, follow the guidance below.
+  </p>
 <% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= title %></h1>
-
-    <p>If you are using a nanomaterial as a colourant, preservative or UV filter it must conform to the restrictions set out in the annexes.</p>
-    <p>Go to <%= link_to "your cosmetic products", responsible_person_notifications_path(current_responsible_person), class: "govuk-link--no-visited-state" %>.</p>
-  </div>
-</div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_conform_to_restrictions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_conform_to_restrictions.html.erb
@@ -1,6 +1,6 @@
 <%= render "cannot_notify" do %>
-  <p>
-    If you are using a nanomaterial as a colourant, preservative or UV filter it must conform to the restrictions set out in the annexes.
+  <p class="govuk-body">
+    If you are using a nanomaterial as a colourant, preservative or <abbr title='Ultraviolet'>UV</abbr> filter it must conform to the restrictions set out in the annexes.
     If this is a new ingredient, follow the guidance below.
   </p>
 <% end %>

--- a/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_conform_to_restrictions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/nanomaterial_build/must_conform_to_restrictions.html.erb
@@ -1,6 +1,6 @@
 <%= render "cannot_notify" do %>
   <p class="govuk-body">
-    If you are using a nanomaterial as a colourant, preservative or <abbr title='Ultraviolet'>UV</abbr> filter it must conform to the restrictions set out in the annexes.
+    If you are using a nanomaterial as a colourant, preservative or <abbr>UV</abbr> filter it must conform to the restrictions set out in the annexes.
     If this is a new ingredient, follow the guidance below.
   </p>
 <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket 1288](https://regulatorydelivery.atlassian.net/browse/COSBETA-1288)

## Description
Update the guidance content for the pages displayed as dead ends when a nanomaterial does not match a condition to be notified.

Extracted the shared template between both pages as only a paragraph changes between them.

## Screenshots of new page content

<img src="https://user-images.githubusercontent.com/1227578/143284285-f382f677-69c4-44b2-a843-418e19d29646.png" width=50% height=50%>


<img src="https://user-images.githubusercontent.com/1227578/143284277-d4d7e29e-a12f-40b1-aa9e-41e59c3434ae.png" width=50% height=50%>

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2309-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2309-search-web.london.cloudapps.digital/
