### PR TITLE
Change image label HTML on notification summary

### DIFF
--- a/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
+++ b/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
@@ -197,6 +197,16 @@ module ResponsiblePersons::NotificationsHelper
      .compact
   end
 
+  def notification_summary_label_image_link(image, responsible_person, notification)
+    if image.passed_antivirus_check?
+      link_to(image.filename, url_for(image.file), class: "govuk-link govuk-link--no-visited-state")
+    elsif image.file_exists?
+      "Processing image #{image.file.filename}..." \
+      "<br>" \
+      "#{link_to('Refresh', edit_responsible_person_notification_path(responsible_person, notification), class: 'govuk-link govuk-link--no-visited-state')}".html_safe
+    end
+  end
+
 private
 
   def label_image_actions_items(notification)

--- a/cosmetics-web/app/views/notifications/_product_details_label_images.html.erb
+++ b/cosmetics-web/app/views/notifications/_product_details_label_images.html.erb
@@ -1,21 +1,14 @@
-<% if notification.image_uploads.present? %>
-  <ul class="govuk-list">
-    <% notification.image_uploads.each do |image| %>
-      <% if image.passed_antivirus_check? %>
-        <li>
-          <%= link_to image.filename, url_for(image.file), class: "govuk-link govuk-link--no-visited-state" %>
-        </li>
-      <% elsif image.file_exists? %>
-        <p>
-          <%= "Processing image #{image.file.filename} ..." %>
-          <br>
-          <%= link_to "Refresh",
-                      edit_responsible_person_notification_path(@responsible_person, @notification),
-                      class: "govuk-link govuk-link--no-visited-state" %>
-        </p>
-      <% end %>
+<% image_uploads = notification.image_uploads %>
+<% if image_uploads.size > 1 %>
+  <ul class="govuk-list govuk-list--bullet">
+    <% image_uploads.each do |image| %>
+      <li>
+        <%= notification_summary_label_image_link(image, @responsible_person, @notification) %>
+      </li>
     <% end %>
   </ul>
+<% elsif image_uploads.one? %>
+  <%= notification_summary_label_image_link(image_uploads.first, @responsible_person, @notification) %>
 <% elsif allow_edits %>
   <%= link_to "Add product images",
     new_responsible_person_notification_product_image_upload_path(notification.responsible_person, notification),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket 1312](https://regulatorydelivery.atlassian.net/browse/COSBETA-1312)

## Description

- When there is an individual image, it won't be wrapped inside a list.
- When having multiple images, they will be listed with bullet points.
- When the image is waiting for antivirus check, don't wrap the text
  with a paragraph but within a list element.
- Extracted as a helper the code generating the label image link so
  can be re-used in different blocks.

## Review apps
<!--- Edit links after PR is created -->
https://cosmetics-pr-2313-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2313-search-web.london.cloudapps.digital/