### PR TITLE
Allow users to cancel invitations to their Responsible Person

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/invitations_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/invitations_controller.rb
@@ -42,7 +42,7 @@ private
   end
 
   def authorize_responsible_person
-    authorize @responsible_person, :show?
+    authorize @responsible_person, :update?
   end
 
   def send_invite_email

--- a/cosmetics-web/app/controllers/responsible_persons/invitations_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/invitations_controller.rb
@@ -2,9 +2,28 @@ class ResponsiblePersons::InvitationsController < SubmitApplicationController
   before_action :set_responsible_person
   before_action :authorize_responsible_person
   before_action :validate_responsible_person
-  before_action :set_invitation
+  before_action :set_invitation, only: %i[cancel destroy resend]
 
-  skip_before_action :create_or_join_responsible_person
+  skip_before_action :create_or_join_responsible_person, only: :create
+
+  def new
+    @invite_member_form = ResponsiblePersons::InviteMemberForm.new(responsible_person: @responsible_person)
+  end
+
+  def create
+    @invite_member_form = ResponsiblePersons::InviteMemberForm.new(
+      invite_member_form_params.merge(responsible_person: @responsible_person),
+    )
+
+    if @invite_member_form.valid?
+      create_invitation!
+      send_invite_email
+      redirect_to(responsible_person_team_members_path(@responsible_person),
+                  confirmation: "Invite sent to #{@invite_member_form.email}")
+    else
+      render :new
+    end
+  end
 
   def cancel; end
 
@@ -45,12 +64,26 @@ private
     authorize @responsible_person, :update?
   end
 
+  def create_invitation!
+    # If an existing user is invited, the name of the existing user will be used instead of the one provided in the form.
+    name = SubmitUser.find_by(email: @invite_member_form.email)&.name || @invite_member_form.name
+    @invitation = @responsible_person.pending_responsible_person_users.create!(
+      name: name,
+      email_address: @invite_member_form.email,
+      inviting_user: current_user,
+    )
+  end
+
   def send_invite_email
     SubmitNotifyMailer.send_responsible_person_invite_email(
       @responsible_person,
       @invitation,
       current_user.name,
     ).deliver_later
+  end
+
+  def invite_member_form_params
+    params.require(:invite_member_form).permit(:name, :email)
   end
 
   # See: SecondaryAuthenticationConcern

--- a/cosmetics-web/app/controllers/responsible_persons/invitations_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/invitations_controller.rb
@@ -1,0 +1,42 @@
+class ResponsiblePersons::InvitationsController < SubmitApplicationController
+  before_action :set_responsible_person
+  before_action :authorize_responsible_person
+  before_action :validate_responsible_person
+  before_action :set_invitation
+
+  skip_before_action :create_or_join_responsible_person
+
+  def cancel; end
+
+  def destroy
+    case params[:cancel_invitation]
+    when "yes"
+      @invitation.destroy!
+      redirect_to(responsible_person_team_members_path(@responsible_person), confirmation: "The invitation was cancelled")
+    when "no"
+      redirect_to(responsible_person_team_members_path(@responsible_person))
+    else
+      @invitation.errors.add(:cancel_invitation, "Select yes if you want to cancel the invitation")
+      render :cancel
+    end
+  end
+
+private
+
+  def set_responsible_person
+    @responsible_person = ResponsiblePerson.find(params[:responsible_person_id])
+  end
+
+  def set_invitation
+    @invitation = @responsible_person.pending_responsible_person_users.find(params[:id])
+  end
+
+  def authorize_responsible_person
+    authorize @responsible_person, :show?
+  end
+
+  # See: SecondaryAuthenticationConcern
+  def current_operation
+    SecondaryAuthentication::Operations::INVITE_USER
+  end
+end

--- a/cosmetics-web/app/views/responsible_persons/invitations/cancel.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/invitations/cancel.html.erb
@@ -1,0 +1,34 @@
+<% title = "Do you want to cancel the invitation?" %>
+<% page_title(title, errors: @invitation.errors.any?) %>
+
+<% content_for :after_header do %>
+  <%= render "layouts/navbar" %>
+  <%= link_to "Back", responsible_person_team_members_path(@responsible_person), class: "govuk-back-link" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <%= error_summary(@invitation.errors, map_errors: { cancel_invitation: :cancel_invitation_yes }) %>
+  <div class="govuk-grid-column-full">
+    <%= form_with model: @invitation, url: responsible_person_invitation_path(@responsible_person, @invitation), method: :delete, novalidate: true do |form| %>
+      <% heading = capture do %>
+        <h1 class="govuk-fieldset__heading">
+          <%= title %>
+        </h1>
+      <% end %>
+
+      <%= render "form_components/govuk_radios",
+              form: form,
+              key: :cancel_invitation,
+              fieldset: { legend: { html: heading, classes: "govuk-fieldset__legend--l" } },
+              idPrefix: "cancel_invitation",
+              name: "cancel_invitation",
+              hint: { text: "Invitation emails already sent to the user will not work if you cancel the invitation." },
+              classes: "govuk-!-padding-top-3",
+              items: [{ text: "Yes", value: :yes },
+                      { text: "No", value: :no }] %>
+      <div class="govuk-button-group">
+        <%= govukButton text: "Save and continue" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/invitations/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/invitations/new.html.erb
@@ -6,7 +6,7 @@
   <%= link_to "Back", responsible_person_team_members_path(@responsible_person), class: "govuk-back-link" %>
 <% end %>
 
-<%= form_with model: @invite_member_form, scope: :invite_member_form, url: responsible_person_team_members_path(@responsible_person), method: :post do |form| %>
+<%= form_with model: @invite_member_form, scope: :invite_member_form, url: responsible_person_invitations_path(@responsible_person), method: :post do |form| %>
   <div class="govuk-grid-row">
     <%= error_summary_for(@invite_member_form) %>
     <div class="govuk-grid-column-two-thirds">

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -62,29 +62,33 @@
             <td class="govuk-table__cell"></td>
           </tr>
         <% end %>
-        <% @responsible_person.pending_responsible_person_users.each do |user| %>
+        <% @responsible_person.pending_responsible_person_users.each do |invitation| %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">
               <span class="govuk-!-font-weight-regular">
-                <%= user.name %><span class="govuk-visually-hidden">:</span>
+                <%= invitation.name %><span class="govuk-visually-hidden">:</span>
                 <br>
                 <span class="govuk-!-font-size-16">Awaiting confirmation</span>
               </span>
             </th>
             <td class="govuk-table__cell">
-              <%= mail_to user.email_address, nil, class: "govuk-link govuk-link--no-visited-state" %>
+              <%= mail_to invitation.email_address, nil, class: "govuk-link govuk-link--no-visited-state" %>
               <span class="govuk-visually-hidden"> | </span>
               <br>
-              <%= link_to resend_invitation_responsible_person_team_member_path(@responsible_person, user),
-                  class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 govuk-!-font-weight-bold" do %>
-                Resend invitation <span class="govuk-visually-hidden"> to <%= user.name %></span>
+              <%= link_to resend_invitation_responsible_person_team_member_path(@responsible_person, invitation),
+                  class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 govuk-!-font-weight-bold govuk-!-margin-right-2" do %>
+                Resend invitation <span class="govuk-visually-hidden"> to <%= invitation.name %></span>
+              <% end %>
+              <span class="govuk-visually-hidden"> | </span>
+              <%= link_to cancel_responsible_person_invitation_path(@responsible_person, invitation),
+                  class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 govuk-!-font-weight-bold opss-no-wrap" do %>
+                Cancel invitation <span class="govuk-visually-hidden"> to <%= invitation.name %></span>
               <% end %>
             </td>
-            <td class="govuk-table__cell"><%= user.inviting_user.name %></td>
+            <td class="govuk-table__cell"><%= invitation.inviting_user.name %></td>
           </tr>
         <% end %>
       </tbody>
     </table>
   </div>
 </div>
-

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
         <%= link_to "Invite another team member",
-                    new_responsible_person_team_member_path,
+                    new_responsible_person_invitation_path(@responsible_person),
                     class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset" %>
       </div>
     </div>

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.erb
@@ -75,7 +75,7 @@
               <%= mail_to invitation.email_address, nil, class: "govuk-link govuk-link--no-visited-state" %>
               <span class="govuk-visually-hidden"> | </span>
               <br>
-              <%= link_to resend_invitation_responsible_person_team_member_path(@responsible_person, invitation),
+              <%= link_to resend_responsible_person_invitation_path(@responsible_person, invitation),
                   class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-16 govuk-!-font-weight-bold govuk-!-margin-right-2" do %>
                 Resend invitation <span class="govuk-visually-hidden"> to <%= invitation.name %></span>
               <% end %>

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -113,9 +113,6 @@ Rails.application.routes.draw do
       end
 
       resources :team_members, controller: "responsible_persons/team_members", only: %i[index] do
-        member do
-          get "new-account", action: :new_account
-        end
         collection do
           get :join
           post "sign-out-before-joining", action: :sign_out_before_joining

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -123,6 +123,12 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :invitations, controller: "responsible_persons/invitations", only: [:destroy] do
+        member do
+          get :cancel
+        end
+      end
+
       resources :notifications, param: :reference_number, controller: "responsible_persons/notifications", only: %i[index show new edit] do
         resources :build, controller: "responsible_persons/wizard/notification_build", only: %i[show update new]
         resources :additional_information, controller: "responsible_persons/additional_information", only: %i[index]

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -112,7 +112,7 @@ Rails.application.routes.draw do
       resources :contact_persons, controller: "responsible_persons/contact_persons", only: %i[new create edit update] do
       end
 
-      resources :team_members, controller: "responsible_persons/team_members", only: %i[index new create] do
+      resources :team_members, controller: "responsible_persons/team_members", only: %i[index] do
         member do
           get "new-account", action: :new_account
         end
@@ -122,7 +122,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :invitations, controller: "responsible_persons/invitations", only: [:destroy] do
+      resources :invitations, controller: "responsible_persons/invitations", only: %i[new create destroy] do
         member do
           get :cancel
           get :resend # Ideally this would be a PATCH action, but doesn't play well with redirection after 2FA triggered by the link to resend with patch method.

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -115,7 +115,6 @@ Rails.application.routes.draw do
       resources :team_members, controller: "responsible_persons/team_members", only: %i[index new create] do
         member do
           get "new-account", action: :new_account
-          get "resend-invitation", action: :resend_invitation
         end
         collection do
           get :join
@@ -126,6 +125,7 @@ Rails.application.routes.draw do
       resources :invitations, controller: "responsible_persons/invitations", only: [:destroy] do
         member do
           get :cancel
+          get :resend # Ideally this would be a PATCH action, but doesn't play well with redirection after 2FA triggered by the link to resend with patch method.
         end
       end
 

--- a/cosmetics-web/spec/controllers/responsible_persons/team_members_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/team_members_controller_spec.rb
@@ -28,65 +28,6 @@ RSpec.describe ResponsiblePersons::TeamMembersController, :with_stubbed_mailer, 
     end
   end
 
-  describe "POST #create" do
-    let(:params) { { responsible_person_id: responsible_person.id } }
-    let(:name) { "John Doe" }
-
-    it "render back to add team member form if no email is provided" do
-      post(:create, params: params.merge(invite_member_form: { email: "", name: name }))
-      expect(response).to render_template(:new)
-    end
-
-    it "render back to add team member form if no name is provided" do
-      post(:create, params: params.merge(invite_member_form: { email: email_address, name: "" }))
-      expect(response).to render_template(:new)
-    end
-
-    it "render back to add team member form if user is already a member of the team" do
-      post(:create, params: params.merge(invite_member_form: {
-        email: user.email,
-        name: name,
-      }))
-      expect(response).to render_template(:new)
-    end
-
-    it "render back to add team member form if user has already been invited to the team" do
-      create(:pending_responsible_person_user, responsible_person: responsible_person, email_address: email_address)
-
-      post(:create, params: params.merge(invite_member_form: { email: email_address, name: name }))
-      expect(response).to render_template(:new)
-    end
-
-    it "creates an invitation with the given data plus the user that created the invitation" do
-      expect {
-        post(:create, params: params.merge(invite_member_form: { email: email_address, name: name }))
-      }.to change(PendingResponsiblePersonUser, :count).by(1)
-      expect(PendingResponsiblePersonUser.last)
-        .to have_attributes(inviting_user: user, email_address: email_address, name: name)
-    end
-
-    it "uses the existing user name for the invitation when inviting an email belonging to an existing user" do
-      create(:submit_user, email: email_address, name: "John Original Name")
-      expect {
-        post(:create, params: params.merge(invite_member_form: { email: email_address, name: name }))
-      }.to change(PendingResponsiblePersonUser, :count).by(1)
-      expect(PendingResponsiblePersonUser.last.name).to eq("John Original Name")
-    end
-
-    it "sends responsible person invite email" do
-      stub_notify_mailer
-
-      post(:create, params: params.merge(invite_member_form: { email: email_address, name: name }))
-
-      expect(SubmitNotifyMailer).to have_received(:send_responsible_person_invite_email)
-    end
-
-    it "redirects to the responsible person team members page" do
-      post(:create, params: params.merge(invite_member_form: { email: email_address, name: name }))
-      expect(response).to redirect_to(responsible_person_team_members_path(responsible_person))
-    end
-  end
-
   describe "GET #join" do
     let(:pending_responsible_person_user) { create(:pending_responsible_person_user, responsible_person: responsible_person, inviting_user: user) }
     let(:params) { { responsible_person_id: responsible_person.id, invitation_token: pending_responsible_person_user.invitation_token } }
@@ -114,10 +55,4 @@ RSpec.describe ResponsiblePersons::TeamMembersController, :with_stubbed_mailer, 
       end
     end
   end
-end
-
-def stub_notify_mailer
-  result = double
-  allow(result).to receive(:deliver_later)
-  allow(SubmitNotifyMailer).to receive(:send_responsible_person_invite_email) { result }
 end

--- a/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
+++ b/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
       expect_user_to_have_received_sms_code(user.reload.direct_otp, user)
       complete_secondary_authentication_sms_with(user.direct_otp)
 
-      expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/team_members/new")
+      expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/invitations/new")
 
       # We use the wrong name when inviting the existing user
       fill_in "Full name", with: "John DiffName"
@@ -69,7 +69,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
       expect_user_to_have_received_sms_code(user.reload.direct_otp, user)
       complete_secondary_authentication_sms_with(user.direct_otp)
 
-      expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/team_members/new")
+      expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/invitations/new")
 
       fill_in "Full name", with: invited_user.name
       fill_in "Email address", with: invited_user.email.upcase
@@ -96,7 +96,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
       expect_user_to_have_received_sms_code(user.reload.direct_otp, user)
       complete_secondary_authentication_sms_with(user.direct_otp)
 
-      expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/team_members/new")
+      expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/invitations/new")
 
       fill_in "Full name", with: invited_user.name
       fill_in "Email address", with: invited_user.email.upcase
@@ -126,7 +126,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     expect_user_to_have_received_sms_code(user.reload.direct_otp, user)
     complete_secondary_authentication_sms_with(user.direct_otp)
 
-    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/team_members/new")
+    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/invitations/new")
 
     fill_in "Full name", with: invited_user.name
     fill_in "Email address", with: invited_user.email
@@ -211,7 +211,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     visit team_path
     click_on "Invite another team member"
 
-    expect(page).to have_current_path("#{team_path}/new")
+    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/invitations/new")
     fill_in "Full name", with: "John New User"
     fill_in "Email address", with: "newusertoregister@example.com"
     click_on "Send invitation"
@@ -446,7 +446,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     expect_user_to_have_received_sms_code(user.reload.direct_otp, user)
     complete_secondary_authentication_sms_with(user.direct_otp)
 
-    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/team_members/new")
+    expect(page).to have_current_path("/responsible_persons/#{responsible_person.id}/invitations/new")
 
     fill_in "Full name", with: "John New User"
     fill_in "Email address", with: "newusertoregister@example.com"

--- a/cosmetics-web/spec/requests/responsible_person_access_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_person_access_spec.rb
@@ -54,7 +54,7 @@ describe "Access control for actions related to responsible person" do
   end
 
   context "when visiting the responsible person add a member page" do
-    let(:url) { "/responsible_persons/#{rp1.id}/team_members/new" }
+    let(:url) { "/responsible_persons/#{rp1.id}/invitations/new" }
 
     include_examples "proper authorization"
   end

--- a/cosmetics-web/spec/requests/responsible_persons/invitations_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/invitations_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Responsible Person user invitations", :with_stubbed_notify, type
   end
 
   describe "Resending an invitation" do
-    let!(:invitation) do
+    let(:invitation) do
       create(:pending_responsible_person_user, responsible_person: responsible_person, inviting_user: user)
     end
 

--- a/cosmetics-web/spec/requests/responsible_persons/invitations_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/invitations_spec.rb
@@ -1,17 +1,86 @@
 require "rails_helper"
 
-RSpec.describe "Responsible Person user invitations", type: :request, with_stubbed_notify: true do
+RSpec.describe "Responsible Person user invitations", :with_stubbed_notify, type: :request do
   let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
   let(:other_responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
+  let(:user) { create(:submit_user) }
 
   before do
     configure_requests_for_submit_domain
-
-    sign_in_as_member_of_responsible_person(responsible_person)
+    sign_in_as_member_of_responsible_person(responsible_person, user)
   end
 
   after do
     sign_out(:submit_user)
+  end
+
+  describe "Creating an invitation" do
+    let(:params) { { responsible_person_id: responsible_person.id } }
+    let(:name) { "John Doe" }
+    let(:email_address) { "user@example.com" }
+
+    it "render back to add team member form if no email is provided" do
+      post responsible_person_invitations_path(responsible_person),
+           params: params.merge(invite_member_form: { email: "", name: name })
+      expect(response).to render_template(:new)
+    end
+
+    it "render back to add team member form if no name is provided" do
+      post responsible_person_invitations_path(responsible_person),
+           params: params.merge(invite_member_form: { email: email_address, name: "" })
+      expect(response).to render_template(:new)
+    end
+
+    it "render back to add team member form if user is already a member of the team" do
+      post responsible_person_invitations_path(responsible_person),
+           params: params.merge(invite_member_form: {
+             email: user.email,
+             name: name,
+           })
+      expect(response).to render_template(:new)
+    end
+
+    it "render back to add team member form if user has already been invited to the team" do
+      create(:pending_responsible_person_user, responsible_person: responsible_person, email_address: email_address)
+
+      post responsible_person_invitations_path(responsible_person),
+           params: params.merge(invite_member_form: { email: email_address, name: name })
+      expect(response).to render_template(:new)
+    end
+
+    it "creates an invitation with the given data plus the user that created the invitation" do
+      expect {
+        post responsible_person_invitations_path(responsible_person),
+             params: params.merge(invite_member_form: { email: email_address, name: name })
+      }.to change(PendingResponsiblePersonUser, :count).by(1)
+      expect(PendingResponsiblePersonUser.last)
+        .to have_attributes(inviting_user: user, email_address: email_address, name: name)
+    end
+
+    it "uses the existing user name for the invitation when inviting an email belonging to an existing user" do
+      create(:submit_user, email: email_address, name: "John Original Name")
+      expect {
+        post responsible_person_invitations_path(responsible_person),
+             params: params.merge(invite_member_form: { email: email_address, name: name })
+      }.to change(PendingResponsiblePersonUser, :count).by(1)
+      expect(PendingResponsiblePersonUser.last.name).to eq("John Original Name")
+    end
+
+    it "sends responsible person invite email" do
+      allow(SubmitNotifyMailer).to receive(:send_responsible_person_invite_email)
+        .and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: true))
+
+      post responsible_person_invitations_path(responsible_person),
+           params: params.merge(invite_member_form: { email: email_address, name: name })
+
+      expect(SubmitNotifyMailer).to have_received(:send_responsible_person_invite_email)
+    end
+
+    it "redirects to the responsible person team members page" do
+      post responsible_person_invitations_path(responsible_person),
+           params: params.merge(invite_member_form: { email: email_address, name: name })
+      expect(response).to redirect_to(responsible_person_team_members_path(responsible_person))
+    end
   end
 
   describe "Resending invitation" do

--- a/cosmetics-web/spec/requests/responsible_persons/invitations_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/invitations_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Responsible Person user invitations", type: :request, with_stubbed_notify: true do
+  let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
+  let(:other_responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
+
+  before do
+    configure_requests_for_submit_domain
+
+    sign_in_as_member_of_responsible_person(responsible_person)
+  end
+
+  after do
+    sign_out(:submit_user)
+  end
+
+  describe "Resending invitation" do
+    context "when invitation does not belongs to responsible person" do
+      let(:invitation) { create(:pending_responsible_person_user, responsible_person: other_responsible_person) }
+
+      it "returns 404" do
+        get resend_responsible_person_invitation_path(responsible_person, invitation)
+        expect(response).to redirect_to("/404")
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/requests/responsible_persons/team_members_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/team_members_spec.rb
@@ -23,15 +23,4 @@ RSpec.describe "Team members management", type: :request, with_stubbed_notify: t
       end
     end
   end
-
-  describe "Resending invitation" do
-    context "when invitation does not belongs to responsible person" do
-      let(:invitation) { create(:pending_responsible_person_user, responsible_person: other_responsible_person) }
-
-      it "returns 404" do
-        get resend_invitation_responsible_person_team_member_path(responsible_person, invitation)
-        expect(response).to redirect_to("/404")
-      end
-    end
-  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1293)

## Description
<!--- Describe your changes in detail -->

Allowing Responsible Person users to cancel pending invitations to their Responsible Person.

Invitation routes have been refactored, so now we have:
- `/responsible_person/:rp_id/invitations/new` to add a new invitation from the team members page.
- `/responsible_person/:rp_id/invitations/:inv_id/resend` to resend an existing invitation.
- `/responsible_person/:rp_id/invitations/:inv_id/cancel` to cancel an invitation.

Team members controller now is only in charge of:
- listing the team members and pending invitations
- enable people with invitation links to join the team/RP.

## Screenshots
The cancel invitation button is now available on the team members page:
![image](https://user-images.githubusercontent.com/1227578/145429591-1e2b1a2a-36f6-429e-be0d-c8c90f395e29.png)

Clicking on it takes the user to a confirmation page:
![image](https://user-images.githubusercontent.com/1227578/145429883-3b54cf22-1d32-4944-9238-40db75a6d0b2.png)

User is redirected back to team members page and a confirmation message is displayed once the invitation has been cancelled:
![image](https://user-images.githubusercontent.com/1227578/145430051-ef8d8824-5f37-418c-a195-62087c209dc4.png)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2318-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2318-search-web.london.cloudapps.digital/
