### PR TITLE
Fix radio buttons error anchoring

### DIFF
--- a/cosmetics-web/app/views/nanomaterial_notifications/notified_to_eu.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/notified_to_eu.html.erb
@@ -14,7 +14,8 @@
 
     <%= form_for @nanomaterial_notification, url: notified_to_eu_nanomaterial_path(@nanomaterial_notification), html: { novalidate: true } do |form| %>
 
-      <%= error_summary_for(@nanomaterial_notification, first_values: {eu_notified: "true"}) %>
+      <%= error_summary(@nanomaterial_notification.errors,
+                        map_errors: { eu_notified: "eu_notified_true", notified_to_eu_on: "notified_to_eu_on-notified_to_eu_on[day]" }) %>
 
       <% if @nanomaterial_notification.errors[:notified_to_eu_on].size > 0 %>
         <% errorMessage = {
@@ -55,31 +56,30 @@
           }]) %>
 
 
-      <%= render "components/govuk_radios",
-          "idPrefix": "eu_notified",
-          "name": "eu_notified",
-          "fieldset": {
-            "legend": {
-              "html": safe_join([page_title_prefix, content_tag('span', brexit_date, class: 'no-wrap'), "?"]),
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
-            }
+      <%= render "form_components/govuk_radios",
+        form: form,
+        key: :eu_notified,
+        fieldset: {
+          legend: {
+            html: safe_join([page_title_prefix, content_tag('span', brexit_date, class: 'no-wrap'), "?"]),
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--xl"
+          }
+        },
+        idPrefix: "eu_notified",
+        name: "eu_notified",
+        items: [
+          {
+            value: :true,
+            html: safe_join(["Yes, the EU was notified about the nanomaterial on CPNP before ", content_tag('span', display_full_month_date(EU_EXIT_DATE), class: 'no-wrap')]),
+            conditional: {html: date_notified_to_eu_html}
           },
-          "items": [
-            {
-              "value": "true",
-              "html": safe_join(["Yes, the EU was notified about the nanomaterial on CPNP before ", content_tag('span', display_full_month_date(EU_EXIT_DATE), class: 'no-wrap')]),
-              "checked": @nanomaterial_notification.eu_notified == true,
-              "conditional": {"html": date_notified_to_eu_html}
-            },
-            {
-              "value": "false",
-              "text": "No",
-              "checked": @nanomaterial_notification.eu_notified == false,
-            }
-          ]
-        %>
-
+          {
+            value: :false,
+            text: "No",
+          },
+        ]
+      %>
       <%= govukButton text: "Continue" %>
     <% end %>
 

--- a/cosmetics-web/app/views/responsible_persons/select.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/select.html.erb
@@ -13,8 +13,7 @@
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= error_summary_for(@responsible_persons_selection_form,
-                        first_values: { selection: @responsible_persons_selection_form.radio_items.first[:value] }) %>
+    <%= error_summary(@responsible_persons_selection_form.errors, map_errors: { selection: "change-rp_1" }) %>
     <%= form_with model: @responsible_persons_selection_form, url: select_responsible_persons_path, method: :post, html: { novalidate: true } do |form| %>
       <% heading = capture do %>
         <h1 class="govuk-fieldset__heading">

--- a/cosmetics-web/app/views/responsible_persons/select.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/select.html.erb
@@ -13,7 +13,10 @@
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= error_summary(@responsible_persons_selection_form.errors, map_errors: { selection: "change-rp_1" }) %>
+    <%=
+      first_rp_id = @responsible_persons_selection_form.radio_items.first[:value]
+      error_summary(@responsible_persons_selection_form.errors, map_errors: { selection: "change-rp_#{first_rp_id}" })
+    %>
     <%= form_with model: @responsible_persons_selection_form, url: select_responsible_persons_path, method: :post, html: { novalidate: true } do |form| %>
       <% heading = capture do %>
         <h1 class="govuk-fieldset__heading">


### PR DESCRIPTION
[Jira 1249](https://regulatorydelivery.atlassian.net/browse/COSBETA-1249)
Fix error display/ error summary messages anchoring in two forms/pages:
1 - Responsible person selection form.
2 - When adding a nanomaterial. The form/page asking about if/date when was notified to the EU.

## Description
In 2 pages:
![Screenshot from 2021-12-13 13-25-39](https://user-images.githubusercontent.com/1227578/145821019-d1b6f434-957b-4013-89ba-347cb0eabb0f.png)

![Screenshot from 2021-12-13 13-26-00](https://user-images.githubusercontent.com/1227578/145821041-2a4cfb66-ad3d-40db-9fd9-7bc8656b0562.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2320-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2320-search-web.london.cloudapps.digital/

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
