### PR TITLE
Order Notifications CSV by completion date

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -9,7 +9,7 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        @notifications = NotificationsDecorator.new(@responsible_person.notifications.completed.order(:created_at))
+        @notifications = NotificationsDecorator.new(@responsible_person.notifications.completed.order(notification_complete_at: :desc))
         render csv: @notifications, filename: "all-notifications-#{Time.zone.now.to_s(:db)}"
       end
     end

--- a/cosmetics-web/spec/requests/notifications_page_spec.rb
+++ b/cosmetics-web/spec/requests/notifications_page_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe "Notifications page", :with_stubbed_antivirus, :with_stubbed_noti
         let(:expected_csv) do
           <<~CSV
             Product name,UK cosmetic product number,Notification date,EU Reference number,EU Notification date,Internal reference,Number of items,Item 1 Level 1 category,Item 1 Level 2 category,Item 1 Level 3 category
-            Product 1,UKCP-00000001,2021-02-20 13:00:00 +0000,,,,0
             Product 2,UKCP-00000002,2021-02-20 13:01:00 +0000,,,,0
+            Product 1,UKCP-00000001,2021-02-20 13:00:00 +0000,,,,0
           CSV
         end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket 1171](https://regulatorydelivery.atlassian.net/browse/COSBETA-1171
)
## Description
<!--- Describe your changes in detail -->
The Notifications CSV export was ordering the notifications ascending by their creation date.
We want to show the most recently submitted notifications first, so the order has been changed to load the notifications from most recently
completed to older ones.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2326-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2326-search-web.london.cloudapps.digital/
