### PR TITLE
Rename blank category as "All" in Search filters

### DIFF
--- a/cosmetics-web/app/views/poison_centres/notifications/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/_filters.html.erb
@@ -15,7 +15,7 @@
           <label class="govuk-label" for="notification_search_form_category">
             Product category
           </label>
-          <%= form.select :category, @search_form.class::CATEGORIES, { include_blank: true },  class: "govuk-select" %>
+          <%= form.select :category, @search_form.class::CATEGORIES, { include_blank: "All" },  class: "govuk-select" %>
           <%= form.hidden_field :q, id: :notification_search_form_q_hidden %>
           <%= form.hidden_field :sort_by, id: 'notification_search_form_sort_by_date_filter_hidden' %>
         </div>


### PR DESCRIPTION
[Jira ticket 1330](https://regulatorydelivery.atlassian.net/browse/COSBETA-1330)

Instead of displaying a blank selection with non-text when the filters
do not include a specific category, we want to display "All".

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
![image](https://user-images.githubusercontent.com/1227578/146377298-bacf5394-3699-45ef-820f-567689086d4b.png)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2327-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2327-search-web.london.cloudapps.digital/
