### PR TITLE
Remove obvious UK/EU html abbr tag titles

### DIFF
--- a/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
+++ b/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
@@ -2,24 +2,24 @@ module ResponsiblePersons::NotificationsHelper
   def notification_summary_references_rows(notification)
     [
       {
-        key: { html: "<abbr title='United Kingdom'>UK</abbr> cosmetic product number".html_safe },
+        key: { html: "<abbr>UK</abbr> cosmetic product number".html_safe },
         value: { text: notification.reference_number_for_display },
       },
       if notification.cpnp_reference.present?
         {
-          key: { html: "<abbr title='European Union'>EU</abbr> reference number".html_safe },
+          key: { html: "<abbr>EU</abbr> reference number".html_safe },
           value: { text: notification.cpnp_reference },
         }
       end,
       if notification.cpnp_notification_date.present?
         {
-          key: { html: "First notified in the <abbr title='European Union'>EU</abbr>".html_safe },
+          key: { html: "First notified in the <abbr>EU</abbr>".html_safe },
           value: { text: display_full_month_date(notification.cpnp_notification_date) },
         }
       end,
       if notification.notification_complete_at.present?
         {
-          key: { html: "<abbr title='United Kingdom'>UK</abbr> notified".html_safe },
+          key: { html: "<abbr>UK</abbr> notified".html_safe },
           value: { text: display_full_month_date(notification.notification_complete_at) },
         }
       end,

--- a/cosmetics-web/app/views/poison_centres/notifications/_results.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/_results.html.erb
@@ -21,9 +21,9 @@
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th class="govuk-visually-hidden">&nbsp;</th>
-              <th id="uknotified" scope="col" class="govuk-table__header"><abbr title='United Kingdom'>UK</abbr> notified</th>
-              <th id="ukcosprodnumber" scope="col" class="govuk-table__header"><abbr title='United Kingdom'>UK</abbr> cosmetic product number</th>
-              <th id="eurefnumber" scope="col" class="govuk-table__header"><abbr title='European Union'>EU</abbr> reference number</th>
+              <th id="uknotified" scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
+              <th id="ukcosprodnumber" scope="col" class="govuk-table__header"><abbr>UK</abbr> cosmetic product number</th>
+              <th id="eurefnumber" scope="col" class="govuk-table__header"><abbr>EU</abbr> reference number</th>
             </tr>
           </thead>
           <% results.each.with_index(1) do |notification, index| %>
@@ -33,9 +33,9 @@
             <tfoot class="govuk-table__head">
               <tr class="govuk-table__row">
                 <th class="govuk-visually-hidden">&nbsp;</th>
-                <th scope="col" class="govuk-table__header"><abbr title='United Kingdom'>UK</abbr> notified</th>
-                <th scope="col" class="govuk-table__header"><abbr title='United Kingdom'>UK</abbr> cosmetic product number</th>
-                <th scope="col" class="govuk-table__header"><abbr title='European Union'>EU</abbr> reference number</th>
+                <th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
+                <th scope="col" class="govuk-table__header"><abbr>UK</abbr> cosmetic product number</th>
+                <th scope="col" class="govuk-table__header"><abbr>EU</abbr> reference number</th>
               </tr>
             </tfoot>
           <% end %>


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1341)

These terms don't need to have a title as their meaning is common knowledge and the title information can be noisy for screen readers.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2343-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2343-search-web.london.cloudapps.digital/
