### PR TITLE
Bugfix: back-link for nanomaterial without nanoelements

### DIFF
--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -14,7 +14,7 @@ module ComponentBuildHelper
       responsible_person_notification_build_path(notification.responsible_person, notification, :add_product_image)
     elsif step == :select_category && @category.present?
       wizard_path(:select_category, category: Component.get_parent_category(@category))
-    elsif step == :select_category && @component&.nano_material.present?
+    elsif step == :select_category && @component&.nano_material&.nano_elements&.any?
       last_nanoelement = @component.nano_material.nano_elements.last
       nanoelement_step = last_nanoelement.standard? ? :confirm_usage : :when_products_containing_nanomaterial_can_be_placed_on_market
       responsible_person_notification_component_nanomaterial_build_path(notification.responsible_person, notification, @component, last_nanoelement, nanoelement_step)


### PR DESCRIPTION
[Associated error in bug tracking software](https://sentry.io/organizations/beis/issues/2873987414/?project=1398436&query=is%3Aunresolved)

The logic for the backlink path generation was assuming that when a nanomaterial is present in the component, there will be nanoelements associated with the nanomaterial.

This is not the case for some imported notifications.
When these notifications are drafts, the user still can navigate through their flow.

The service was throwing exception for those cases as "last_nanoelement.standard?" was trying to call a method over a "nil" object.

To resolve it, the branch condition asserts over the presence of a nano element.

