### PR TITLE
Guard against missing frame formulations IDs

### DIFF
--- a/cosmetics-web/app/controllers/frame_formulations_controller.rb
+++ b/cosmetics-web/app/controllers/frame_formulations_controller.rb
@@ -5,6 +5,9 @@ class FrameFormulationsController < PubliclyAccessibleController
 
   def show
     @formulation = FrameFormulations::ALL.find { |formulation| formulation["number"] == params[:id].to_i }
+    return redirect_to "/404" if @formulation.blank?
+
     @subformulation = @formulation["data"].find { |formulation| formulation["childNumber"] == params[:sub_id].to_i }
+    return redirect_to "/404" if @subformulation.blank?
   end
 end


### PR DESCRIPTION
## Description
When the wrong ID or SubID is given in the URL for the frame formulation page, instead of assuming the formulation/subformulation are found and trying to load the template, will redirect to 404 page, treating it as an ActiveRecord "not found" situation.

Noticed this after an attempt of SQL attack against this controller, passing SQL commands as ID/SUBID parameters.

The attack had no danger (especially as this controller does not query the DB), but caused 500 errors in the service that brought attention to the need to redirect to 404 instead.

Related Sentry issues:
- https://sentry.io/organizations/beis/issues/2908098191/?project=1398436
- https://sentry.io/organizations/beis/issues/2908098178/?project=1398436

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->


<!--- Describe your changes in detail -->

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2347-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2347-search-web.london.cloudapps.digital/
