### PR TITLE
Migrate smoke tests to Selenium web driver

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -52,7 +52,6 @@ gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk
 group :development, :test do
   gem "brakeman", "~> 4.7.2"
   gem "capybara", "~> 3.36.0"
-  gem "capybara-mechanize"
   gem "capybara-screenshot"
   gem "coveralls_reborn", "~> 0.22.0"
   gem "debase", "~> 0.2.5.beta2"
@@ -73,6 +72,7 @@ group :development, :test do
   gem "rubocop-rails", "~> 2.12.4"
   gem "rubocop-rspec", "~> 2.6.0"
   gem "ruby-debug-ide", "~> 0.7.0"
+  gem "selenium-webdriver", "~> 4.1"
   gem "simplecov", "~> 0.21.2"
   gem "simplecov-console", "~> 0.6.0"
   gem "simplecov-lcov", "~> 0.7.0"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -117,13 +117,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-mechanize (1.11.0)
-      capybara (>= 2.4.4, < 4)
-      mechanize (~> 2.7.0)
     capybara-screenshot (1.0.25)
       capybara (>= 1.0, < 4)
       launchy
     cf-app-utils (0.6)
+    childprocess (4.1.0)
     chunky_png (1.4.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.9)
@@ -257,16 +255,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    mechanize (2.7.7)
-      domain_name (~> 0.5, >= 0.5.1)
-      http-cookie (~> 1.0)
-      mime-types (>= 1.17.2)
-      net-http-digest_auth (~> 1.1, >= 1.1.1)
-      net-http-persistent (>= 2.5.2)
-      nokogiri (~> 1.6)
-      ntlm-http (~> 0.1, >= 0.1.1)
-      webrick (~> 1.7)
-      webrobots (>= 0.0.9, < 0.2)
     method_source (0.9.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -277,9 +265,6 @@ GEM
     minitest (5.15.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    net-http-digest_auth (1.4.1)
-    net-http-persistent (4.0.1)
-      connection_pool (~> 2.2)
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.12.5)
@@ -287,7 +272,6 @@ GEM
       racc (~> 1.4)
     notifications-ruby-client (5.1.1)
       jwt (>= 1.5, < 3)
-    ntlm-http (0.1.1)
     okcomputer (1.18.4)
     orm_adapter (0.5.0)
     parallel (1.21.0)
@@ -433,6 +417,10 @@ GEM
     rubyzip (2.3.2)
     scout_apm (5.1.1)
       parser
+    selenium-webdriver (4.1.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
     sentry-rails (4.8.1)
       railties (>= 5.0)
@@ -529,7 +517,6 @@ GEM
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
     webrick (1.7.0)
-    webrobots (0.1.2)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -552,7 +539,6 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.60.1)
   brakeman (~> 4.7.2)
   capybara (~> 3.36.0)
-  capybara-mechanize
   capybara-screenshot
   cf-app-utils (~> 0.6)
   coveralls_reborn (~> 0.22.0)
@@ -598,6 +584,7 @@ DEPENDENCIES
   ruby-debug-ide (~> 0.7.0)
   rubyzip (~> 2.3.0)
   scout_apm
+  selenium-webdriver (~> 4.1)
   sentry-rails (~> 4.8.1)
   sentry-ruby (~> 4.8.1)
   sentry-sidekiq (~> 4.8.1)
@@ -618,7 +605,7 @@ DEPENDENCIES
   will_paginate (= 3.2.1)
 
 RUBY VERSION
-   ruby 3.0.2p107
+   ruby 3.0.3p157
 
 BUNDLED WITH
-   2.2.22
+   2.2.32

--- a/cosmetics-web/spec/smoke/search_smoke_test_spec.rb
+++ b/cosmetics-web/spec/smoke/search_smoke_test_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Search smoke test" do
-  let(:session) { Capybara::Session.new :mechanize }
+  let(:session) { Capybara::Session.new :selenium_headless }
   let(:product_name) { ENV.fetch("SMOKE_PRODUCT_NAME", "THE MASK by WOW facial hydrogel sheet face mask") }
 
   if ENV["RUN_SMOKE"] == "true"

--- a/cosmetics-web/spec/support/capybara.rb
+++ b/cosmetics-web/spec/support/capybara.rb
@@ -1,11 +1,6 @@
 require "capybara/rspec"
 require "capybara-screenshot/rspec"
-require "capybara/mechanize"
 
 Capybara.register_driver :rack_test do |app|
   Capybara::RackTest::Driver.new(app, respect_data_method: true, headers: { "HTTP_USER_AGENT" => "Capybara" })
-end
-
-Capybara.register_driver :mechanize do |_app|
-  Capybara::Mechanize::Driver.new(proc {})
 end


### PR DESCRIPTION
## Description
Capybara mechanize has been unmaintained for years and is not compatible with Ruby 3 syntax (unless using a fork).

Selenium web driver is the default for Rails 6 integration testing and allows us to run the smoke test without any change but the driver itself.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->


<!--- Describe your changes in detail -->
