### PR TITLE
Disable Rubocop RSpec/MultipleMemoizedHelpers rule

### DIFF
--- a/cosmetics-web/.rubocop.yml
+++ b/cosmetics-web/.rubocop.yml
@@ -85,6 +85,15 @@ RSpec/MultipleExpectations:
     - 'spec/features/**/*'
     - 'spec/smoke/**/*'
 
+# This rule is controversial.
+# We have hundreds of violations of it in our codebase, and resolve them would
+# require a lot of work refactoring our specs to break them down into separate
+# test groups.
+# The individual comments for disabling it in each case are quite noisy, so we're
+# disabling the rule.
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 6
 

--- a/cosmetics-web/.rubocop.yml
+++ b/cosmetics-web/.rubocop.yml
@@ -19,17 +19,6 @@ AllCops:
     - 'bin/**/*'
     - 'vendor/**/*'
 
-# Disable this so that we can use Capybara aliases like
-# 'feature' and 'scenario' for more readable tests
-Capybara/FeatureMethods:
-  Enabled: false
-
-# We can disable this as we're using Capybara with RackTest which
-# doesn't support javascript, and so we we don't need to use the
-# asynchronous `have_current_path` matcher.
-Capybara/CurrentPathExpectation:
-  Enabled: false
-
 Rails:
   Enabled: true
 
@@ -67,6 +56,17 @@ Metrics/BlockLength:
   Exclude:
     - 'Gemfile'
     - 'spec/**/*'
+
+# Disable this so that we can use Capybara aliases like
+# 'feature' and 'scenario' for more readable tests
+RSpec/Capybara/FeatureMethods:
+  Enabled: false
+
+# We can disable this as we're using Capybara with RackTest which
+# doesn't support javascript, and so we we don't need to use the
+# asynchronous `have_current_path` matcher.
+RSpec/Capybara/CurrentPathExpectation:
+  Enabled: false
 
 RSpec/ExpectInHook:
   Exclude:

--- a/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ResponsiblePersons::AdditionalInformationController, :with_stubbe
       end
     end
 
-    context "when a notification has multiple components" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when a notification has multiple components" do
       let(:first_nano_elements) do
         [
           create(:nano_element, iupac_name: "NanoMaterial 1"), create(:nano_element, iupac_name: "NanoMaterial 2")
@@ -74,10 +74,10 @@ RSpec.describe ResponsiblePersons::AdditionalInformationController, :with_stubbe
         expect(response).to redirect_to(new_responsible_person_notification_product_image_upload_path(responsible_person, notification))
       end
 
-      context "when the notification has product images" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when the notification has product images" do
         before { notification.image_uploads.create }
 
-        context "when all components have required nano materials" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when all components have required nano materials" do
           it "redirects to the first component required nano element" do
             nano_element = first_component.nano_material.nano_elements.find(&:required?)
             get :index, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }
@@ -85,7 +85,7 @@ RSpec.describe ResponsiblePersons::AdditionalInformationController, :with_stubbe
           end
         end
 
-        context "when one component is complete" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when one component is complete" do
           let(:first_nano_elements) do
             [
               create(:nano_element, iupac_name: "Element 1A", purposes: %w[other], confirm_toxicology_notified: "yes"),

--- a/cosmetics-web/spec/controllers/component_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/component_build_controller_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe ResponsiblePersons::Wizard::ComponentBuildController, type: :cont
     end
 
     context "when selecting whether the component contains poisonous materials" do
-      context "when an answer is provided" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when an answer is provided" do
         let(:answer) { "true" }
 
         before { post(:update, params: params.merge(id: :contains_poisonous_ingredients, component: { contains_poisonous_ingredients: answer })) }
@@ -242,13 +242,13 @@ RSpec.describe ResponsiblePersons::Wizard::ComponentBuildController, type: :cont
           expect(assigns(:component).contains_poisonous_ingredients).to be(true)
         end
 
-        context "when the answer is true" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when the answer is true" do
           it "redirects to the upload formulation page" do
             expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, notification, component, :upload_formulation))
           end
         end
 
-        context "when the answer is false" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when the answer is false" do
           let(:answer) { "false" }
 
           it "redirects to the select pH range page" do

--- a/cosmetics-web/spec/controllers/formulation_upload_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/formulation_upload_controller_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
-# rubocop:todo RSpec/MultipleMemoizedHelpers
 RSpec.describe ResponsiblePersons::FormulationUploadController, :with_stubbed_antivirus, type: :controller do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:notification) { create(:notification, responsible_person: responsible_person) }
@@ -35,7 +34,7 @@ RSpec.describe ResponsiblePersons::FormulationUploadController, :with_stubbed_an
     sign_out(:submit_user)
   end
 
-  describe "GET #new" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "GET #new" do
     it "assigns the correct component model" do
       get(:new, params: params)
       expect(assigns(:component)).to eq(component)
@@ -47,7 +46,7 @@ RSpec.describe ResponsiblePersons::FormulationUploadController, :with_stubbed_an
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    context "when the notification is already submitted" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the notification is already submitted" do
       subject(:request) { get(:new, params: params) }
 
       let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
@@ -58,7 +57,7 @@ RSpec.describe ResponsiblePersons::FormulationUploadController, :with_stubbed_an
     end
   end
 
-  describe "POST #create" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "POST #create" do
     it "assigns the correct component model" do
       post(:create, params: params)
       expect(assigns(:component)).to eq(component)
@@ -95,7 +94,7 @@ RSpec.describe ResponsiblePersons::FormulationUploadController, :with_stubbed_an
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    context "when the notification is already submitted" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the notification is already submitted" do
       subject(:request) { post(:create, params: params.merge(formulation_file: pdf_file)) }
 
       let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
@@ -106,4 +105,3 @@ RSpec.describe ResponsiblePersons::FormulationUploadController, :with_stubbed_an
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/cosmetics-web/spec/controllers/nanomaterial_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/nanomaterial_build_controller_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
-# rubocop:todo RSpec/MultipleMemoizedHelpers
 RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :controller do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:notification) { create(:notification, responsible_person: responsible_person) }
@@ -34,15 +33,15 @@ RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :c
     sign_out(:submit_user)
   end
 
-  describe "GET #new" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "GET #new" do
     it "redirects to the first step of the wizard" do
       get(:new, params: params)
       expect(response).to redirect_to(responsible_person_notification_component_nanomaterial_build_path(responsible_person, notification, component, nano_element1, :select_purposes))
     end
   end
 
-  describe "GET #show" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    context "when the notification is already submitted" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "GET #show" do
+    context "when the notification is already submitted" do
       subject(:request) { get(:show, params: params.merge({ id: "confirm_usage" })) }
 
       let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
@@ -67,7 +66,7 @@ RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :c
       expect(response).to render_template(:select_purposes)
     end
 
-    describe "at wicked_finish" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "at wicked_finish" do
       it "redirects to a new nanomaterial build page, with the next nano-element, on finish" do
         get(:show, params: params.merge(id: :wicked_finish))
         expect(response).to redirect_to(new_responsible_person_notification_component_nanomaterial_build_path(responsible_person, notification, component, nano_element2))
@@ -79,7 +78,7 @@ RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :c
       end
     end
 
-    describe "at confirm_restrictions" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "at confirm_restrictions" do
       it "redirects to the non-standard nanomaterial path when nano-element purposes include 'other'" do
         nano_element1.update(purposes: %w[other])
         get(:show, params: params.merge(id: :confirm_restrictions))
@@ -88,8 +87,8 @@ RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :c
     end
   end
 
-  describe "POST #update" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    describe "at select_purposes"  do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "POST #update" do
+    describe "at select_purposes"  do
       let(:select_purposes_params) { params.merge(id: :select_purposes) }
 
       it "updates the nano-element with the selected purposes" do
@@ -113,7 +112,7 @@ RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :c
       end
     end
 
-    describe "at confirm_restrictions" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "at confirm_restrictions" do
       let(:confirm_restrictions_params) { params.merge(id: :confirm_restrictions) }
 
       it "redirects to the next page when confirm_restrictions is 'yes'" do
@@ -133,4 +132,3 @@ RSpec.describe ResponsiblePersons::Wizard::NanomaterialBuildController, type: :c
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe ResponsiblePersons::Wizard::NotificationBuildController, :with_st
         post(:update, params: params.merge(id: :add_new_component, notification_reference_number: completed_notification.reference_number, commit: "continue"))
       end
 
-      context "when only 1 valid component has been added" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when only 1 valid component has been added" do
         let(:completed_notification) { create(:notification, responsible_person: responsible_person, components: [create(:component, :with_name)]) }
 
         it "re-renders the page" do
@@ -166,7 +166,7 @@ RSpec.describe ResponsiblePersons::Wizard::NotificationBuildController, :with_st
         end
       end
 
-      context "when the product has 2 valid component" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when the product has 2 valid component" do
         let(:completed_notification) { create(:notification, responsible_person: responsible_person, components: [create(:component, name: "Component 1"), create(:component, name: "Component 2")]) }
 
         it "redirects to the wizard finish" do

--- a/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe PoisonCentres::NotificationsController, type: :controller do # rubocop:todo RSpec/MultipleMemoizedHelpers
+RSpec.describe PoisonCentres::NotificationsController, type: :controller do
   let(:responsible_person_1) { create(:responsible_person, :with_a_contact_person) }
   let(:responsible_person_2) { create(:responsible_person, :with_a_contact_person) }
 
@@ -17,12 +17,12 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do # ru
     sign_out(:search_user)
   end
 
-  describe "When signed in as a Poison Centre user" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "When signed in as a Poison Centre user" do
     before do
       sign_in_as_poison_centre_user
     end
 
-    describe "GET #index" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "GET #index" do
       before do
         rp_1_notifications
         rp_2_notifications
@@ -44,7 +44,7 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do # ru
       end
     end
 
-    describe "search on #index" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "search on #index" do
       before do
         distinct_notification
         similar_notification_one
@@ -63,7 +63,7 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do # ru
       end
     end
 
-    describe "GET #show" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "GET #show" do
       let(:notification) { rp_1_notifications.first }
       let(:reference_number) { notification.reference_number }
 
@@ -77,7 +77,7 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do # ru
         expect(response).to render_template("notifications/show_poison_centre")
       end
 
-      context "when the notification is not found" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when the notification is not found" do
         let(:reference_number) { "1234wrongreference" }
 
         it "redirects to 404 page" do
@@ -87,19 +87,19 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do # ru
     end
   end
 
-  describe "When signed in as an MSA user" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "When signed in as an MSA user" do
     before do
       sign_in_as_msa_user
     end
 
-    describe "GET #index" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "GET #index" do
       it "renders the index template" do
         get :index
         expect(response).to render_template("notifications/index")
       end
     end
 
-    describe "GET #show" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "GET #show" do
       let(:notification) { rp_1_notifications.first }
 
       before { get :show, params: { reference_number: notification.reference_number } }
@@ -108,7 +108,7 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do # ru
         expect(response).to render_template("notifications/show_msa")
       end
 
-      describe "displayed information" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      describe "displayed information" do
         let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions) }
         let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
         let(:notification) { create(:notification, :registered, :ph_values, components: [component], responsible_person: responsible_person) }
@@ -157,7 +157,7 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do # ru
         end
       end
 
-      describe "Notification with CMRS substances" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      describe "Notification with CMRS substances" do
         let(:cmr) { create(:cmr) }
         let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions, cmrs: [cmr]) }
         let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
@@ -172,18 +172,18 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do # ru
     end
   end
 
-  describe "When signed in as a Responsible Person user" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "When signed in as a Responsible Person user" do
     before do
       sign_in_as_member_of_responsible_person(responsible_person_1)
     end
 
-    describe "GET #index" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "GET #index" do
       it "redirects to invalid account" do
         expect(get(:index)).to redirect_to("/invalid-account")
       end
     end
 
-    describe "GET #show" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "GET #show" do
       it "redirects to invalid account" do
         expect(get(:show, params: { reference_number: rp_1_notifications.first.reference_number })).to redirect_to("/invalid-account")
       end

--- a/cosmetics-web/spec/controllers/product_image_upload_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/product_image_upload_controller_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
-# rubocop:todo RSpec/MultipleMemoizedHelpers
 RSpec.describe ResponsiblePersons::ProductImageUploadController, :with_stubbed_antivirus, type: :controller do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:notification) { create(:notification, responsible_person: responsible_person) }
@@ -35,7 +34,7 @@ RSpec.describe ResponsiblePersons::ProductImageUploadController, :with_stubbed_a
     sign_out(:submit_user)
   end
 
-  describe "GET #new" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "GET #new" do
     it "assigns the correct notification model" do
       get(:new, params: params)
       expect(assigns(:notification)).to eq(notification)
@@ -47,7 +46,7 @@ RSpec.describe ResponsiblePersons::ProductImageUploadController, :with_stubbed_a
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    context "when the notification is already submitted" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the notification is already submitted" do
       subject(:request) { get(:new, params: params) }
 
       let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
@@ -58,7 +57,7 @@ RSpec.describe ResponsiblePersons::ProductImageUploadController, :with_stubbed_a
     end
   end
 
-  describe "POST #create" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "POST #create" do
     it "assigns the correct notification model" do
       post(:create, params: params)
       expect(assigns(:notification)).to eq(notification)
@@ -95,7 +94,7 @@ RSpec.describe ResponsiblePersons::ProductImageUploadController, :with_stubbed_a
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    context "when the notification is already submitted" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the notification is already submitted" do
       subject(:request) { post(:create, params: params.merge(image_upload: [image_file])) }
 
       let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
@@ -106,4 +105,3 @@ RSpec.describe ResponsiblePersons::ProductImageUploadController, :with_stubbed_a
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
       expect(response).to redirect_to("http://submit/404")
     end
 
-    context "when the notification is already submitted" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the notification is already submitted" do
       subject(:request) { get(:edit, params: { responsible_person_id: responsible_person.id, reference_number: notification.reference_number }) }
 
       let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
@@ -147,7 +147,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     end
   end
 
-  describe "POST /confirm" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "POST /confirm" do
     let(:draft_notification) { create(:draft_notification, responsible_person: responsible_person) }
     let(:params) { { responsible_person_id: responsible_person.id, reference_number: draft_notification.reference_number } }
 

--- a/cosmetics-web/spec/decorators/notifications_decorator_spec.rb
+++ b/cosmetics-web/spec/decorators/notifications_decorator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NotificationsDecorator do # rubocop:todo RSpec/MultipleMemoizedHelpers
+RSpec.describe NotificationsDecorator do
   let(:date) { Time.zone.local(2020, 9, 22, 13) }
   let(:expected_csv) do
     <<~CSV
@@ -23,7 +23,7 @@ RSpec.describe NotificationsDecorator do # rubocop:todo RSpec/MultipleMemoizedHe
     notifications.each(&:cache_notification_for_csv!)
   end
 
-  describe "#to_csv" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#to_csv" do
     it "returns proper string" do
       csv = described_class.new(notifications).to_csv
 

--- a/cosmetics-web/spec/features/account/forgotten_password_spec.rb
+++ b/cosmetics-web/spec/features/account/forgotten_password_spec.rb
@@ -224,7 +224,6 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
       end
     end
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when user was invited to a responsible persons and followed the link but haven't completed their registration" do
       let(:responsible_person) { create(:responsible_person, :with_a_contact_person, name: "Responsible Person") }
       let(:invitation) do
@@ -276,7 +275,6 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
         expect(page).to have_field("Full name")
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
   end
 
   describe "for search" do

--- a/cosmetics-web/spec/features/creating_an_account_when_having_pending_responsible_person_invitations_spec.rb
+++ b/cosmetics-web/spec/features/creating_an_account_when_having_pending_responsible_person_invitations_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
-# rubocop:todo RSpec/MultipleMemoizedHelpers
 RSpec.describe "Creating an account when having pending responsible person invitations", :with_2fa, :with_stubbed_notify, :with_stubbed_mailer, type: :feature do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:responsible_person2) { create(:responsible_person, :with_a_contact_person) }
@@ -94,4 +93,3 @@ RSpec.describe "Creating an account when having pending responsible person invit
     complete_secondary_authentication_sms_with(otp_code)
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/cosmetics-web/spec/features/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/features/nanomaterial_notifications_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
   end
 
   describe "CSV download" do
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when nanomaterial notications are present", :with_stubbed_antivirus do
       let(:user_id) { submit_user.id }
       let(:rp) { responsible_person }
@@ -30,7 +29,6 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
         expect(page).to have_selector("a", text: "Download a CSV file of notified nanomaterials")
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
     scenario "CSV downloas link is invisible when no nano notifications" do
       visit "/responsible_persons/#{responsible_person.id}/nanomaterials"

--- a/cosmetics-web/spec/forms/notification_search_form_spec.rb
+++ b/cosmetics-web/spec/forms/notification_search_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHelpers
+RSpec.describe NotificationSearchForm do
   subject(:form) do
     described_class.new(q: q,
                         category: category,
@@ -47,8 +47,8 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
     }
   end
 
-  describe "form behaviour" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    context "when form fields are incorrect" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "form behaviour" do
+    context "when form fields are incorrect" do
       let(:date_exact_year) { "foo" }
       let(:date_exact_month) { "bar" }
       let(:date_exact_day) { "baz" }
@@ -67,11 +67,11 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
     end
   end
 
-  describe "#date_to_for_search" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    context "when using range" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#date_to_for_search" do
+    context "when using range" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_RANGE }
 
-      context "when date_to is invalid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when date_to is invalid" do
         let(:date_to_month) { nil }
 
         it "is nil" do
@@ -79,7 +79,7 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
         end
       end
 
-      context "when date_to is empty" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when date_to is empty" do
         let(:date_to) { nil }
 
         it "is nil" do
@@ -87,21 +87,21 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
         end
       end
 
-      context "when using date range" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when using date range" do
         it "is returned properly" do
           expect(form.date_to_for_search).to eq Date.new(2021, 6, 15)
         end
       end
     end
 
-    context "when using exact date" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when using exact date" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_EXACT }
 
       it "is returned properly" do
         expect(form.date_to_for_search).to eq Date.new(2021, 6, 13)
       end
 
-      context "when date_exact is invalid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when date_exact is invalid" do
         let(:date_exact_month) { nil }
 
         it "is nil" do
@@ -109,7 +109,7 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
         end
       end
 
-      context "when date_exact is empty" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when date_exact is empty" do
         let(:date_exact) { nil }
 
         it "is nil" do
@@ -119,11 +119,11 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
     end
   end
 
-  describe "#date_from_for_search" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    context "when using range" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#date_from_for_search" do
+    context "when using range" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_RANGE }
 
-      context "when date_from is invalid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when date_from is invalid" do
         let(:date_from_month) { nil }
 
         it "is nil" do
@@ -131,7 +131,7 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
         end
       end
 
-      context "when date_from is empty" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when date_from is empty" do
         let(:date_from) { nil }
 
         it "is nil" do
@@ -139,21 +139,21 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
         end
       end
 
-      context "when using date range" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when using date range" do
         it "is returned properly" do
           expect(form.date_from_for_search).to eq Date.new(2021, 6, 10)
         end
       end
     end
 
-    context "when using exact date" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when using exact date" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_EXACT }
 
       it "is returned properly" do
         expect(form.date_from_for_search).to eq Date.new(2021, 6, 13)
       end
 
-      context "when date_exact is invalid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when date_exact is invalid" do
         let(:date_exact_month) { nil }
 
         it "is nil" do
@@ -161,7 +161,7 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
         end
       end
 
-      context "when date_exact is empty" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when date_exact is empty" do
         let(:date_exact) { nil }
 
         it "is nil" do
@@ -171,17 +171,17 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
     end
   end
 
-  describe "validations" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "validations" do
     before { form.valid? }
 
-    context "when dates are correct" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when dates are correct" do
       it "is valid" do
         expect(form).to be_valid
       end
     end
 
-    context "when all date fields are blank" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-      context "when using date range" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when all date fields are blank" do
+      context "when using date range" do
         let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_RANGE }
 
         let(:date_from_year) { nil }
@@ -195,7 +195,7 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
           expect(form).not_to be_valid
         end
 
-        context "when any field is present" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when any field is present" do
           let(:date_from_day) { "12" }
 
           it "is invalid" do
@@ -204,20 +204,20 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
         end
       end
 
-      context "when using date exact" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when using date exact" do
         let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_EXACT }
 
         let(:date_exact_year) { "" }
         let(:date_exact_month) { "" }
         let(:date_exact_day) { "" }
 
-        context "when all fields are empty" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when all fields are empty" do
           it "is valid" do
             expect(form).not_to be_valid
           end
         end
 
-        context "when any field is present" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when any field is present" do
           let(:date_exact_day) { "12" }
 
           it "is invalid" do
@@ -228,118 +228,118 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
       end
     end
 
-    shared_examples_for "date validation with missing field" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    shared_examples_for "date validation with missing field" do
       it "has error" do
         expect(form.errors[field]).to be_present
       end
     end
 
-    context "when using exact date" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when using exact date" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_EXACT }
       let(:field)       { :date_exact }
 
-      context "when year is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when year is missing" do
         include_examples "date validation with missing field" do
           let(:date_exact_year) { nil }
         end
       end
 
-      context "when month is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when month is missing" do
         include_examples "date validation with missing field" do
           let(:date_exact_month) { nil }
         end
       end
 
-      context "when day is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when day is missing" do
         include_examples "date validation with missing field" do
           let(:date_exact_day) { nil }
         end
       end
 
-      context "when month is incorrect" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when month is incorrect" do
         include_examples "date validation with missing field" do
           let(:date_exact_month) { "13" }
         end
       end
 
-      context "when day is incorrect" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when day is incorrect" do
         include_examples "date validation with missing field" do
           let(:date_exact_day) { "32" }
         end
       end
     end
 
-    context "when using from date" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when using from date" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_RANGE }
       let(:field)       { :date_from }
 
-      context "when year is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when year is missing" do
         include_examples "date validation with missing field" do
           let(:date_from_year) { nil }
         end
       end
 
-      context "when month is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when month is missing" do
         include_examples "date validation with missing field" do
           let(:date_from_month) { nil }
         end
       end
 
-      context "when day is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when day is missing" do
         include_examples "date validation with missing field" do
           let(:date_from_day) { nil }
         end
       end
 
-      context "when month is incorrect" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when month is incorrect" do
         include_examples "date validation with missing field" do
           let(:date_from_month) { "13" }
         end
       end
 
-      context "when day is incorrect" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when day is incorrect" do
         include_examples "date validation with missing field" do
           let(:date_from_day) { "32" }
         end
       end
     end
 
-    context "when using to date" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when using to date" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_RANGE }
       let(:field)       { :date_to }
 
-      context "when year is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when year is missing" do
         include_examples "date validation with missing field" do
           let(:date_to_year) { nil }
         end
       end
 
-      context "when month is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when month is missing" do
         include_examples "date validation with missing field" do
           let(:date_to_month) { nil }
         end
       end
 
-      context "when day is missing" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when day is missing" do
         include_examples "date validation with missing field" do
           let(:date_to_day) { nil }
         end
       end
 
-      context "when month is incorrect" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when month is incorrect" do
         include_examples "date validation with missing field" do
           let(:date_to_month) { "13" }
         end
       end
 
-      context "when day is incorrect" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when day is incorrect" do
         include_examples "date validation with missing field" do
           let(:date_to_day) { "32" }
         end
       end
     end
 
-    context "when from date is later than to date" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when from date is later than to date" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_RANGE }
 
       let(:date_from_day) { "18" }
@@ -349,7 +349,7 @@ RSpec.describe NotificationSearchForm do # rubocop:todo RSpec/MultipleMemoizedHe
       end
     end
 
-    context "when from date is equal than to date" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when from date is equal than to date" do
       let(:date_filter) { NotificationSearchForm::FILTER_BY_DATE_RANGE }
 
       let(:date_from_day) { date_to_day }

--- a/cosmetics-web/spec/forms/registration/account_security_form_spec.rb
+++ b/cosmetics-web/spec/forms/registration/account_security_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/MultipleMemoizedHelpers
+RSpec.describe Registration::AccountSecurityForm do
   let(:full_name) { "Mr New Name" }
   let(:password) { "testpassword" }
   let(:mobile_number) { "07000 000 000" }
@@ -24,12 +24,12 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
   end
 
   # rubocop:disable RSpec/ExampleLength
-  describe "#update!" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#update!" do
     let(:user) do
       create(:submit_user, :confirmed_not_verified, :invited, name: nil)
     end
 
-    shared_examples "security attributes set" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    shared_examples "security attributes set" do
       it "sets the user security attributes" do
         expect {
           form.update!
@@ -40,7 +40,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
       end
     end
 
-    shared_examples "confirmation token removal" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    shared_examples "confirmation token removal" do
       it "removes the user confirmation token info" do
         expect {
           form.update!
@@ -50,8 +50,8 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
       end
     end
 
-    context "when the form attributes are valid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-      context "when both sms and app authentication are selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the form attributes are valid" do
+      context "when both sms and app authentication are selected" do
         include_examples "security attributes set"
         include_examples "confirmation token removal"
 
@@ -66,7 +66,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
         end
       end
 
-      context "when only the app authentication is selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when only the app authentication is selected" do
         before do
           form.assign_attributes(app_authentication: "1", sms_authentication: "0")
         end
@@ -85,7 +85,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
         end
       end
 
-      context "when only the sms authentication is selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when only the sms authentication is selected" do
         before do
           form.assign_attributes(app_authentication: "0", sms_authentication: "1")
         end
@@ -105,7 +105,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
       end
     end
 
-    context "when the form attributes are not valid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the form attributes are not valid" do
       before { form.password = "" }
 
       it "returns false" do
@@ -130,7 +130,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
   end
   # rubocop:enable RSpec/ExampleLength
 
-  describe "#secret_key" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#secret_key" do
     it "returns secret key if is already set" do
       expect(form.secret_key).to eq secret_key
     end
@@ -142,14 +142,14 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
     end
   end
 
-  describe "#decorated_secret_key" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#decorated_secret_key" do
     it "introduces a space between every 4 characters of the form secret key" do
       form.secret_key = "QSE5PUJFT4ZGTBRPGOOOW3QJWWVZNUP7"
       expect(form.decorated_secret_key).to eq "QSE5 PUJF T4ZG TBRP GOOO W3QJ WWVZ NUP7"
     end
   end
 
-  describe "#app_authentication_code" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#app_authentication_code" do
     before { form.app_authentication_code = "123456" }
 
     it "discards the app authentication code when the app authentication is not selected" do
@@ -163,7 +163,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
     end
   end
 
-  describe "#mobile_number" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#mobile_number" do
     before { form.mobile_number = "07123456789" }
 
     it "discards the mobile number when the sms authentication is not selected" do
@@ -177,8 +177,8 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
     end
   end
 
-  describe "validations" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    context "when the password is too short" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "validations" do
+    context "when the password is too short" do
       let(:password) { "Fo)ba5" }
 
       it "is invalid" do
@@ -191,7 +191,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
       end
     end
 
-    context "when password is too common" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when password is too common" do
       let(:password) { "password" }
 
       it "does not validate user" do
@@ -200,7 +200,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
       end
     end
 
-    describe "name validations" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "name validations" do
       let(:form) do
         described_class.new(password: password,
                             mobile_number: mobile_number,
@@ -210,7 +210,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
                             sms_authentication: "1")
       end
 
-      context "when the user name is not introduced" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when the user name is not introduced" do
         let(:full_name) { nil }
 
         it "is invalid" do
@@ -223,7 +223,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
         end
       end
 
-      context "when a user name containing a URL is introduced" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a user name containing a URL is introduced" do
         let(:full_name) { "Susan www.example.com" }
 
         it "is invalid" do
@@ -236,7 +236,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
         end
       end
 
-      context "when a very long user name is introduced" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a very long user name is introduced" do
         let(:full_name) { "Susan thisisaveryveryveryveryveryveryveryveryveryveryveryveryveryverylongsurname" }
 
         it "is invalid" do
@@ -249,7 +249,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
         end
       end
 
-      context "when a valid user name is introduced" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a valid user name is introduced" do
         let(:full_name) { "John Doe" }
 
         it "is valid" do
@@ -263,7 +263,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
       end
     end
 
-    describe "app authentication methods validations" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "app authentication methods validations" do
       it "is valid when sms is selected" do
         form.sms_authentication = "1"
         form.app_authentication = "0"
@@ -294,11 +294,11 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
       end
     end
 
-    describe "mobile number validations" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-      context "when the sms authentication is selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "mobile number validations" do
+      context "when the sms authentication is selected" do
         before { form.sms_authentication = "1" }
 
-        shared_examples "mobile number" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        shared_examples "mobile number" do
           it "is invalid" do
             expect(form).not_to be_valid
           end
@@ -309,21 +309,21 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
           end
         end
 
-        context "when the mobile number is empty" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when the mobile number is empty" do
           include_examples "mobile number" do
             let(:mobile_number) { "" }
             let(:message) { "Enter a mobile number, like 07700 900 982 or +44 7700 900 982" }
           end
         end
 
-        context "when mobile number has letters" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when mobile number has letters" do
           include_examples "mobile number" do
             let(:mobile_number) { "070000assd" }
             let(:message) { "Enter a mobile number, like 07700 900 982 or +44 7700 900 982" }
           end
         end
 
-        context "when mobile number has not enough characters" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when mobile number has not enough characters" do
           include_examples "mobile number" do
             let(:mobile_number) { "0700710120" }
             let(:message) { "Enter a mobile number, like 07700 900 982 or +44 7700 900 982" }
@@ -331,7 +331,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
         end
       end
 
-      context "when the sms authentication is not selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when the sms authentication is not selected" do
         before { form.sms_authentication = "0" }
 
         it "does not require mobile number" do
@@ -348,8 +348,8 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
       end
     end
 
-    describe "app authentication code validations" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-      context "when the app authentication is selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "app authentication code validations" do
+      context "when the app authentication is selected" do
         before { form.app_authentication = "1" }
 
         it "fails validation when the app authentication code is not present" do
@@ -377,7 +377,7 @@ RSpec.describe Registration::AccountSecurityForm do # rubocop:todo RSpec/Multipl
         end
       end
 
-      context "when the app authentication is not selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when the app authentication is not selected" do
         before { form.app_authentication = "0" }
 
         it "does not require the app authentication code" do

--- a/cosmetics-web/spec/forms/responsible_persons/details_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/details_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleMemoizedHelpers
+RSpec.describe ResponsiblePersons::DetailsForm do
   subject(:form) do
     described_class.new(user: user,
                         name: name,
@@ -19,8 +19,8 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
   let(:county) { "London" }
   let(:postal_code) { "EC1 2PE" }
 
-  describe "#valid?" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    context "when the name is blank" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#valid?" do
+    context "when the name is blank" do
       let(:name) { "" }
 
       before { form.validate }
@@ -34,7 +34,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    context "when the name contains invalid symbols" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the name contains invalid symbols" do
       let(:name) { "<Responsible Person Name>" }
 
       it "is invalid" do
@@ -47,7 +47,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    context "when the name exceeds the allowed length" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the name exceeds the allowed length" do
       let(:name) { "a" * 251 }
 
       it "is invalid" do
@@ -60,7 +60,6 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when the name is the same as another RP name where the user belongs to" do
       let(:user) { create(:submit_user) }
 
@@ -78,9 +77,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
         expect(form.errors.full_messages).to eq(["You are already associated with #{name}"])
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when the name is the same with casing and leading/trailing spacing differences as another RP name where the user belongs to" do
       let(:user) { create(:submit_user) }
       let(:name) { " RESP Person Name " }
@@ -99,9 +96,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
         expect(form.errors.full_messages).to eq(["You are already associated with #{name.strip}"])
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when the name is the same as another RP name where the user has an active invitation for" do
       let(:user) { create(:submit_user) }
 
@@ -120,9 +115,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
           .to eq(["You have already been invited to join #{name}. Check your email inbox for your invite"])
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when the name is the same with casing and leading/trailing spacing differences as another RP name where the user has an active invitation for" do
       let(:user) { create(:submit_user) }
       let(:name) { " RESP Person Name " }
@@ -142,9 +135,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
           .to eq(["You have already been invited to join #{name.strip}. Check your email inbox for your invite"])
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when the name is the same as another RP name where the user has an expired invitation for" do
       let(:user) { create(:submit_user) }
 
@@ -162,9 +153,8 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
         expect(form.errors.full_messages).to be_empty
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-    context "when the first address line is blank" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the first address line is blank" do
       let(:address_line_1) { "" }
 
       before { form.validate }
@@ -178,7 +168,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    context "when the second address line is blank" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the second address line is blank" do
       let(:address_line_2) { "" }
 
       before { form.validate }
@@ -192,7 +182,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    context "when the city is blank" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the city is blank" do
       let(:city) { "" }
 
       before { form.validate }
@@ -206,7 +196,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    context "when the county is blank" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the county is blank" do
       let(:county) { "" }
 
       before { form.validate }
@@ -220,7 +210,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    context "when the postal code is blank" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the postal code is blank" do
       let(:postal_code) { "" }
 
       before { form.validate }
@@ -234,7 +224,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    context "when the postal code does not belong to UK" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the postal code does not belong to UK" do
       let(:postal_code) { "JJJJJ" }
 
       before { form.validate }
@@ -248,7 +238,7 @@ RSpec.describe ResponsiblePersons::DetailsForm do # rubocop:todo RSpec/MultipleM
       end
     end
 
-    context "when the postal code does contains leading/trailing spaces" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when the postal code does contains leading/trailing spaces" do
       let(:postal_code) { " EC1 2PE " }
 
       before { form.validate }

--- a/cosmetics-web/spec/helpers/application_helper_spec.rb
+++ b/cosmetics-web/spec/helpers/application_helper_spec.rb
@@ -56,7 +56,7 @@ describe ApplicationHelper do
     end
 
     context "when providing a list with attributes order" do
-      context "with all the attributes defined in the order" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "with all the attributes defined in the order" do
         let(:order) { %i[mobile_number email name] }
 
         it "generates the error summary with an ordered and formatted list of errors" do
@@ -67,7 +67,7 @@ describe ApplicationHelper do
         end
       end
 
-      context "when some attribute is missing in the order" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when some attribute is missing in the order" do
         let(:order) { %i[mobile_number name] }
 
         it "adds the attribute errors after the ordered ones" do
@@ -78,7 +78,7 @@ describe ApplicationHelper do
         end
       end
 
-      context "when the order includes attributes without errors" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when the order includes attributes without errors" do
         let(:order) { %i[bar name foo mobile_number email] }
 
         it "ignores them and respects the order for the attributes with errors" do

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Component, type: :model do
   end
 
   describe "name validation" do
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when there is already a component with the same name for the same notification" do
       let(:component) { described_class.new(name: "Component X", notification: notification) }
 
@@ -42,9 +41,7 @@ RSpec.describe Component, type: :model do
         expect(component.errors[:name]).to eql(["You’ve already told us about an item called ‘Component X’"])
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when there is already a component with the same name but using uppercase for the same notification" do
       let(:component) { described_class.new(name: "Component X", notification: notification) }
 
@@ -61,9 +58,7 @@ RSpec.describe Component, type: :model do
         expect(component.errors[:name]).to eql(["You’ve already told us about an item called ‘Component X’"])
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "when there is already a component with no name for the same notification" do
       let(:component) { described_class.new(name: nil, notification: notification) }
 
@@ -75,7 +70,6 @@ RSpec.describe Component, type: :model do
         expect(component).to be_valid
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
   end
 
   describe "formulation_required", :with_stubbed_antivirus do
@@ -388,7 +382,7 @@ RSpec.describe Component, type: :model do
   end
 
   describe "#nano_material_required?" do
-    context "when there is no nanomaterial" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when there is no nanomaterial" do
       let(:component) { build(:component) }
 
       it "does not require nano material information" do
@@ -396,18 +390,18 @@ RSpec.describe Component, type: :model do
       end
     end
 
-    context "when there is a nano material" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when there is a nano material" do
       let(:first_nano_element) { build(:nano_element) }
       let(:nano_material) { build(:nano_material, nano_elements: [first_nano_element]) }
       let(:component) { build(:component, nano_material: nano_material) }
 
-      context "when a nano element requires information" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a nano element requires information" do
         it "requires more information the nano_material" do
           expect(component).to be_nano_material_required
         end
       end
 
-      context "when a nano element does not require information" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a nano element does not require information" do
         let(:first_nano_element) { build(:nano_element, confirm_toxicology_notified: "yes", purposes: %w[other]) }
 
         it "requires nano material information" do
@@ -417,7 +411,7 @@ RSpec.describe Component, type: :model do
     end
   end
 
-  describe "#poisonous_ingredients_answer" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#poisonous_ingredients_answer" do
     let(:component) { build(:component) }
 
     it "returns nil if contains_poisonous_ingredients is nil" do

--- a/cosmetics-web/spec/models/secondary_authentication/direct_otp_spec.rb
+++ b/cosmetics-web/spec/models/secondary_authentication/direct_otp_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SecondaryAuthentication::DirectOtp do # rubocop:todo RSpec/MultipleMemoizedHelpers
+RSpec.describe SecondaryAuthentication::DirectOtp do
   let(:attempts) { 0 }
   let(:direct_otp) { "11111" }
   let(:direct_otp_sent_at) { Time.zone.now }
@@ -8,7 +8,7 @@ RSpec.describe SecondaryAuthentication::DirectOtp do # rubocop:todo RSpec/Multip
   let(:user) { create(:submit_user, second_factor_attempts_count: attempts, direct_otp_sent_at: direct_otp_sent_at, second_factor_attempts_locked_at: second_factor_attempts_locked_at, direct_otp: direct_otp) }
   let(:secondary_authentication) { described_class.new(user) }
 
-  describe "#valid_otp?" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#valid_otp?" do
     it "increase attempts when checking code" do
       expect {
         secondary_authentication.valid_otp? "123"
@@ -19,7 +19,7 @@ RSpec.describe SecondaryAuthentication::DirectOtp do # rubocop:todo RSpec/Multip
       expect(secondary_authentication).to be_valid_otp(user.reload.direct_otp)
     end
 
-    context "when maximum attempts exceeded" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when maximum attempts exceeded" do
       let(:attempts) { 11 }
 
       before do
@@ -61,14 +61,14 @@ RSpec.describe SecondaryAuthentication::DirectOtp do # rubocop:todo RSpec/Multip
       end
     end
 
-    context "when using WHITELISTED_2FA_CODE env" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-      shared_examples_for "successful auth" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when using WHITELISTED_2FA_CODE env" do
+      shared_examples_for "successful auth" do
         specify do
           expect(secondary_authentication).to be_valid_otp(whitelisted_otp)
         end
       end
 
-      shared_examples_for "failed auth" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      shared_examples_for "failed auth" do
         specify do
           expect(secondary_authentication).not_to be_valid_otp(whitelisted_otp)
         end
@@ -87,17 +87,17 @@ RSpec.describe SecondaryAuthentication::DirectOtp do # rubocop:todo RSpec/Multip
         allow(Rails.configuration).to receive(:vcap_application).and_return(vcap_application)
       end
 
-      context "when ENV['VCAP_APPLICATION'] doesn't exist" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when ENV['VCAP_APPLICATION'] doesn't exist" do
         it_behaves_like "failed auth"
       end
 
-      context "when ENV['VCAP_APPLICATION'] is string" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when ENV['VCAP_APPLICATION'] is string" do
         let(:vcap_application) { "foo" }
 
         it_behaves_like "failed auth"
       end
 
-      context "when ENV['VCAP_APPLICATION'] is empty hash" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when ENV['VCAP_APPLICATION'] is empty hash" do
         let(:vcap_application) do
           {}.to_json
         end
@@ -105,7 +105,6 @@ RSpec.describe SecondaryAuthentication::DirectOtp do # rubocop:todo RSpec/Multip
         it_behaves_like "failed auth"
       end
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when ENV['VCAP_APPLICATION'] does not have application_uris key" do
         let(:vcap_application) do
           { "foo" => "bar" }.to_json
@@ -113,33 +112,25 @@ RSpec.describe SecondaryAuthentication::DirectOtp do # rubocop:todo RSpec/Multip
 
         it_behaves_like "failed auth"
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when ENV['VCAP_APPLICATION'] application_uris key is string" do
         let(:application_uris) { "foo" }
 
         it_behaves_like "failed auth"
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when ENV['VCAP_APPLICATION'] application_uris key is empty array" do
         let(:application_uris) { [] }
 
         it_behaves_like "failed auth"
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when ENV['VCAP_APPLICATION'] application_uris doesn't fit allowed url" do
         let(:application_uris) { %w[foo] }
 
         it_behaves_like "failed auth"
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when ENV['VCAP_APPLICATION'] application_uris has more than 2 values" do
         let(:application_uris) do
           ["staging-submit.cosmetic-product-notifications.service.gov.uk",
@@ -149,40 +140,33 @@ RSpec.describe SecondaryAuthentication::DirectOtp do # rubocop:todo RSpec/Multip
 
         it_behaves_like "failed auth"
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when ENV['VCAP_APPLICATION'] application_uris is production url" do
         let(:application_uris) { ["submit.cosmetic-product-notifications.service.gov.uk"] }
 
         it_behaves_like "failed auth"
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when ENV['VCAP_APPLICATION'] application_uris is staging url" do
         let(:application_uris) { ["staging-submit.cosmetic-product-notifications.service.gov.uk"] }
 
         it_behaves_like "successful auth"
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when ENV['VCAP_APPLICATION'] application_uris is review app url" do
         let(:application_uris) { ["cosmetics-pr-1730-submit-web.london.cloudapps.digital"] }
 
         it_behaves_like "successful auth"
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
     end
   end
 
-  describe "#otp_locked?" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#otp_locked?" do
     it "returns false when second_factor_attempts_locked_at is empty" do
       expect(secondary_authentication.otp_locked?).to eq(false)
     end
 
-    context "when second_factor_attempts_locked_at is not empty" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when second_factor_attempts_locked_at is not empty" do
       let(:second_factor_attempts_locked_at) { Time.zone.now }
 
       it "returns true" do

--- a/cosmetics-web/spec/models/user/new_email_concern_spec.rb
+++ b/cosmetics-web/spec/models/user/new_email_concern_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe User, type: :model do # rubocop:todo RSpec/FilePath
       travel_back
     end
 
-    describe "#new_email_pending_confirmation!" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe "#new_email_pending_confirmation!" do
       let(:user) { create(:submit_user, email: old_email) }
       let(:mailer) { double }
 
@@ -25,7 +25,7 @@ RSpec.describe User, type: :model do # rubocop:todo RSpec/FilePath
         allow(mailer).to receive(:deliver_later)
       end
 
-      context "when successful" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when successful" do
         it "saves email" do
           expect {
             user.new_email_pending_confirmation!(new_email)
@@ -53,8 +53,8 @@ RSpec.describe User, type: :model do # rubocop:todo RSpec/FilePath
         end
       end
 
-      context "with validation errors" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-        shared_examples "invalid email" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "with validation errors" do
+        shared_examples "invalid email" do
           specify do
             expect {
               user.new_email_pending_confirmation!(new_email)
@@ -62,19 +62,19 @@ RSpec.describe User, type: :model do # rubocop:todo RSpec/FilePath
           end
         end
 
-        context "when email is empty" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when email is empty" do
           let(:new_email) { "" }
 
           include_examples "invalid email"
         end
 
-        context "when email is missing domain" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when email is missing domain" do
           let(:new_email) { "foo@bar" }
 
           include_examples "invalid email"
         end
 
-        context "when email is incorrect" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when email is incorrect" do
           let(:new_email) { "foo.bar.com" }
 
           include_examples "invalid email"
@@ -82,8 +82,8 @@ RSpec.describe User, type: :model do # rubocop:todo RSpec/FilePath
       end
     end
 
-    describe ".confirm_new_email!(token)" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-      shared_examples "invalid token" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    describe ".confirm_new_email!(token)" do
+      shared_examples "invalid token" do
         it "does not change email" do
           begin
             described_class.confirm_new_email!(token)
@@ -112,7 +112,7 @@ RSpec.describe User, type: :model do # rubocop:todo RSpec/FilePath
         allow(mailer).to receive(:deliver_later)
       end
 
-      context "when token is valid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when token is valid" do
         let(:token) { expected_token }
 
         it "changes email successfully" do
@@ -132,13 +132,13 @@ RSpec.describe User, type: :model do # rubocop:todo RSpec/FilePath
         end
       end
 
-      context "when token is invalid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when token is invalid" do
         let(:token) { "wrong-token" }
 
         include_examples "invalid token"
       end
 
-      context "when token is expired" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when token is expired" do
         let(:token) { expected_token }
 
         before do

--- a/cosmetics-web/spec/requests/assets_security_spec.rb
+++ b/cosmetics-web/spec/requests/assets_security_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Asset security", type: :request do
     end
   end
 
-  context "when using representations proxy controller" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  context "when using representations proxy controller" do
     # /rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)      active_storage/representations/proxy#show
     let(:image_upload) do
       create(:image_upload,
@@ -51,7 +51,7 @@ RSpec.describe "Asset security", type: :request do
                                            variation_key: image_variant.variation.key)
     end
 
-    context "when user is submit user" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when user is submit user" do
       let(:other_responsible_person) { create(:responsible_person, :with_a_contact_person) }
 
       let(:submitted_nanomaterial_notification) { create(:nanomaterial_notification, :submitted, responsible_person: responsible_person) }
@@ -60,7 +60,7 @@ RSpec.describe "Asset security", type: :request do
         configure_requests_for_submit_domain
       end
 
-      context "when user is not logged in" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when user is not logged in" do
         it "raises exception" do
           expect {
             get asset_url
@@ -68,7 +68,6 @@ RSpec.describe "Asset security", type: :request do
         end
       end
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when logged as responsible person that is notification owner" do
         before do
           sign_in_as_member_of_responsible_person(responsible_person)
@@ -84,9 +83,8 @@ RSpec.describe "Asset security", type: :request do
           expect(response.status).to eq(200)
         end
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      context "when logged as different responsible person" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when logged as different responsible person" do
         before do
           sign_in_as_member_of_responsible_person(other_responsible_person)
         end
@@ -103,14 +101,14 @@ RSpec.describe "Asset security", type: :request do
       end
     end
 
-    context "when user is search user" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when user is search user" do
       let(:search_user) { create(:poison_centre_user) }
 
       before do
         configure_requests_for_search_domain
       end
 
-      context "when user is not logged in" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when user is not logged in" do
         it "redirects" do
           expect {
             get asset_url
@@ -118,7 +116,7 @@ RSpec.describe "Asset security", type: :request do
         end
       end
 
-      context "when user is logged in" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when user is logged in" do
         before do
           sign_in search_user
         end
@@ -139,7 +137,7 @@ RSpec.describe "Asset security", type: :request do
   context "when using blob asset proxy" do
     let(:asset_url) { rails_storage_proxy_path(image_upload.file) }
 
-    context "when user is submit user" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when user is submit user" do
       let(:other_responsible_person) { create(:responsible_person, :with_a_contact_person) }
 
       let(:submitted_nanomaterial_notification) { create(:nanomaterial_notification, :submitted, responsible_person: responsible_person) }
@@ -148,7 +146,7 @@ RSpec.describe "Asset security", type: :request do
         configure_requests_for_submit_domain
       end
 
-      context "when user is not logged in" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when user is not logged in" do
         it "raises exception" do
           expect {
             get asset_url
@@ -156,7 +154,6 @@ RSpec.describe "Asset security", type: :request do
         end
       end
 
-      # rubocop:todo RSpec/MultipleMemoizedHelpers
       context "when logged as responsible person that is notification owner" do
         before do
           sign_in_as_member_of_responsible_person(responsible_person)
@@ -172,9 +169,8 @@ RSpec.describe "Asset security", type: :request do
           expect(response.status).to eq(200)
         end
       end
-      # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-      context "when logged as different responsible person" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when logged as different responsible person" do
         before do
           sign_in_as_member_of_responsible_person(other_responsible_person)
         end
@@ -191,14 +187,14 @@ RSpec.describe "Asset security", type: :request do
       end
     end
 
-    context "when user is search user" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when user is search user" do
       let(:search_user) { create(:poison_centre_user) }
 
       before do
         configure_requests_for_search_domain
       end
 
-      context "when user is not logged in" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when user is not logged in" do
         it "redirects" do
           expect {
             get asset_url
@@ -206,7 +202,7 @@ RSpec.describe "Asset security", type: :request do
         end
       end
 
-      context "when user is logged in" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when user is logged in" do
         before do
           sign_in search_user
         end

--- a/cosmetics-web/spec/requests/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/requests/nanomaterial_notifications_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
     end
   end
 
-  describe "GET /responsible_persons/:id/nanomaterials.csv" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "GET /responsible_persons/:id/nanomaterials.csv" do
     let(:rp) { responsible_person }
     let(:expected_csv) do
       <<~CSV
@@ -258,7 +258,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
     context "when the user has access and notification is submittable" do
       let(:nanomaterial_notification) { create(:nanomaterial_notification, :submittable, responsible_person: responsible_person, name: "Previous name") }
 
-      context "with a valid new name" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "with a valid new name" do
         let(:name) { "Updated name" }
 
         it "redirects to the Check your answers page" do
@@ -270,7 +270,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         end
       end
 
-      context "with no new name given" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "with no new name given" do
         let(:name) { "" }
 
         it "renders the page" do
@@ -286,7 +286,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
     context "when the user has access but EU question not yet answered" do
       let(:nanomaterial_notification) { create(:nanomaterial_notification, responsible_person: responsible_person, name: "Previous name", eu_notified: nil) }
 
-      context "with a valid new name" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "with a valid new name" do
         let(:name) { "Updated name" }
 
         it "redirects to the EU notification question page" do
@@ -362,7 +362,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         patch "/nanomaterials/#{nanomaterial_notification.id}/notified_to_eu", params: nanomaterial_params
       end
 
-      context "when a valid pre-Brexit date is entered" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a valid pre-Brexit date is entered" do
         let(:nanomaterial_params) do
           {
             eu_notified: "true",
@@ -379,7 +379,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         end
       end
 
-      context "when the EU wasn’t notified" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when the EU wasn’t notified" do
         let(:nanomaterial_params) do
           {
             eu_notified: "false",
@@ -391,7 +391,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         end
       end
 
-      context "when no answer was selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when no answer was selected" do
         let(:nanomaterial_params) { {} }
 
         it "renders an error page" do
@@ -399,7 +399,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         end
       end
 
-      context "when a an invalid date is entered" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a an invalid date is entered" do
         let(:nanomaterial_params) do
           {
             eu_notified: "true",
@@ -428,7 +428,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         patch "/nanomaterials/#{nanomaterial_notification.id}/notified_to_eu", params: nanomaterial_params
       end
 
-      context "when a valid answer is given" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a valid answer is given" do
         let(:nanomaterial_params) { { eu_notified: "false" } }
 
         it "redirects to the Check your answers page" do
@@ -514,7 +514,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         patch "/nanomaterials/#{nanomaterial_notification.id}/file", params: params
       end
 
-      context "when a file is selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when a file is selected" do
         let(:file) { Rack::Test::UploadedFile.new("spec/fixtures/files/testPdf.pdf", "application/pdf", true) }
         let(:params) { { nanomaterial_notification: { file: file } } }
 
@@ -523,7 +523,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         end
       end
 
-      context "when no file is selected" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when no file is selected" do
         let(:params) { {} }
 
         it "is renders a page" do

--- a/cosmetics-web/spec/requests/responsible_persons/delete_notification_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/delete_notification_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
-# rubocop:todo RSpec/MultipleMemoizedHelpers
 RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubbed_notify, type: :request do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
   let(:user) { build(:submit_user, :with_sms_secondary_authentication) }
@@ -11,7 +10,7 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
   let(:draft_notification) { create(:draft_notification, responsible_person: responsible_person) }
   let(:notification) { create(:registered_notification, responsible_person: responsible_person) }
 
-  context "when deleting notification user notification" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  context "when deleting notification user notification" do
     before do
       sign_in_as_member_of_responsible_person(responsible_person, user)
     end
@@ -37,7 +36,7 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
       }.to change(Notification.deleted, :count).from(0).to(1)
     end
 
-    context "when 2FA time passed", :with_2fa do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when 2FA time passed", :with_2fa do
       before do
         get delete_responsible_person_delete_notification_url(responsible_person, draft_notification)
         post secondary_authentication_sms_url,
@@ -71,7 +70,7 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
     end
   end
 
-  context "when deleting notification that belongs to other user" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  context "when deleting notification that belongs to other user" do
     before do
       sign_in_as_member_of_responsible_person(other_responsible_person, user)
     end
@@ -83,4 +82,3 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/cosmetics-web/spec/requests/responsible_persons/edit_address_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/edit_address_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Edit Responsible Person Address", type: :request do
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    context "when providing the needed data" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when providing the needed data" do
       let(:update_request) { put "/responsible_persons/#{responsible_person.id}", params: { responsible_person: params } }
 
       it "redirects to the responsible person page" do

--- a/cosmetics-web/spec/requests/responsible_persons/invitations_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/invitations_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Responsible Person user invitations", :with_stubbed_notify, type
     sign_out(:submit_user)
   end
 
-  describe "Creating an invitation" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "Creating an invitation" do
     let(:params) { { responsible_person_id: responsible_person.id } }
     let(:name) { "John Doe" }
     let(:email_address) { "user@example.com" }

--- a/cosmetics-web/spec/requests/secondary_authentication/sms_spec.rb
+++ b/cosmetics-web/spec/requests/secondary_authentication/sms_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Secondary Authentication with SMS submit", :with_2fa, :with_stub
     end
   end
 
-  describe "#create" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "#create" do
     subject(:submit_2fa) do
       post secondary_authentication_sms_path,
            params: { otp_code: submitted_code, user_id: user.id }
@@ -71,7 +71,7 @@ RSpec.describe "Secondary Authentication with SMS submit", :with_2fa, :with_stub
       sign_in(user)
     end
 
-    shared_examples_for "code not accepted" do |*errors| # rubocop:todo RSpec/MultipleMemoizedHelpers
+    shared_examples_for "code not accepted" do |*errors|
       it "does not leave the two factor form page" do
         submit_2fa
         expect(response).to render_template(:new)
@@ -85,13 +85,13 @@ RSpec.describe "Secondary Authentication with SMS submit", :with_2fa, :with_stub
       end
     end
 
-    context "when code is invalid" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when code is invalid" do
       let(:submitted_code) { "" }
 
       include_examples "code not accepted", "Enter the security code"
     end
 
-    context "with correct otp" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "with correct otp" do
       it "redirects to the main page" do
         submit_2fa
         expect(response).to redirect_to(submit_root_path)
@@ -111,30 +111,30 @@ RSpec.describe "Secondary Authentication with SMS submit", :with_2fa, :with_stub
       end
     end
 
-    context "with incorrect otp" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "with incorrect otp" do
       let(:submitted_code) { secondary_authentication.direct_otp.reverse }
 
       include_examples "code not accepted", "Incorrect security code"
     end
 
-    context "with expired otp" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "with expired otp" do
       let(:direct_otp_sent_at) { (SecondaryAuthentication::DirectOtp::OTP_EXPIRY_SECONDS * 2).seconds.ago }
 
       include_examples "code not accepted", "The security code has expired. New code sent."
     end
 
-    context "with too many attempts" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "with too many attempts" do
       let(:attempts) { max_attempts + 1 }
 
       include_examples "code not accepted", "Incorrect security code"
     end
 
-    context "with resending otp code" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "with resending otp code" do
       # rubocop:disable RSpec/AnyInstance
-      context "when code is expired" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+      context "when code is expired" do
         let(:direct_otp_sent_at) { (SecondaryAuthentication::DirectOtp::OTP_EXPIRY_SECONDS * 2).seconds.ago }
 
-        context "when secondary authentication is locked" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        context "when secondary authentication is locked" do
           let(:second_factor_attempts_locked_at) { Time.zone.now }
 
           it "does not send the code" do

--- a/cosmetics-web/spec/search/poison_centre_search_spec.rb
+++ b/cosmetics-web/spec/search/poison_centre_search_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Poison centre search" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+RSpec.describe "Poison centre search" do
   let(:results) { keyword_search(keyword) }
   let(:notifications) { results.records }
 
@@ -20,8 +20,8 @@ RSpec.describe "Poison centre search" do # rubocop:todo RSpec/MultipleMemoizedHe
     Notification.elasticsearch.import force: true
   end
 
-  describe "Search by post code" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    context "when searching by full code" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  describe "Search by post code" do
+    context "when searching by full code" do
       let(:keyword) { "N12 8AA" }
 
       it "finds proper notifications" do
@@ -29,7 +29,7 @@ RSpec.describe "Poison centre search" do # rubocop:todo RSpec/MultipleMemoizedHe
       end
     end
 
-    context "when searching by part code" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when searching by part code" do
       let(:keyword) { "N12" }
 
       it "finds proper notifications" do
@@ -37,7 +37,7 @@ RSpec.describe "Poison centre search" do # rubocop:todo RSpec/MultipleMemoizedHe
       end
     end
 
-    context "when searching by different code" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when searching by different code" do
       let(:keyword) { "LA1" }
 
       it "finds proper notifications" do

--- a/cosmetics-web/spec/services/notification_delete_service_spec.rb
+++ b/cosmetics-web/spec/services/notification_delete_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe NotificationDeleteService do
     create(:responsible_person_user, user: submit_user, responsible_person: responsible_person)
   end
 
-  context "when the notification is completed" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  context "when the notification is completed" do
     let(:notification) { create(:registered_notification, cpnp_reference: "123412344") }
 
     it "deletes the notification" do
@@ -49,7 +49,7 @@ RSpec.describe NotificationDeleteService do
       )
     end
 
-    context "when submit user is not provided" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when submit user is not provided" do
       let(:current_user) { nil }
 
       it "is not saved" do
@@ -69,7 +69,7 @@ RSpec.describe NotificationDeleteService do
       end
     end
 
-    context "when 7 days passed" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+    context "when 7 days passed" do
       before do
         travel_to 8.days.from_now
       end
@@ -94,7 +94,7 @@ RSpec.describe NotificationDeleteService do
     end
   end
 
-  context "when the notification is a draft" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  context "when the notification is a draft" do
     let(:notification) { create(:draft_notification, cpnp_reference: "123412344") }
 
     it "deletes the notification" do

--- a/cosmetics-web/spec/services/update_responsible_person_address_spec.rb
+++ b/cosmetics-web/spec/services/update_responsible_person_address_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do # rubocop:todo RSpec/MultipleMemoizedHelpers
+RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
   let(:original_address) do
     {
       address_line_1: "Original street",
@@ -72,7 +72,6 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do # rubocop
     expect(result.error).to eq "Address contains unknown fields"
   end
 
-  # rubocop:todo RSpec/MultipleMemoizedHelpers
   context "when the provided address is the same as the original address" do
     let!(:result) do
       described_class.call(user: user, responsible_person: responsible_person, address: original_address)
@@ -94,10 +93,9 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do # rubocop
       expect(responsible_person.reload.address_logs).to be_empty
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
-  context "when the provided address is different from the original one" do # rubocop:todo RSpec/MultipleMemoizedHelpers
-    context "without any exception" do # rubocop:todo RSpec/MultipleMemoizedHelpers
+  context "when the provided address is different from the original one" do
+    context "without any exception" do
       let!(:result) do
         described_class.call(user: user, responsible_person: responsible_person, address: new_address)
       end
@@ -161,7 +159,6 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do # rubocop
       # rubocop:enable RSpec/ExampleLength
     end
 
-    # rubocop:todo RSpec/MultipleMemoizedHelpers
     context "with an exception while attempting to archive the previous address" do
       let(:address_log_stub) { instance_double(ResponsiblePersonAddressLog) }
       let(:result) do
@@ -186,6 +183,5 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do # rubocop
         expect(delivered_emails).to be_empty
       end
     end
-    # rubocop:enable RSpec/MultipleMemoizedHelpers
   end
 end


### PR DESCRIPTION
We have hundreds of violations of it in our codebase and resolving them would
require a lot of work refactoring our specs to break them down into separate
test groups.
The individual comments for disabling it in each case are quite noisy, so we're
disabling the rule.
