### PR TITLE
Filter Pundit auth exceptions from Sentry

### DIFF
--- a/cosmetics-web/config/initializers/sentry.rb
+++ b/cosmetics-web/config/initializers/sentry.rb
@@ -7,5 +7,11 @@ Rails.application.configure do
     config.breadcrumbs_logger = [:active_support_logger] # Inject Sentry logger breadcrumbs
     config.dsn = ENV["SENTRY_DSN"]
     config.send_default_pii = false
+
+    config.before_send = lambda do |event, hint|
+      return if hint[:exception].is_a?(Pundit::NotAuthorizedError)
+
+      event
+    end
   end
 end

--- a/cosmetics-web/config/initializers/sentry.rb
+++ b/cosmetics-web/config/initializers/sentry.rb
@@ -6,12 +6,7 @@ Rails.application.configure do
   Sentry.init do |config|
     config.breadcrumbs_logger = [:active_support_logger] # Inject Sentry logger breadcrumbs
     config.dsn = ENV["SENTRY_DSN"]
+    config.excluded_exceptions += ["Pundit::NotAuthorizedError"]
     config.send_default_pii = false
-
-    config.before_send = lambda do |event, hint|
-      return if hint[:exception].is_a?(Pundit::NotAuthorizedError)
-
-      event
-    end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1359)

These errors are meant to block users to access resources they shouldn't be able to. The exceptions are not runtime exceptions that may be caused by bugs or need to be resolved.

Given we have a very tight error quota in our Sentry plan and that Pundit errors give us no value, we will benefit from not sending them to Sentry.

 
## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2356-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2356-search-web.london.cloudapps.digital/


