### PR TITLE
Capitalise responsible person wording

### DIFF
--- a/cosmetics-web/app/mailers/submit_notify_mailer.rb
+++ b/cosmetics-web/app/mailers/submit_notify_mailer.rb
@@ -33,7 +33,7 @@ class SubmitNotifyMailer < NotifyMailer
 
   def send_responsible_person_invite_email(responsible_person, invited_team_member, inviting_user_name)
     @host = submit_host
-    set_reference("Invite user to join responsible person")
+    set_reference("Invite user to join Responsible Person")
     user = SubmitUser.find_by(email: invited_team_member.email_address)
     if user
       set_template(TEMPLATES[:responsible_person_invitation_for_existing_user])

--- a/cosmetics-web/app/services/update_responsible_person_address.rb
+++ b/cosmetics-web/app/services/update_responsible_person_address.rb
@@ -4,10 +4,10 @@ class UpdateResponsiblePersonAddress
   delegate :responsible_person, :user, :address, :original_address, to: :context
 
   def call
-    context.fail!(error: "No responsible person provided") unless responsible_person
+    context.fail!(error: "No Responsible Person provided") unless responsible_person
     context.fail!(error: "No user provided") unless user
     context.fail!(error: "No address provided") unless address
-    context.fail!(error: "User does not belong to responsible person") unless user_belongs_to_responsible_person?
+    context.fail!(error: "User does not belong to Responsible Person") unless user_belongs_to_responsible_person?
     context.fail!(error: "Address contains unknown fields") unless valid_address_fields?
 
     context.previous_address = previous_address

--- a/cosmetics-web/app/views/confirmation/link_expired.html.erb
+++ b/cosmetics-web/app/views/confirmation/link_expired.html.erb
@@ -4,6 +4,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">This link has expired</h1>
 
-    <p>Please ask the user who created the responsible person to resend the email</p>
+    <p>Please ask the user who created the Responsible Person to resend the email</p>
   </div>
 </div>

--- a/cosmetics-web/app/views/help/accessibility_statement.html.erb
+++ b/cosmetics-web/app/views/help/accessibility_statement.html.erb
@@ -103,11 +103,11 @@
     <p>
       Content that is not within the scope of the accessibility regulations
       From 1 January 2021, the Submit cosmetic product notifications service requires a
-      ‘responsible person’ – a manufacturer, importer, distributor or appointed company or
+      ‘Responsible Person’ – a manufacturer, importer, distributor or appointed company or
       person – to register cosmetic products before they are placed on the market in Great
       Britain. Cosmetic products available to consumers in Great Britain on 31 December
       2020 must also be notified under transitional arrangements. The Submit cosmetic
-      product notifications service allows responsible persons to upload documents they
+      product notifications service allows Responsible Persons to upload documents they
       have produced. This third-party content is neither funded nor developed by OPSS
       and is not under its control. As such it is exempt under section 4(2)(e) of the
       accessibility regulations.

--- a/cosmetics-web/app/views/help/privacy_notice.html.erb
+++ b/cosmetics-web/app/views/help/privacy_notice.html.erb
@@ -49,7 +49,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>name, email address and telephone number of all users who create an account</li>
-      <li>address and name of the ‘responsible person’</li>
+      <li>address and name of the ‘Responsible Person’</li>
       <li>name, email address and phone number of the ‘contact person’</li>
       <li>questions, queries or feedback you might provide if you contact us</li>
       <li>internet Protocol (IP) address, and details of which version of web browser used.</li>
@@ -104,7 +104,7 @@
 
     <h2 class="govuk-heading-m">How we share your data</h2>
 
-    <p>We share your personal data (specifically contact person, and responsible person) in the following ways:</p>
+    <p>We share your personal data (specifically contact person, and Responsible Person) in the following ways:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>With the National Poisons Information Service (NPIS) for healthcare purposes</li>

--- a/cosmetics-web/app/views/layouts/_navbar.html.erb
+++ b/cosmetics-web/app/views/layouts/_navbar.html.erb
@@ -9,7 +9,7 @@
       <%= link_to "Nanomaterials", responsible_person_nanomaterials_path(@responsible_person), "data-topnav": "nanomaterial_notifications", class: "govuk-link--no-visited-state" %>
     </li>
     <li class="<%= "app-navigation--current-page" if params[:controller] == "responsible_persons" %>">
-      <%= link_to "Responsible person", responsible_person_path(@responsible_person), "data-topnav": "responsible_persons", class: "govuk-link--no-visited-state" %>
+      <%= link_to "Responsible Person", responsible_person_path(@responsible_person), "data-topnav": "responsible_persons", class: "govuk-link--no-visited-state" %>
     </li>
     <li class="<%= "app-navigation--current-page" if params[:controller] == "responsible_persons/team_members" %>">
       <%= link_to "Team members", responsible_person_team_members_path(@responsible_person), "data-topnav": "responsible_persons/team_members", class: "govuk-link--no-visited-state" %>

--- a/cosmetics-web/app/views/notifications/_responsible_person_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_responsible_person_details.html.erb
@@ -1,5 +1,5 @@
 <% responsible_person = local_assigns[:responsible_person] %>
-<h2 class="govuk-heading-m">Responsible person</h2>
+<h2 class="govuk-heading-m">Responsible Person</h2>
 <%= govukSummaryList(
   classes: "govuk-summary-list check-your-answers-table",
   rows: [

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/join_existing.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/join_existing.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Join existing responsible person" %>
+<% content_for :page_title, "Join existing Responsible Person" %>
 <% content_for :after_header do %>
   <%= link_to "Back", wizard_path(:create_or_join_existing), class: "govuk-back-link" %>
 <% end %>

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/select_type.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/select_type.html.erb
@@ -1,4 +1,4 @@
-<% page_title "Responsible person type", errors: @responsible_person.errors.any? %>
+<% page_title "Responsible Person type", errors: @responsible_person.errors.any? %>
 <% content_for :after_header do %>
   <% default_back_path =  if current_user.responsible_persons.none?
                             wizard_path(:create_or_join_existing)

--- a/cosmetics-web/app/views/responsible_persons/notifications/_aside_responsible_person_details.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_aside_responsible_person_details.html.erb
@@ -1,6 +1,6 @@
 <aside class="govuk-grid-column-one-quarter opss-desktop-padding-left-0">
   <div class="opss-border-all govuk-!-padding-top-2 govuk-!-padding-right-2 govuk-!-padding-bottom-2 govuk-!-padding-left-2 govuk-!-margin-top-4 govuk-!-margin-bottom-4">
-    <h2 class="govuk-heading-s">Responsible person</h2>
+    <h2 class="govuk-heading-s">Responsible Person</h2>
     <% key_value_classes = "govuk-!-display-block govuk-!-font-size-16" %>
     <%= govukSummaryList(
       classes: "govuk-summary-list--no-border opss-summary-list-vertical",

--- a/cosmetics-web/app/views/search/landing_page/index.html.erb
+++ b/cosmetics-web/app/views/search/landing_page/index.html.erb
@@ -34,10 +34,10 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>product name</li>
           <li>product category</li>
-          <li>responsible person</li>
+          <li>Responsible Person</li>
         </ul>
 
-        <div class="govuk-inset-text">The ‘responsible person’ is the company (or individual) responsible for ensuring the regulations are followed. Every cosmetic product placed on the GB market must have a UK based responsible person.</div>
+        <div class="govuk-inset-text">The ‘Responsible Person’ is the company (or individual) responsible for ensuring the regulations are followed. Every cosmetic product placed on the GB market must have a UK based Responsible Person.</div>
 
         <h3 class="govuk-heading-s">National Poisons Information Service (NPIS) staff</h3>
 

--- a/cosmetics-web/spec/features/account/forgotten_password_spec.rb
+++ b/cosmetics-web/spec/features/account/forgotten_password_spec.rb
@@ -259,7 +259,7 @@ RSpec.feature "Resetting your password", :with_test_queue_adapter, :with_stubbed
         email = delivered_emails.first
 
         expect(email.recipient).to eq "inviteduser@example.com"
-        expect(email.reference).to eq "Invite user to join responsible person"
+        expect(email.reference).to eq "Invite user to join Responsible Person"
         expect(email.template).to eq mailer::TEMPLATES[:responsible_person_invitation_for_existing_user]
         expect(email.personalization).to eq(
           invitation_url: "http://#{ENV.fetch('SUBMIT_HOST')}#{invitation_path}",

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -347,7 +347,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
         email = delivered_emails.first
 
         expect(email.recipient).to eq "inviteduser@example.com"
-        expect(email.reference).to eq "Invite user to join responsible person"
+        expect(email.reference).to eq "Invite user to join Responsible Person"
         expect(email.template).to eq SubmitNotifyMailer::TEMPLATES[:responsible_person_invitation_for_existing_user]
         expect(email.personalization).to eq(
           invitation_url: "http://#{ENV.fetch('SUBMIT_HOST')}#{invitation_path}",

--- a/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
+++ b/cosmetics-web/spec/features/inviting_a_colleague_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
       email = delivered_emails.first
       expect(email).to have_attributes(
         recipient: invited_user.email,
-        reference: "Invite user to join responsible person",
+        reference: "Invite user to join Responsible Person",
         template: SubmitNotifyMailer::TEMPLATES[:responsible_person_invitation_for_existing_user],
         personalization: { invitation_url: "http://#{ENV['SUBMIT_HOST']}/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{invitation.invitation_token}",
                            invite_sender: user.name,
@@ -146,7 +146,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
     email = delivered_emails.first
     expect(email).to have_attributes(
       recipient: invited_user.email,
-      reference: "Invite user to join responsible person",
+      reference: "Invite user to join Responsible Person",
       template: SubmitNotifyMailer::TEMPLATES[:responsible_person_invitation_for_existing_user],
       personalization: { invitation_url: "http://#{ENV['SUBMIT_HOST']}/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{invitation.invitation_token}",
                          invite_sender: user.name,
@@ -225,7 +225,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
 
     expect(original_email).to have_attributes(
       recipient: "newusertoregister@example.com",
-      reference: "Invite user to join responsible person",
+      reference: "Invite user to join Responsible Person",
       template: SubmitNotifyMailer::TEMPLATES[:responsible_person_invitation],
       personalization: { invitation_url: "http://#{ENV['SUBMIT_HOST']}/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{invitation.invitation_token}",
                          invite_sender: original_inviting_user.name,
@@ -270,7 +270,7 @@ RSpec.describe "Inviting a team member", :with_stubbed_antivirus, :with_stubbed_
 
     expect(new_email).to have_attributes(
       recipient: "newusertoregister@example.com",
-      reference: "Invite user to join responsible person",
+      reference: "Invite user to join Responsible Person",
       template: SubmitNotifyMailer::TEMPLATES[:responsible_person_invitation_for_existing_user],
       personalization: { invitation_url: "http://#{ENV['SUBMIT_HOST']}/responsible_persons/#{responsible_person.id}/team_members/join?invitation_token=#{invitation.invitation_token}",
                          invite_sender: user.name,

--- a/cosmetics-web/spec/features/multiple_responsible_person_spec.rb
+++ b/cosmetics-web/spec/features/multiple_responsible_person_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
     click_on "Your cosmetic products"
 
     expect_to_be_on_responsible_person_notifications_page(responsible_person_1)
-    click_on "Responsible person"
+    click_on "Responsible Person"
     click_on "Change the Responsible Person"
     choose name_2
     click_on "Save and continue"
@@ -57,7 +57,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
     click_on "Your cosmetic products"
 
     expect_to_be_on_responsible_person_notifications_page(responsible_person_1)
-    click_on "Responsible person"
+    click_on "Responsible Person"
     click_on "Change the Responsible Person"
     expect(page).to have_h1("Change the Responsible Person")
     choose "Add a new Responsible Person"
@@ -80,7 +80,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
     click_on "Your cosmetic products"
 
     expect_to_be_on_responsible_person_notifications_page(responsible_person_1)
-    click_on "Responsible person"
+    click_on "Responsible Person"
     click_on "Change the Responsible Person"
     expect(page).to have_h1("Change the Responsible Person")
     choose "Add a new Responsible Person"

--- a/cosmetics-web/spec/services/update_responsible_person_address_spec.rb
+++ b/cosmetics-web/spec/services/update_responsible_person_address_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
   it "fails when no responsible person is provided" do
     result = described_class.call(user: user, address: new_address)
     expect(result).to be_failure
-    expect(result.error).to eq "No responsible person provided"
+    expect(result.error).to eq "No Responsible Person provided"
   end
 
   it "fails when no address is provided" do
@@ -62,7 +62,7 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
     other_user = create(:submit_user)
     result = described_class.call(user: other_user, responsible_person: responsible_person, address: new_address)
     expect(result).to be_failure
-    expect(result.error).to eq "User does not belong to responsible person"
+    expect(result.error).to eq "User does not belong to Responsible Person"
   end
 
   it "fails when fields not belonging to the RP address are provided" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1222)

Turning any `responsible person` or `Responsible person` text occurrences through the service into `Responsible Person`.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2357-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2357-search-web.london.cloudapps.digital/
