### PR TITLE
Bug Fix: date helper called when date is not present

### DIFF
--- a/cosmetics-web/app/views/poison_centres/notifications/_registered_product.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/_registered_product.html.erb
@@ -19,7 +19,7 @@
       Metadata
     </th>
     <td headers="uknotified <%= cell_headers %>" class="govuk-table__cell">
-      <%= display_full_month_date notification.notification_complete_at.presence || "&nbsp;".html_safe %>
+      <%= notification.notification_complete_at.present? ? display_full_month_date(notification.notification_complete_at) : "&nbsp;".html_safe %>
     </td>
     <td headers="ukcosprodnumber <%= cell_headers %>" class="govuk-table__cell">
       <%= notification.reference_number_for_display.presence || "&nbsp;".html_safe %>


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1363)

## Description
The construction of this line was causing the `#display_full_month_date` helper method to be called with nil values instead of only being called when the notification completion date is present.

This is causing 500 errors in production when Search users attempt to view the Search notifications index while having notifications that lack completion date in DB (probably ZIP imported).

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->


<!--- Describe your changes in detail -->

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2360-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2360-search-web.london.cloudapps.digital/
