### PR TITLE
Cover empty ref. case when formatting ref. numbers

### DIFF
--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -138,6 +138,8 @@ class Notification < ApplicationRecord
   end
 
   def reference_number_for_display
+    return "" if reference_number.blank?
+
     sprintf("UKCP-%08d", reference_number)
   end
 

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -338,4 +338,16 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
       end
     end
   end
+
+  describe "#reference_number_for_display" do
+    it "returns empty string if reference number is not set" do
+      notification = build_stubbed(:notification, reference_number: nil)
+      expect(notification.reference_number_for_display).to eq ""
+    end
+
+    it "formats the reference number" do
+      notification = build_stubbed(:notification, reference_number: "60162968")
+      expect(notification.reference_number_for_display).to eq "UKCP-60162968"
+    end
+  end
 end


### PR DESCRIPTION
[Error in production](https://sentry.io/organizations/beis/issues/2927889849/?project=1398436)

The current code blindly trusts that, when attempting to format a notification reference number for display, the reference number is present.

When this is not the case, calling this method causes an exception.
Fixing this by returning an empty string in that case.



## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/

