### PR TITLE
Fix search pagination

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 ruby "~> 3.0"
 
-gem "will_paginate", "3.2.1" # Must be laoded before elasticsearch gems
+gem "kaminari" # Must be loaded before ElasticSearch gems
 
 # Needed a feature added into AASM master branch but still not tagged with a new version.
 gem "aasm", "5.2.0"
@@ -21,7 +21,6 @@ gem "govuk_notify_rails", "~> 2.1.0"
 gem "image_processing", "~> 1.2"
 gem "interactor"
 gem "jbuilder", "~> 2.9"
-gem "kaminari"
 gem "lograge", "~> 0.11.2"
 gem "mini_magick", "~> 4.9.4"
 gem "okcomputer", "~> 1.18.1"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -526,7 +526,6 @@ GEM
     websocket-extensions (0.1.5)
     wicked (1.3.4)
       railties (>= 3.0.7)
-    will_paginate (3.2.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.27)
@@ -606,7 +605,6 @@ DEPENDENCIES
   webpacker (~> 5.0)
   webrick (~> 1.7)
   wicked (~> 1.3.4)
-  will_paginate (= 3.2.1)
 
 RUBY VERSION
    ruby 3.0.3p157

--- a/cosmetics-web/app/controllers/nanomaterial_notifications_controller.rb
+++ b/cosmetics-web/app/controllers/nanomaterial_notifications_controller.rb
@@ -16,7 +16,7 @@ class NanomaterialNotificationsController < SubmitApplicationController
 
     respond_to do |format|
       format.html do
-        @nanomaterial_notifications = @nanomaterial_notifications.paginate(page: params[:page], per_page: PER_PAGE)
+        @nanomaterial_notifications = @nanomaterial_notifications.page(params[:page]).per(PER_PAGE)
       end
       format.csv do
         @notifications = NanomaterialNotificationsDecorator.new(@nanomaterial_notifications)

--- a/cosmetics-web/app/controllers/poison_centres/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/notifications_controller.rb
@@ -9,7 +9,7 @@ class PoisonCentres::NotificationsController < SearchApplicationController
     # Notifications are only listed in ElasticSearch index when completed, but if an indexed notification gets deleted,
     # it won't be removed from the index until the next reindex is run (once per day).
     # During that period, the result record will be a deleted notification with empty values. We don't want to show those.
-    @notifications = @result.records.completed.paginate(page: params[:page], per_page: PER_PAGE)
+    @notifications = @result.records.completed.page(params[:page]).per(PER_PAGE)
   end
 
   def show

--- a/cosmetics-web/app/controllers/poison_centres/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/notifications_controller.rb
@@ -5,11 +5,11 @@ class PoisonCentres::NotificationsController < SearchApplicationController
     @search_form = NotificationSearchForm.new(search_params)
     @search_form.validate
 
-    @result = search_notifications
+    @search_response = search_notifications
     # Notifications are only listed in ElasticSearch index when completed, but if an indexed notification gets deleted,
     # it won't be removed from the index until the next reindex is run (once per day).
     # During that period, the result record will be a deleted notification with empty values. We don't want to show those.
-    @notifications = @result.records.completed.page(params[:page]).per(PER_PAGE)
+    @notifications = @search_response.records.completed
   end
 
   def show
@@ -27,7 +27,9 @@ private
 
   def search_notifications
     query = ElasticsearchQuery.new(keyword: @search_form.q, category: @search_form.category, from_date: @search_form.date_from_for_search, to_date: @search_form.date_to_for_search, sort_by: @search_form.sort_by)
-    Notification.full_search(query)
+    # Pagination needs to be kept together with the full search query to automatically paginate the query with Kaminari values
+    # instead of defaulting to ElasticSearch returning the first 10 hits.
+    Notification.full_search(query).page(params[:page]).per(PER_PAGE)
   end
 
   def search_params

--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -80,8 +80,8 @@ private
   def get_registered_notifications(page_size)
     @responsible_person.notifications
       .completed
-      .paginate(page: params[:page], per_page: page_size)
       .order(notification_complete_at: :desc)
+      .page(params[:page]).per(page_size)
   end
 
   def add_image_upload_errors

--- a/cosmetics-web/app/views/poison_centres/notifications/_results.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/_results.html.erb
@@ -1,7 +1,7 @@
 <section class="govuk-grid-column-three-quarters" id="search-results-section">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body"><%= pluralize(@result.results.total, 'product') %> <%= display_keywords %> <%= display_filters_informations %> <%= @result.results.total == 1 ? "was found." : "were found." %></p>
+      <p class="govuk-body"><%= pluralize(search_response.results.total, 'product') %> <%= display_keywords %> <%= display_filters_informations %> <%= search_response.results.total == 1 ? "was found." : "were found." %></p>
     </div>
 
     <div class="govuk-grid-column-one-third">
@@ -40,7 +40,7 @@
             </tfoot>
           <% end %>
         </table>
-        <%= paginate @notifications, views_prefix: "pagination", nav_class: "opss-pagination-link--no-top-border" %>
+        <%= paginate search_response, views_prefix: "pagination", nav_class: "opss-pagination-link--no-top-border" %>
       </div>
     </div>
   <% end %>

--- a/cosmetics-web/app/views/poison_centres/notifications/index.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/index.html.erb
@@ -34,5 +34,5 @@
 
 <div class="govuk-grid-row">
   <%= render "filters" %>
-  <%= render "results", results: @notifications %>
+  <%= render "results", results: @notifications, search_response: @search_response %>
 </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
@@ -27,7 +27,7 @@
   </div>
 </div>
 
-<% if @registered_notifications.total_entries.zero? %>
+<% if @registered_notifications.total_count.zero? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
     <p class="govuk-body">
@@ -61,10 +61,10 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-top-7">
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            Product notifications (<%= @registered_notifications.count %>)
+            Product notifications (<%= @registered_notifications.total_count %>)
           </h2>
           <p class="govuk-body govuk-!-margin-bottom-0">
-          There are currently <%= (count = @registered_notifications.count) > 0 ? count : 'no' %> notified cosmetic products.
+          There are currently <%= (count = @registered_notifications.total_count) > 0 ? count : 'no' %> notified cosmetic products.
           </p>
         </div>
         <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2 govuk-!-margin-top-7">

--- a/cosmetics-web/spec/features/notification_search_spec.rb
+++ b/cosmetics-web/spec/features/notification_search_spec.rb
@@ -151,50 +151,45 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     end
   end
 
-  describe "Results pagination" do
-    before do
-      17.times do |i|
-        create(:notification, :registered, :with_component, notification_complete_at: 5.days.ago, product_name: "Sun Lotion #{i}")
-      end
+  scenario "Does not display pagination until has more than 20 results" do
+    17.times do |i|
+      create(:notification, :registered, :with_component, notification_complete_at: 5.days.ago, product_name: "Sun Lotion #{i}")
+    end
+    Notification.elasticsearch.import force: true
+    sign_in user
+
+    expect(page).to have_h1("Search cosmetic products")
+    expect(page).to have_link("Cream")
+    expect(page).to have_link("Shower Bubbles")
+    expect(page).to have_link("Bath Bubbles")
+    17.times do |i|
+      expect(page).to have_link("Sun Lotion #{i}")
     end
 
-    scenario "Does not display pagination with 20 results" do
-      Notification.elasticsearch.import force: true
-      sign_in user
+    expect(page).not_to have_text("Page 1")
+    expect(page).not_to have_link("Next page")
 
-      expect(page).to have_h1("Search cosmetic products")
-      expect(page).to have_link("Cream")
-      expect(page).to have_link("Shower Bubbles")
-      expect(page).to have_link("Bath Bubbles")
-      17.times do |i|
-        expect(page).to have_link("Sun Lotion #{i}")
-      end
+    # With 21 results, we should see the pagination
+    create(:notification, :registered, :with_component, notification_complete_at: 5.days.ago, product_name: "Sun Lotion 17")
+    Notification.elasticsearch.import force: true
 
-      expect(page).not_to have_text("Page 1")
-      expect(page).not_to have_link("Next page")
+    visit "/notifications"
+
+    expect(page).to have_h1("Search cosmetic products")
+    expect(page).to have_link("Cream")
+    expect(page).to have_link("Shower Bubbles")
+    expect(page).to have_link("Bath Bubbles")
+    (1..16).each do |i|
+      expect(page).to have_link("Sun Lotion #{i}")
     end
+    expect(page).not_to have_link("Sun Lotion 0")
+    expect(page).to have_text("Page 1")
+    expect(page).to have_link("Next page")
 
-    scenario "Displays pagination with 21 results" do
-      create(:notification, :registered, :with_component, notification_complete_at: 5.days.ago, product_name: "Sun Lotion 17")
-      Notification.elasticsearch.import force: true
-      sign_in user
-
-      expect(page).to have_h1("Search cosmetic products")
-      expect(page).to have_link("Cream")
-      expect(page).to have_link("Shower Bubbles")
-      expect(page).to have_link("Bath Bubbles")
-      (1..16).each do |i|
-        expect(page).to have_link("Sun Lotion #{i}")
-      end
-      expect(page).not_to have_link("Sun Lotion 0")
-      expect(page).to have_text("Page 1")
-      expect(page).to have_link("Next page")
-
-      click_link("Next page")
-      expect(page).to have_h1("Search cosmetic products")
-      expect(page).to have_link("Sun Lotion 0")
-      expect(page).to have_text("Page 2")
-      expect(page).to have_link("Previous page")
-    end
+    click_link("Next page")
+    expect(page).to have_h1("Search cosmetic products")
+    expect(page).to have_link("Sun Lotion 0")
+    expect(page).to have_text("Page 2")
+    expect(page).to have_link("Previous page")
   end
 end


### PR DESCRIPTION
- Migrate all the service pagination to `kaminari`.
- Remove `will_paginate`.
- Fix an issue with ElasticSearch pagination recently introduced with the change of where ES results get paginated: https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/pull/2367
- Test pagination so I don't break it again :( 


## Description
We recently did some work that delayed the ES search results' pagination to exclude deleted notifications from the results.

An unintended consequence of that change is that we do not pass the pagination limits to the ElasticSearch query anymore, and the ElasticSearch query started defaulting to return the first 10 hits instead of all (or the 20 desired ones per page).

This breaks the Search by limiting the results to 10 per search. Even the default index is limited to 10 results.

Fixing it by moving the pagination back to the ES query call, and excluding the deleted notification from the already paginated results.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2386-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2386-search-web.london.cloudapps.digital/


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1227578/151942655-d46e75d7-1b01-4cd7-873e-f5567f7d49fe.png)

### After
![image](https://user-images.githubusercontent.com/1227578/151942580-bfcdf603-089f-4201-b725-92ad008df084.png)

## Nanomaterials pagination in Submit still works as expected
![image](https://user-images.githubusercontent.com/1227578/151944508-4b316126-9880-4ff1-91a4-5c70c3022a22.png)

### Cosmetics products pagination in Submit still works as expected
![image](https://user-images.githubusercontent.com/1227578/151944649-c5c0826d-313f-4304-9d62-accb81ef8d73.png)
