### PR TITLE
Fix: Add org. to Opensearch image for Smoke tests

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -26,7 +26,7 @@ jobs:
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       opensearch:
-        image: opensearch:1.2.4
+        image: opensearchproject/opensearch:1.2.4
         ports: ["9200:9200"]
         options: -e="discovery.type=single-node" --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
     steps:


### PR DESCRIPTION
Docker pull of Opensearch image is failing in Smoke tests. The org prefix is missing.