### PR TITLE
1412 dont create notification until name

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/drafts_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/drafts_controller.rb
@@ -25,12 +25,8 @@ class ResponsiblePersons::DraftsController < SubmitApplicationController
 
 private
 
-  def responsible_person
-    @responsible_person = ResponsiblePerson.find(params[:responsible_person_id])
-  end
-
   def set_responsible_person
-    responsible_person
+    @responsible_person = ResponsiblePerson.find(params[:responsible_person_id])
   end
 
   def set_notification

--- a/cosmetics-web/app/controllers/responsible_persons/drafts_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/drafts_controller.rb
@@ -1,7 +1,13 @@
 class ResponsiblePersons::DraftsController < SubmitApplicationController
-  before_action :set_notification
+  before_action :set_notification, except: :new
+  before_action :set_responsible_person
 
   def show
+  end
+
+  def new
+    @notification = Notification.new
+    render 'show'
   end
 
   def add_component
@@ -20,7 +26,11 @@ class ResponsiblePersons::DraftsController < SubmitApplicationController
 private
 
   def responsible_person
-    @notification&.responsible_person
+    @responsible_person = ResponsiblePerson.find(params[:responsible_person_id])
+  end
+
+  def set_responsible_person
+    responsible_person
   end
 
   def set_notification

--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -18,9 +18,16 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
   def show; end
 
   def new
-    @notification = Notification.create(responsible_person: @responsible_person)
+    @notification = Notification.new
+  end
 
-    redirect_to new_responsible_person_notification_product_path(@responsible_person, @notification)
+  def create
+    @notification = @responsible_person.notifications.new(notification_params)
+    if @notification.save
+      redirect_to responsible_person_notification_product_path(@responsible_person, @notification, :add_internal_reference)
+    else
+      render 'new'
+    end
   end
 
   # Check your answers page
@@ -36,12 +43,6 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
     if params[:submit_failed]
       add_image_upload_errors
     end
-  end
-
-  def create_for_draft
-    notification = Notification.create(responsible_person: @responsible_person)
-
-    redirect_to responsible_person_notification_draft_path(@responsible_person, notification)
   end
 
   def confirm
@@ -102,5 +103,10 @@ private
     if @notification.images_pending_anti_virus_check?
       @notification.errors.add :image_uploads, "waiting for files to pass anti virus check. Refresh to update"
     end
+  end
+
+  def notification_params
+    params.fetch(:notification, {})
+      .permit(:product_name)
   end
 end

--- a/cosmetics-web/app/helpers/draft_helper.rb
+++ b/cosmetics-web/app/helpers/draft_helper.rb
@@ -186,7 +186,7 @@ module DraftHelper
 
   def sections_completed
     case @notification.state.to_sym
-    when NotificationStateConcern::EMPTY
+    when NotificationStateConcern::EMPTY, NotificationStateConcern::PRODUCT_NAME_ADDED
       0
     when NotificationStateConcern::READY_FOR_NANOMATERIALS
       1

--- a/cosmetics-web/app/helpers/draft_helper.rb
+++ b/cosmetics-web/app/helpers/draft_helper.rb
@@ -44,7 +44,7 @@ module DraftHelper
   end
 
   def product_badge(notification)
-    if notification.state == 'empty'
+    if notification.state_lower_than?(NotificationStateConcern::READY_FOR_NANOMATERIALS)
       not_started_badge
     else
       completed_badge

--- a/cosmetics-web/app/views/responsible_persons/drafts/_product.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/drafts/_product.html.erb
@@ -7,9 +7,15 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
-        <a href="<%= new_responsible_person_notification_product_path(@notification.responsible_person, @notification) %>" class="govuk-link govuk-link--no-visited-state" aria-describedby="product-status">
-          Create the product
-        </a>
+        <% if @notification.persisted? %>
+          <a href="<%= new_responsible_person_notification_product_path(@notification.responsible_person, @notification) %>" class="govuk-link govuk-link--no-visited-state" aria-describedby="product-status">
+            Create the product
+          </a>
+        <% else %>
+          <a href="<%= new_responsible_person_notification_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" aria-describedby="product-status">
+            Create the product
+          </a>
+        <% end %>
       </span>
 
       <%= product_badge(@notification) %>

--- a/cosmetics-web/app/views/responsible_persons/drafts/_product_info.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/drafts/_product_info.html.erb
@@ -50,9 +50,11 @@
 
         </div>
         <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
-          <a href="<%= delete_responsible_person_delete_notification_path(@notification.responsible_person, @notification) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset">
-            Delete <span class="govuk-visually-hidden">this </span>draft
-          </a>
+          <% if @notification.persisted? %>
+            <a href="<%= delete_responsible_person_delete_notification_path(@notification.responsible_person, @notification) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset">
+              Delete <span class="govuk-visually-hidden">this </span>draft
+            </a>
+          <% end %>
         </div>
       </div>
 

--- a/cosmetics-web/app/views/responsible_persons/drafts/guides/_product_name_added.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/drafts/guides/_product_name_added.html.erb
@@ -1,0 +1,1 @@
+<%= render 'responsible_persons/drafts/guides/empty' %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
@@ -12,7 +12,7 @@
         </h1>
       </div>
       <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
-        <a href="<%= create_for_draft_responsible_person_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset">
+        <a href="<%= new_responsible_person_draft_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset">
           Add a cosmetic product
         </a>
       </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/new.html.erb
@@ -10,7 +10,6 @@
 
     <%= form_with model: @notification, url: responsible_person_notifications_path, method: :post do |form| %>
       <%= render partial: 'responsible_persons/wizard/notification_product/add_product_name_form', locals: { form: form, title: title } %>
-
     <% end %>
   </div>
 </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/new.html.erb
@@ -9,20 +9,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <%= form_with model: @notification, url: responsible_person_notifications_path, method: :post do |form| %>
-
-      <%= error_summary_for(@notification) %>
-
-      <h1 class="govuk-heading-l"><%= title %></h1>
-
-      <p class="govuk-body">Include the trade mark or brand, the product line and the specific name of the product as it appears on the packaging. Include the type of product (for example, ‘shower gel’) unless it’s included in the product name.</p>
-
-      <%= render "form_components/govuk_input",
-              form: form,
-              key: :product_name,
-              label: { text: "Product name", classes: "govuk-label--m", isPageHeading: false },
-              hint: { text: "For example, ‘SkinSoft body fresh with aloe vera, shower gel’." } %>
-
-      <%= govukButton text: "Continue" %>
+      <%= render partial: 'responsible_persons/wizard/notification_product/add_product_name_form', locals: { form: form, title: title } %>
 
     <% end %>
   </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/new.html.erb
@@ -1,0 +1,29 @@
+<% title = "What’s the product called?" %>
+
+<% page_title title, errors: @notification.errors.any? %>
+<% content_for :after_header do %>
+  <%= link_to "Back", new_responsible_person_draft_path(@responsible_person), class: "govuk-back-link" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <%= form_with model: @notification, url: responsible_person_notifications_path, method: :post do |form| %>
+
+      <%= error_summary_for(@notification) %>
+
+      <h1 class="govuk-heading-l"><%= title %></h1>
+
+      <p class="govuk-body">Include the trade mark or brand, the product line and the specific name of the product as it appears on the packaging. Include the type of product (for example, ‘shower gel’) unless it’s included in the product name.</p>
+
+      <%= render "form_components/govuk_input",
+              form: form,
+              key: :product_name,
+              label: { text: "Product name", classes: "govuk-label--m", isPageHeading: false },
+              hint: { text: "For example, ‘SkinSoft body fresh with aloe vera, shower gel’." } %>
+
+      <%= govukButton text: "Continue" %>
+
+    <% end %>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/notification_product/_add_product_name_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/notification_product/_add_product_name_form.html.erb
@@ -1,0 +1,13 @@
+<%= error_summary_for(@notification) %>
+
+<h1 class="govuk-heading-l"><%= title %></h1>
+
+<p class="govuk-body">Include the trade mark or brand, the product line and the specific name of the product as it appears on the packaging. Include the type of product (for example, ‘shower gel’) unless it’s included in the product name.</p>
+
+<%= render "form_components/govuk_input",
+        form: form,
+        key: :product_name,
+        label: { text: "Product name", classes: "govuk-label--m", isPageHeading: false },
+        hint: { text: "For example, ‘SkinSoft body fresh with aloe vera, shower gel’." } %>
+
+<%= govukButton text: "Continue" %>

--- a/cosmetics-web/app/views/responsible_persons/wizard/notification_product/add_product_name.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/notification_product/add_product_name.html.erb
@@ -10,19 +10,7 @@
 
     <%= form_with model: @notification, url: wizard_path, method: :put do |form| %>
 
-      <%= error_summary_for(@notification) %>
-
-      <h1 class="govuk-heading-l"><%= title %></h1>
-
-      <p class="govuk-body">Include the trade mark or brand, the product line and the specific name of the product as it appears on the packaging. Include the type of product (for example, ‘shower gel’) unless it’s included in the product name.</p>
-
-      <%= render "form_components/govuk_input",
-              form: form,
-              key: :product_name,
-              label: { text: "Product name", classes: "govuk-label--m", isPageHeading: false },
-              hint: { text: "For example, ‘SkinSoft body fresh with aloe vera, shower gel’." } %>
-
-      <%= govukButton text: "Continue" %>
+      <%= render partial: 'add_product_name_form', locals: { form: form, title: title } %>
 
     <% end %>
   </div>

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -126,7 +126,8 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :notifications, param: :reference_number, controller: "responsible_persons/notifications", only: %i[index show new edit] do
+      resource :draft, controller: "responsible_persons/drafts", only: %i[new]
+      resources :notifications, param: :reference_number, controller: "responsible_persons/notifications", only: %i[index show new edit create] do
         resources :build, controller: "responsible_persons/wizard/notification_build", only: %i[show update new]
         resources :product, controller: "responsible_persons/wizard/notification_product", only: %i[show update new] do
         end
@@ -156,9 +157,6 @@ Rails.application.routes.draw do
           resources :build, controller: "responsible_persons/wizard/notification_nanomaterial", only: %i[show update new]
         end
 
-        collection do
-          get :create_for_draft
-        end
         member do
           post :confirm
         end


### PR DESCRIPTION
This code introduces a little bit duplication:
* draft view is being displayed in 2 different situations: when product is created and not created
* product name form is used in 2 places: in wizad and as typical rails form

To solved this and reduce need for additional controllers in action, I did following changes:

**Added new route: `/responsible_persons/:id/drafts/new`**

above route is using current `ResponsiblePersons::DraftController`, new action `new` is added which renders `show` template.
The `show` template is adjusted to handle non persisted notification.

**Added `new` and `create` action to existing notification controller**
Cleaned up existing actions and added 2 `rails'y` actions `new` and `create`. The `new` template is using `add_product_name` template from wizard.
