### PR TITLE
Redirect to RP page after creating Contact Person

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/contact_persons_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/contact_persons_controller.rb
@@ -13,7 +13,7 @@ class ResponsiblePersons::ContactPersonsController < SubmitApplicationController
 
   def create
     if @contact_person.save
-      redirect_to responsible_person_notifications_path(@responsible_person)
+      redirect_to responsible_person_path(@responsible_person)
     else
       render :new
     end

--- a/cosmetics-web/spec/features/creating_a_responsible_person_spec.rb
+++ b/cosmetics-web/spec/features/creating_a_responsible_person_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Creating a responsible person", type: :feature do
     fill_in_rp_sole_trader_details(name: "Auto-test rpuser")
     fill_in_rp_contact_details
 
-    expect(page).to have_h1("Cosmetic products")
+    expect(page).to have_h1("UK Responsible Person")
   end
 
   scenario "creating a responsible person as a limited company" do
@@ -41,7 +41,7 @@ RSpec.describe "Creating a responsible person", type: :feature do
     fill_in_rp_business_details(name: "Auto-test rpuser")
     fill_in_rp_contact_details
 
-    expect(page).to have_h1("Cosmetic products")
+    expect(page).to have_h1("UK Responsible Person")
   end
 
   scenario "creating a responsible person with the same name as an existing one" do
@@ -62,7 +62,7 @@ RSpec.describe "Creating a responsible person", type: :feature do
     expect(page).not_to have_css("h2#error-summary-title", text: "There is a problem")
     fill_in_rp_contact_details
 
-    expect(page).to have_h1("Cosmetic products")
+    expect(page).to have_h1("UK Responsible Person")
   end
 
   scenario "creating a responsible person with the same name as another responbible person the user belongs to" do

--- a/cosmetics-web/spec/features/multiple_responsible_person_spec.rb
+++ b/cosmetics-web/spec/features/multiple_responsible_person_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
     fill_in_rp_business_details(name: name)
     fill_in_rp_contact_details
 
-    expect(page).to have_h1("Cosmetic products")
-    expect(page).to have_css(".responsible-person-name", text: name)
+    expect(page).to have_h1("UK Responsible Person")
+    expect(page).to have_text(name)
   end
 
   scenario "Adding new responsible person - cant ommit contact details" do

--- a/cosmetics-web/spec/requests/contact_person_request_spec.rb
+++ b/cosmetics-web/spec/requests/contact_person_request_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "Contact person pages", :with_stubbed_mailer, type: :request do
         }
       end
 
-      it "redirects to the notifications dashboard" do
-        expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications")
+      it "redirects to the Responsible Person page" do
+        expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}")
       end
 
       it "saves the contact person’s details" do


### PR DESCRIPTION
As done when changing RP, when finishing adding a new RP after adding
contact person details, we want to redirect the user to the Responsible
Person page instead of redirecting them to the RP notifications page.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
