### PR TITLE
Allow users to edit RP type

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons_controller.rb
@@ -24,11 +24,11 @@ class ResponsiblePersonsController < SubmitApplicationController
   def edit; end
 
   def update
-    result = UpdateResponsiblePersonAddress.call(responsible_person: @responsible_person,
+    result = UpdateResponsiblePersonDetails.call(responsible_person: @responsible_person,
                                                  user: current_user,
-                                                 address: responsible_person_address_params.to_h)
+                                                 details: update_params.to_h)
     if result.success?
-      confirmation = "Responsible Person address changed successfully" if result.address_changed
+      confirmation = "Responsible Person details changed successfully" if result.changed
       redirect_to(responsible_person_path(@responsible_person), confirmation: confirmation)
     else
       render :edit
@@ -52,8 +52,9 @@ private
       )
   end
 
-  def responsible_person_address_params
+  def update_params
     params.require(:responsible_person).permit(
+      :account_type,
       :address_line_1,
       :address_line_2,
       :city,

--- a/cosmetics-web/app/views/responsible_persons/edit.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/edit.html.erb
@@ -1,4 +1,4 @@
-<% page_title("Edit the UK Responsible Person details", errors: @responsible_person.errors.any?) %>
+<% page_title("Edit the Responsible Person details", errors: @responsible_person.errors.any?) %>
 
 <% content_for :after_header do %>
   <%= link_to "Back", responsible_person_path(@responsible_person), class: "govuk-back-link" %>
@@ -9,7 +9,7 @@
     <%= error_summary(@responsible_person.errors, %i[address_line_1 address_line_2 city county postal_code]) %>
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-      Edit the <abbr>UK</abbr> Responsible Person details
+      Edit the Responsible Person details
     </h1>
 
     <%= govukDetails(summaryHtml: "Help with the <abbr>UK</abbr> Responsible Person details".html_safe, classes: "opss-details--sm govuk-!-margin-top-4") do %>

--- a/cosmetics-web/app/views/responsible_persons/edit.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/edit.html.erb
@@ -30,7 +30,7 @@
     <%= govukWarningText(
       iconFallbackText: "Warning",
       classes: "govuk-!-margin-bottom-0 govuk-!-margin-top-7 opss-warning-text--s",
-      text: "You must update your cosmetic product labels with the new address. Any cosmetic products you have notified will be associated with the new address. You will not need to submit a new notification."
+      text: "You must update your cosmetic product labels with any change to the address. Any cosmetic products you have notified will be associated with the new address. You will not need to submit a new notification."
     )%>
 
     <%= govukWarningText(

--- a/cosmetics-web/app/views/responsible_persons/edit.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/edit.html.erb
@@ -44,6 +44,23 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@responsible_person, method: :put, html: { novalidate: true }) do |form| %>
+      <%= render("form_components/govuk_radios",
+                 form: form,
+                 key: :account_type,
+                 formGroup: { classes: "govuk-!-margin-top-6" },
+                 fieldset: { legend: { html: "Is the <abbr>UK</abbr> Responsible Person a business or an individual?".html_safe,
+                             classes: "govuk-fieldset__legend--s" } },
+                 classes: "govuk-radios--small",
+                 items: [
+                   { html: "Limited company or Limited Liability Partnership (<abbr>LLP</abbr>)".html_safe,
+                     id: "account_type_business",
+                     value: :business,
+                     label: { classes: "govuk-!-padding-bottom-0" } },
+                   { text: "Individual or sole trader",
+                     id: "account_type_individual",
+                     value: :individual,
+                     label: { classes: "govuk-!-padding-bottom-0" } },
+                 ]) %>
       <fieldset class="govuk-fieldset ">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
           <h2 class="govuk-fieldset__heading">

--- a/cosmetics-web/app/views/responsible_persons/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "UK Responsible Person" %>
+<% content_for :page_title, "Responsible Person" %>
 <% content_for :after_header do %>
   <%= render "layouts/navbar" %>
 <% end %>
@@ -10,7 +10,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-2" aria-describedby="responsible-person-hint">
-          <abbr>UK</abbr> Responsible Person
+          Responsible Person
         </h1>
       </div>
       <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">

--- a/cosmetics-web/app/views/responsible_persons/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/show.html.erb
@@ -68,6 +68,16 @@
               when "business" then "Limited company or Limited Liability Partnership (LLP)"
               end
           },
+          actions: {
+            items: [
+              {
+                href: edit_responsible_person_path(@responsible_person),
+                text: "Edit",
+                classes: "govuk-link--no-visited-state",
+                visuallyHiddenText: "the business type"
+              }
+            ]
+          }
         }
       ])
     %>

--- a/cosmetics-web/spec/features/creating_a_responsible_person_spec.rb
+++ b/cosmetics-web/spec/features/creating_a_responsible_person_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Creating a responsible person", type: :feature do
     fill_in_rp_sole_trader_details(name: "Auto-test rpuser")
     fill_in_rp_contact_details
 
-    expect(page).to have_h1("UK Responsible Person")
+    expect(page).to have_h1("Responsible Person")
   end
 
   scenario "creating a responsible person as a limited company" do
@@ -37,7 +37,7 @@ RSpec.describe "Creating a responsible person", type: :feature do
     fill_in_rp_business_details(name: "Auto-test rpuser")
     fill_in_rp_contact_details
 
-    expect(page).to have_h1("UK Responsible Person")
+    expect(page).to have_h1("Responsible Person")
   end
 
   scenario "creating a responsible person with the same name as an existing one" do
@@ -57,7 +57,7 @@ RSpec.describe "Creating a responsible person", type: :feature do
     expect(page).not_to have_css("h2#error-summary-title", text: "There is a problem")
     fill_in_rp_contact_details
 
-    expect(page).to have_h1("UK Responsible Person")
+    expect(page).to have_h1("Responsible Person")
   end
 
   scenario "creating a responsible person with the same name as another responbible person the user belongs to" do
@@ -69,7 +69,7 @@ RSpec.describe "Creating a responsible person", type: :feature do
     expect_to_be_on__responsible_person_declaration_page
     click_button "I confirm"
 
-    expect(page).to have_h1("UK Responsible Person")
+    expect(page).to have_h1("Responsible Person")
     click_link "Add a Responsible Person"
 
     expect(page).to have_h1("Add a Responsible Person")

--- a/cosmetics-web/spec/features/editing_responsible_person_address_spec.rb
+++ b/cosmetics-web/spec/features/editing_responsible_person_address_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Editing responsible person address", :with_stubbed_mailer, type:
     expect_to_be_on__responsible_person_page
     click_link("Edit the address", href: "/responsible_persons/#{responsible_person.id}/edit")
 
-    expect(page).to have_h1("Edit the UK Responsible Person details")
+    expect(page).to have_h1("Edit the Responsible Person details")
     expect_back_link_to_responsible_person_page
 
     # First attempts with validation error
@@ -35,7 +35,7 @@ RSpec.describe "Editing responsible person address", :with_stubbed_mailer, type:
     fill_in "Postcode", with: ""
     click_button "Save and continue"
 
-    expect(page).to have_h1("Edit the UK Responsible Person details")
+    expect(page).to have_h1("Edit the Responsible Person details")
     expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
     expect(page).to have_link("Enter a building and street", href: "#address_line_1")
     expect(page).to have_css("span#address_line_1-error", text: "Enter a building and street")

--- a/cosmetics-web/spec/features/editing_responsible_person_details_spec.rb
+++ b/cosmetics-web/spec/features/editing_responsible_person_details_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Editing responsible person address", :with_stubbed_mailer, type: :feature do
+RSpec.describe "Editing responsible person details", :with_stubbed_mailer, type: :feature do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person, name: "Test RP") }
   let(:user) { create(:submit_user) }
   let(:other_member) { create(:submit_user) }
@@ -17,7 +17,7 @@ RSpec.describe "Editing responsible person address", :with_stubbed_mailer, type:
     expect(page).not_to have_link("Edit")
   end
 
-  scenario "user belonging to the responsible person can edit the responsible person address" do
+  scenario "user belonging to the responsible person can edit the Responsible Person address" do
     sign_in_as_member_of_responsible_person(responsible_person, user)
     visit "/responsible_persons/#{responsible_person.id}"
 
@@ -26,8 +26,10 @@ RSpec.describe "Editing responsible person address", :with_stubbed_mailer, type:
 
     expect(page).to have_h1("Edit the Responsible Person details")
     expect_back_link_to_responsible_person_page
+    expect(page).to have_checked_field("Individual or sole trader")
 
     # First attempts with validation error
+    choose "Limited company or Limited Liability Partnership (LLP)"
     fill_in "Building and street line 1 of 2", with: ""
     fill_in "Building and street line 2 of 2", with: ""
     fill_in "Town or city", with: ""
@@ -45,6 +47,7 @@ RSpec.describe "Editing responsible person address", :with_stubbed_mailer, type:
     expect(page).to have_css("span#postal_code-error", text: "Enter a postcode")
 
     # Successful attempt
+    choose "Limited company or Limited Liability Partnership (LLP)"
     fill_in "Building and street line 1 of 2", with: "Office building name"
     fill_in "Building and street line 2 of 2", with: "Example street"
     fill_in "Town or city", with: "Manchester"
@@ -53,7 +56,12 @@ RSpec.describe "Editing responsible person address", :with_stubbed_mailer, type:
     click_button "Save and continue"
 
     expect_to_be_on__responsible_person_page
-    expect(page).to have_text("Responsible Person address changed successfully")
+    expect(page).to have_text("Responsible Person details changed successfully")
+    business_type_elem = page.find("dt", text: "Business type", exact_text: true)
+    expect(business_type_elem).to have_sibling("td, dd",
+                                               text: "Limited company or Limited Liability Partnership (LLP)",
+                                               exact_text: true)
+
     address_elem = page.find("dt", text: "Address", exact_text: true)
     expect(address_elem).to have_sibling("dd", text: "Office building name", exact_text: false)
     expect(address_elem).to have_sibling("dd", text: "Example street", exact_text: false)

--- a/cosmetics-web/spec/features/multiple_responsible_person_spec.rb
+++ b/cosmetics-web/spec/features/multiple_responsible_person_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
     click_on "Change the Responsible Person"
     choose name_2
     click_on "Save and continue"
-    expect(page).to have_h1("UK Responsible Person")
+    expect(page).to have_h1("Responsible Person")
     expect(page).to have_current_path("/responsible_persons/#{responsible_person_2.id}")
   end
 
@@ -69,7 +69,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
     fill_in_rp_business_details(name: name)
     fill_in_rp_contact_details
 
-    expect(page).to have_h1("UK Responsible Person")
+    expect(page).to have_h1("Responsible Person")
     expect(page).to have_text(name)
   end
 

--- a/cosmetics-web/spec/requests/responsible_persons/edit_details_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/edit_details_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Edit Responsible Person Address", type: :request do
+RSpec.describe "Edit Responsible Person Details", type: :request do
   let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
   let(:other_responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
   let(:user) { responsible_person.users.first }
@@ -45,9 +45,10 @@ RSpec.describe "Edit Responsible Person Address", type: :request do
     end
   end
 
-  describe "Update address" do
+  describe "Update details" do
     let(:params) do
       {
+        account_type: "business",
         address_line_1: "11",
         address_line_2: "Fake St",
         city: "Fake City",
@@ -77,19 +78,22 @@ RSpec.describe "Edit Responsible Person Address", type: :request do
         expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}")
       end
 
-      it "updates the responsible person's address" do
+      # rubocop:disable RSpec/ExampleLength
+      it "updates the responsible person's details" do
         update_request
-        expect(responsible_person.reload).to have_attributes(address_line_1: "11",
+        expect(responsible_person.reload).to have_attributes(account_type: "business",
+                                                             address_line_1: "11",
                                                              address_line_2: "Fake St",
                                                              city: "Fake City",
                                                              county: "County",
                                                              postal_code: "FA1 1FA")
       end
+      # rubocop:enable RSpec/ExampleLength
 
       it "response includes a confirmation message" do
         update_request
         follow_redirect!
-        expect(response.body).to include("Responsible Person address changed successfully")
+        expect(response.body).to include("Responsible Person details changed successfully")
       end
 
       it "records the previous responsible person address into DB" do
@@ -100,6 +104,7 @@ RSpec.describe "Edit Responsible Person Address", type: :request do
     context "when missing some required data" do
       let(:params) do
         {
+          account_type: "",
           address_line_1: "",
           address_line_2: "Fake St",
           city: "",
@@ -112,8 +117,9 @@ RSpec.describe "Edit Responsible Person Address", type: :request do
         put "/responsible_persons/#{responsible_person.id}", params: { responsible_person: params }
       end
 
-      it "renders a page instead of redirecting" do
+      it "renders the edit page instead of redirecting" do
         expect(response.status).to be 200
+        expect(response).to render_template(:edit)
       end
 
       it "includes a validation error message in the response" do
@@ -122,6 +128,7 @@ RSpec.describe "Edit Responsible Person Address", type: :request do
 
       it "does not update the responsible person’s details" do
         expect(responsible_person.reload).to have_attributes(
+          account_type: "individual",
           address_line_1: "Street address",
           city: "City",
           postal_code: "AB12 3CD",

--- a/cosmetics-web/spec/services/update_responsible_person_details_spec.rb
+++ b/cosmetics-web/spec/services/update_responsible_person_details_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
-RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
-  let(:original_address) do
+RSpec.describe UpdateResponsiblePersonDetails, :with_stubbed_mailer do
+  let(:original_details) do
     {
+      account_type: "individual",
       address_line_1: "Original street",
       address_line_2: "",
       city: "Original city",
@@ -11,8 +12,9 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
     }
   end
 
-  let(:new_address) do
+  let(:new_details) do
     {
+      account_type: "business",
       address_line_1: "Office building",
       address_line_2: "Fake St",
       city: "FooBar City",
@@ -29,7 +31,7 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
     create(:responsible_person,
            users: [user, second_member, third_member],
            created_at: Time.zone.local(2021, 11, 6),
-           **original_address)
+           **original_details)
   end
 
   before do
@@ -41,48 +43,80 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
   end
 
   it "fails when no user is provided" do
-    result = described_class.call(responsible_person: responsible_person, address: new_address)
+    result = described_class.call(responsible_person: responsible_person, details: new_details)
     expect(result).to be_failure
     expect(result.error).to eq "No user provided"
   end
 
   it "fails when no responsible person is provided" do
-    result = described_class.call(user: user, address: new_address)
+    result = described_class.call(user: user, details: new_details)
     expect(result).to be_failure
     expect(result.error).to eq "No Responsible Person provided"
   end
 
-  it "fails when no address is provided" do
+  it "fails when no details are provided" do
     result = described_class.call(user: user, responsible_person: responsible_person)
     expect(result).to be_failure
-    expect(result.error).to eq "No address provided"
+    expect(result.error).to eq "No details provided"
   end
 
   it "fails when given user does not belong to responsible person" do
     other_user = create(:submit_user)
-    result = described_class.call(user: other_user, responsible_person: responsible_person, address: new_address)
+    result = described_class.call(user: other_user, responsible_person: responsible_person, details: new_details)
     expect(result).to be_failure
     expect(result.error).to eq "User does not belong to Responsible Person"
   end
 
-  it "fails when fields not belonging to the RP address are provided" do
-    new_address[:foo] = "bar"
-    result = described_class.call(user: user, responsible_person: responsible_person, address: new_address)
+  it "fails when not allowed fields are provided" do
+    new_details[:name] = "foobar"
+    result = described_class.call(user: user, responsible_person: responsible_person, details: new_details)
     expect(result).to be_failure
-    expect(result.error).to eq "Address contains unknown fields"
+    expect(result.error).to eq "Details contain invalid attributes"
   end
 
-  context "when the provided address is the same as the original address" do
+  context "when the provided details are the same as the original ones" do
     let!(:result) do
-      described_class.call(user: user, responsible_person: responsible_person, address: original_address)
+      described_class.call(user: user, responsible_person: responsible_person, details: original_details)
     end
 
     it "succeeds" do
       expect(result).to be_success
     end
 
+    it "marks the result as unchanged" do
+      expect(result.changed).to eq false
+    end
+
     it "does not change the responsible person address values" do
-      expect(responsible_person.reload).to have_attributes(original_address)
+      expect(responsible_person.reload).to have_attributes(original_details)
+    end
+
+    it "does not send any email" do
+      expect(delivered_emails).to be_empty
+    end
+
+    it "does not record the original address for the responsible person" do
+      expect(responsible_person.reload.address_logs).to be_empty
+    end
+  end
+
+  context "when the business type has changed but the address has not" do
+    let!(:result) do
+      described_class.call(user: user,
+                           responsible_person: responsible_person,
+                           details: original_details.merge(account_type: "business"))
+    end
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "marks the result as changed" do
+      expect(result.changed).to eq true
+    end
+
+    it "changes the responsible person business type in DB but not the address" do
+      expect(responsible_person.reload).to have_attributes(original_details.merge(account_type: "business"))
     end
 
     it "does not send any email" do
@@ -97,15 +131,19 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
   context "when the provided address is different from the original one" do
     context "without any exception" do
       let!(:result) do
-        described_class.call(user: user, responsible_person: responsible_person, address: new_address)
+        described_class.call(user: user, responsible_person: responsible_person, details: new_details)
       end
 
       it "succeeds" do
         expect(result).to be_success
       end
 
+      it "marks the result as changed" do
+        expect(result.changed).to eq true
+      end
+
       it "update the responsible person address values" do
-        expect(responsible_person.reload).to have_attributes(new_address)
+        expect(responsible_person.reload).to have_attributes(new_details)
       end
 
       it "does send an email to all the responsible person members" do
@@ -147,11 +185,11 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
       it "records the original address for the responsible person" do
         expect(responsible_person.address_logs.size).to eq 1
         expect(responsible_person.address_logs.first).to have_attributes(
-          line_1: original_address[:address_line_1],
-          line_2: original_address[:address_line_2],
-          city: original_address[:city],
-          county: original_address[:county],
-          postal_code: original_address[:postal_code],
+          line_1: original_details[:address_line_1],
+          line_2: original_details[:address_line_2],
+          city: original_details[:city],
+          county: original_details[:county],
+          postal_code: original_details[:postal_code],
           start_date: responsible_person.created_at,
           end_date: time_service_was_called,
         )
@@ -160,9 +198,18 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
     end
 
     context "with an exception while attempting to archive the previous address" do
-      let(:address_log_stub) { instance_double(ResponsiblePersonAddressLog) }
+      let(:address_log_stub) do
+        instance_double(ResponsiblePersonAddressLog,
+                        line_1: nil,
+                        line_2: nil,
+                        city: nil,
+                        county: nil,
+                        postal_code: nil,
+                        start_date: nil,
+                        end_date: nil)
+      end
       let(:result) do
-        described_class.call(user: user, responsible_person: responsible_person, address: new_address)
+        described_class.call(user: user, responsible_person: responsible_person, details: new_details)
       end
 
       before do
@@ -175,8 +222,8 @@ RSpec.describe UpdateResponsiblePersonAddress, :with_stubbed_mailer do
         expect(result).to be_failure
       end
 
-      it "does not keep the Responsible Person address update" do
-        expect(responsible_person.reload).to have_attributes(original_address)
+      it "reverts the Responsible Person details change" do
+        expect(responsible_person.reload).to have_attributes(original_details)
       end
 
       it "no emails are sent" do

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -138,7 +138,7 @@ end
 
 def expect_to_be_on__responsible_person_page
   expect(page.current_path).to eql("/responsible_persons/#{responsible_person.id}")
-  expect(page).to have_h1("UK Responsible Person")
+  expect(page).to have_h1("Responsible Person")
 end
 
 def expect_back_link_to_responsible_person_page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1370)

## Description
Users from a Responsible Person will be able to edit the RP account type, choosing between Individual or Business.

This change is accessible from the Responsible Person details page, adding a link to edit the RP type.
This link sends the user to the RP edit page, also used for editing the RP address.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2417-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2417-search-web.london.cloudapps.digital/

## Screenshots
### RP details page
![image](https://user-images.githubusercontent.com/1227578/153932130-f3431ac0-4003-4c5e-a771-61d20835d29a.png)

### RP edit page
![image](https://user-images.githubusercontent.com/1227578/153932237-f6dd2a06-eefa-4473-8fd2-70d7127484a0.png)
