### PR TITLE
Only offer date range to Search non-js users

### DIFF
--- a/cosmetics-web/app/assets/application/javascripts/notification_search.js
+++ b/cosmetics-web/app/assets/application/javascripts/notification_search.js
@@ -33,4 +33,11 @@ $(function () {
       })
     }, false)
   }
+
+  /* hide first filter for non js - start */
+  if (document.getElementById('by-date-range')) {
+    if (!window.location.search) { // = no querystring
+      document.getElementById('by-date-range').removeAttribute('checked')
+    }
+  }
 })

--- a/cosmetics-web/app/assets/application/javascripts/notification_search.js
+++ b/cosmetics-web/app/assets/application/javascripts/notification_search.js
@@ -55,5 +55,6 @@ $(function () {
         document.getElementById('by-date-range').removeAttribute('checked')
       }
     }
+    document.getElementById('conditional-date-block-2').classList.remove('opss-js-enabled-hidden')
   }
 })

--- a/cosmetics-web/app/assets/application/javascripts/notification_search.js
+++ b/cosmetics-web/app/assets/application/javascripts/notification_search.js
@@ -36,8 +36,24 @@ $(function () {
 
   /* hide first filter for non js - start */
   if (document.getElementById('by-date-range')) {
-    if (!window.location.search) { // = no querystring
+    /* Removes checked date range radio (collapses date rangge) when there is no query string. */
+    if (!window.location.search) {
       document.getElementById('by-date-range').removeAttribute('checked')
+    } else { // When there is a query string
+      const IDinputs = document.getElementById('conditional-date-block-2')
+      const myInputs = IDinputs.getElementsByTagName('input')
+      let anyVal = false
+      /* Identifies if any of the date inputs has a value */
+      for (i = 0; i < myInputs.length; ++i) {
+        if (myInputs[i].value != '') {
+          anyVal = true
+          break
+        }
+      }
+      /* If all the date range inputs are empty, removes checked radio (collapses date range) */
+      if (anyVal == false) {
+        document.getElementById('by-date-range').removeAttribute('checked')
+      }
     }
   }
 })

--- a/cosmetics-web/app/assets/application/javascripts/notification_search.js
+++ b/cosmetics-web/app/assets/application/javascripts/notification_search.js
@@ -44,14 +44,14 @@ $(function () {
       const myInputs = IDinputs.getElementsByTagName('input')
       let anyVal = false
       /* Identifies if any of the date inputs has a value */
-      for (i = 0; i < myInputs.length; ++i) {
-        if (myInputs[i].value != '') {
+      for (const input of myInputs) {
+        if (input.value !== '') {
           anyVal = true
           break
         }
       }
       /* If all the date range inputs are empty, removes checked radio (collapses date range) */
-      if (anyVal == false) {
+      if (anyVal === false) {
         document.getElementById('by-date-range').removeAttribute('checked')
       }
     }

--- a/cosmetics-web/app/assets/packs/shared.js
+++ b/cosmetics-web/app/assets/packs/shared.js
@@ -2,11 +2,11 @@
 import Rails from 'rails-ujs'
 import GOVUKFrontend from 'govuk-frontend'
 
+import '../application/javascripts/notification_search'
 import '../application/javascripts/location_picker'
 import '../application/javascripts/autocomplete'
 import '../application/javascripts/bulk_file_upload_error_handling'
 import '../application/javascripts/image_size_validation'
-import '../application/javascripts/notification_search'
 
 import * as ActiveStorage from '@rails/activestorage'
 

--- a/cosmetics-web/app/views/poison_centres/notifications/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/_filters.html.erb
@@ -72,7 +72,7 @@
       <button type="submit" class="govuk-button" data-module="govuk-button">
         Apply
       </button>
-      <button type="reset" class="govuk-button govuk-!-font-size-16 opss-button-link" id="opss-reset">
+      <button type="reset" class="govuk-button govuk-!-font-size-16 opss-button-link opss-nojs-hide" id="opss-reset">
         Reset
       </button>
     </div>

--- a/cosmetics-web/app/views/poison_centres/notifications/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/_filters.html.erb
@@ -21,13 +21,13 @@
         </div>
         <div class="govuk-radios govuk-radios--small govuk-radios--conditional opss-radios--tight" data-module="govuk-radios">
 
-          <div class="govuk-radios__item">
+          <div class="govuk-radios__item opss-nojs-hide">
             <%= form.radio_button :date_filter, @search_form.class::FILTER_BY_DATE_EXACT, 'class' => "govuk-radios__input", 'id' => "by-date", 'aria-describedby' => "by-date-hint", 'aria-controls' => "conditional-date-block-1" %>
             <label class="govuk-label govuk-radios__label" for="by-date">
               Date
             </label>
           </div>
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden <%= search_date_filter_group_error_class(:date_exact) %>" id="conditional-date-block-1">
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden opss-nojs-hide <%= search_date_filter_group_error_class(:date_exact) %>" id="conditional-date-block-1">
             <div class="govuk-form-group">
 
               <div id="by-date-hint" class="govuk-hint govuk-!-font-size-16">
@@ -39,7 +39,7 @@
             </div>
           </div>
           <div class="govuk-radios__item">
-            <%= form.radio_button :date_filter, @search_form.class::FILTER_BY_DATE_RANGE, 'class' => "govuk-radios__input", 'id' => "by-date-range", 'aria-describedby' => "by-date-hint", 'aria-controls' => "conditional-date-block-2" %>
+            <%= form.radio_button :date_filter, @search_form.class::FILTER_BY_DATE_RANGE, 'class' => "govuk-radios__input", 'id' => "by-date-range", 'aria-describedby' => "by-date-hint", 'aria-controls' => "conditional-date-block-2", 'checked' => true %>
             <label class="govuk-label govuk-radios__label" for="by-date-range">
               Date range
             </label>

--- a/cosmetics-web/app/views/poison_centres/notifications/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications/_filters.html.erb
@@ -45,7 +45,7 @@
             </label>
           </div>
 
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden <%= search_date_filter_group_error_class(:date_from, :date_to) %>" id="conditional-date-block-2">
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden opss-js-enabled-hidden <%= search_date_filter_group_error_class(:date_from, :date_to) %>" id="conditional-date-block-2">
             <div class="govuk-form-group">
 
               <div id="by-date-range-hint" class="govuk-hint govuk-!-font-size-16">


### PR DESCRIPTION
Instead of having all the date input filter fields expanded, causing
confusion when filling multiple fields but not selecting the radio
button for either date/date range filtering, now Search users using
browsers without JS, will only have the date range inputs displayed
and pre-selected.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2420-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2420-search-web.london.cloudapps.digital/
