### PR TITLE
Upgrade Redis version from 3 to 6

### DIFF
--- a/cosmetics-web/deploy-review.sh
+++ b/cosmetics-web/deploy-review.sh
@@ -32,7 +32,7 @@ if [ -z "$REDIS_NAME" ]
 then
   REDIS_NAME=cosmetics-review-redis
 fi
-cf create-service redis tiny-3.2 $REDIS_NAME
+cf create-service redis micro-6.x $REDIS_NAME
 
 # Wait until redis service is prepared, might take up to 10 minutes
 until cf service $REDIS_NAME > /tmp/redis_exists && grep "create succeeded" /tmp/redis_exists; do sleep 20; echo "Waiting for redis"; done

--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -14,7 +14,7 @@ applications:
   services:
     - cosmetics-database
     - cosmetics-opensearch-1
-    - cosmetics-queue
+    - cosmetics-queue-v6
     - opss-log-drain
     - cosmetics-aws-env
     - cosmetics-auth-env


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1382)

## Description
Upgrading Redis service in all our environments to Redis v6 from current Redis v3.2

## Chosen plans

### Int (review apps) and Staging
- From **tiny-3.2** 568MB RAM, single node, no failover, daily backups (for instances created after 21/1/2019). Free for trial orgs. Costs for billable orgs.

- To **micro-6.x** 568MB RAM, single node, no failover, daily backups. Free for trial orgs. Costs for billable orgs.
Micro 6.x offers the same resources as the current Tiny 3.2. Tiny 6.x uses 1.5GB RAM (that we do not need in this environment)

### Production
- From **tiny-ha-3.2** 1.5GB RAM, highly-available, daily backups
- To **tiny-ha-6.x** 1.5GB RAM, highly-available, daily backups

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2434-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2434-search-web.london.cloudapps.digital/


### To Do:
- [x] Create Staging and Production Redis v6 services.
- [x] Point manifest to new Redis v6 services.
- [x] Out of hours: Deploy to Staging/Production.
- [ ] Out of hours: Unbind Redis v3 service from Staging/Production