### PR TITLE
Improvements over nanomaterials and multi-items wizard pages

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
@@ -92,12 +92,7 @@ private
     return rerender_current_step unless form.valid?
 
     model.save_routing_answer(step, form.contains_nanomaterials)
-
-    if form.contains_nanomaterials?
-      nano_materials_count = form.nanomaterials_count.to_i
-      nano_materials_count -= 1 if @notification.nano_materials.present?
-      @notification.make_ready_for_nanomaterials!(nano_materials_count)
-    end
+    @notification.make_ready_for_nanomaterials!(form.nanomaterials_count.to_i)
     render_next_step @notification
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
@@ -60,7 +60,7 @@ private
 
   def set_final_state_for_wizard
     # Make sure state wont be overrided if notification is in higher state
-    return if @notification.notification_product_wizard_completed?
+    return if @notification.product_wizard_completed?
 
     @notification.set_state_on_product_wizard_completed!
   end

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
@@ -26,7 +26,7 @@ class ResponsiblePersons::Wizard::NotificationProductController < SubmitApplicat
   def show
     case step
     when :completed
-      set_final_state_for_wizard
+      @notification.set_state_on_product_wizard_completed!
       render "responsible_persons/wizard/completed"
     else
       render_wizard
@@ -57,13 +57,6 @@ class ResponsiblePersons::Wizard::NotificationProductController < SubmitApplicat
   end
 
 private
-
-  def set_final_state_for_wizard
-    # Make sure state wont be overrided if notification is in higher state
-    return if @notification.product_wizard_completed?
-
-    @notification.set_state_on_product_wizard_completed!
-  end
 
   def update_add_internal_reference
     case params.dig(:notification, :add_internal_reference)

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
@@ -108,22 +108,7 @@ private
     form = single_or_multi_component_form
     return rerender_current_step unless form.valid?
 
-    if form.single_component?
-      @notification.components.create if @notification.components.empty?
-    elsif form.multi_component?
-      components_count = form.components_count&.to_i
-      # This happens only when there only one component
-      if components_count > @notification.components.count
-        # TODO: quite entangled
-
-        # We can reset previous state, as previous state functionality
-        # is to prevent messing state when nanos are added.
-        @notification.reset_previous_state!
-        @notification.revert_to_details_complete
-      end
-      required_components_count = @notification.components.present? ? components_count - 1 : components_count
-      required_components_count.times { @notification.components.create }
-    end
+    @notification.make_single_ready_for_components!(form.components_count.to_i)
     render_next_step @notification
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
@@ -77,9 +77,9 @@ private
     end
   end
 
-  # Run this step only when notification doesn't already have multiple nanomaterials
+  # Run this step only when notification doesn't already have nanomaterials
   def update_contains_nanomaterials
-    return render_next_step @notification if @notification.nano_materials.count > 1
+    return render_next_step @notification if @notification.nano_materials.any?
 
     form = contains_nanomaterials_form
     return rerender_current_step unless form.valid?

--- a/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/wizard/notification_product_controller.rb
@@ -98,7 +98,7 @@ private
 
   # Run this step only when notifications does not have multiple components
   def update_single_or_multi_component_step
-    return render_next_step @notification if @notification.components.count > 1
+    return render_next_step @notification if @notification.multi_component?
 
     form = single_or_multi_component_form
     return rerender_current_step unless form.valid?

--- a/cosmetics-web/app/forms/responsible_persons/wizard/notification_product/contains_nanomaterials_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/wizard/notification_product/contains_nanomaterials_form.rb
@@ -9,7 +9,7 @@ module ResponsiblePersons
 
         validates :contains_nanomaterials, inclusion: { in: %w[yes no] }
         validates :nanomaterials_count,
-                  numericality: { greater_than: 0, less_than_or_equal_to: 10 },
+                  numericality: { greater_than: 0, less_than_or_equal_to: 10, only_integer: true },
                   if: -> { contains_nanomaterials == "yes" }
 
         def contains_nanomaterials?

--- a/cosmetics-web/app/forms/responsible_persons/wizard/notification_product/contains_nanomaterials_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/wizard/notification_product/contains_nanomaterials_form.rb
@@ -1,0 +1,21 @@
+module ResponsiblePersons
+  module Wizard
+    module NotificationProduct
+      class ContainsNanomaterialsForm < Form
+        include StripWhitespace
+
+        attribute :contains_nanomaterials
+        attribute :nanomaterials_count
+
+        validates :contains_nanomaterials, inclusion: { in: %w[yes no] }
+        validates :nanomaterials_count,
+                  numericality: { greater_than: 0, less_than_or_equal_to: 10 },
+                  if: -> { contains_nanomaterials == "yes" }
+
+        def contains_nanomaterials?
+          contains_nanomaterials == "yes"
+        end
+      end
+    end
+  end
+end

--- a/cosmetics-web/app/forms/responsible_persons/wizard/notification_product/single_or_multi_component_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/wizard/notification_product/single_or_multi_component_form.rb
@@ -1,0 +1,28 @@
+module ResponsiblePersons
+  module Wizard
+    module NotificationProduct
+      class SingleOrMultiComponentForm < Form
+        SINGLE = "single".freeze
+        MULTI = "multiple".freeze
+
+        include StripWhitespace
+
+        attribute :single_or_multi_component
+        attribute :components_count
+
+        validates :single_or_multi_component, inclusion: { in: [SINGLE, MULTI] }
+        validates :components_count,
+                  numericality: { greater_than: 1, less_than_or_equal_to: 10 },
+                  if: -> { multi_component? }
+
+        def single_component?
+          single_or_multi_component == SINGLE
+        end
+
+        def multi_component?
+          single_or_multi_component == MULTI
+        end
+      end
+    end
+  end
+end

--- a/cosmetics-web/app/forms/responsible_persons/wizard/notification_product/single_or_multi_component_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/wizard/notification_product/single_or_multi_component_form.rb
@@ -12,7 +12,7 @@ module ResponsiblePersons
 
         validates :single_or_multi_component, inclusion: { in: [SINGLE, MULTI] }
         validates :components_count,
-                  numericality: { greater_than: 1, less_than_or_equal_to: 10 },
+                  numericality: { greater_than: 1, less_than_or_equal_to: 10, only_integer: true },
                   if: -> { multi_component? }
 
         def single_component?

--- a/cosmetics-web/app/models/concerns/notification_state_concern.rb
+++ b/cosmetics-web/app/models/concerns/notification_state_concern.rb
@@ -75,7 +75,7 @@ module NotificationStateConcern
   end
 
   def set_state_on_product_wizard_completed!
-    return if product_wizard_completed? # State wont be overrided if notification is in higher state
+    return if product_wizard_completed? # State wont be overridden if notification is in higher state
 
     if nano_materials.count.positive?
       update_state(READY_FOR_NANOMATERIALS)

--- a/cosmetics-web/app/models/concerns/notification_state_concern.rb
+++ b/cosmetics-web/app/models/concerns/notification_state_concern.rb
@@ -75,6 +75,8 @@ module NotificationStateConcern
   end
 
   def set_state_on_product_wizard_completed!
+    return if product_wizard_completed? # State wont be overrided if notification is in higher state
+
     if nano_materials.count.positive?
       update_state(READY_FOR_NANOMATERIALS)
     elsif multi_component?

--- a/cosmetics-web/app/models/concerns/notification_state_concern.rb
+++ b/cosmetics-web/app/models/concerns/notification_state_concern.rb
@@ -102,7 +102,7 @@ module NotificationStateConcern
     end
   end
 
-  def notification_product_wizard_completed?
+  def product_wizard_completed?
     !empty? && !product_name_added?
   end
 

--- a/cosmetics-web/app/models/concerns/notification_state_concern.rb
+++ b/cosmetics-web/app/models/concerns/notification_state_concern.rb
@@ -103,7 +103,7 @@ module NotificationStateConcern
   end
 
   def notification_product_wizard_completed?
-    [EMPTY, PRODUCT_NAME_ADDED].exclude?(state)
+    !empty? && !product_name_added?
   end
 
   # TODO: quite entangled

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -203,6 +203,18 @@ class Notification < ApplicationRecord
     cpnp_reference.present?
   end
 
+  def make_ready_for_nanomaterials!(count)
+    count = count.to_i
+    return unless count.positive?
+
+    count.times do
+      nano_materials.create.tap do |nano|
+        nano.nano_elements.create
+      end
+    end
+    revert_to_ready_for_nanomaterials
+  end
+
   # =========================================
   # DELETING NOTIFICATIONS
   # =========================================

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -110,10 +110,6 @@ class Notification < ApplicationRecord
     )
   end
 
-  def notification_product_wizard_completed?
-    !empty? && !product_name_added?
-  end
-
   def reference_number_for_display
     return "" if reference_number.blank?
 

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -200,13 +200,12 @@ class Notification < ApplicationRecord
   end
 
   # Sets up a given count of nanomaterials for the notification.
-  # Nothing to do if notification already contains multiple nanomaterials.
+  # Nothing to do if notification already contains nanomaterials.
   # Returns number of nano materials added to the notification
   def make_ready_for_nanomaterials!(count)
     count = count.to_i
-    return 0 unless count.positive? && nano_materials.count <= 1
+    return 0 unless count.positive? && nano_materials.none?
 
-    count -= 1 if nano_materials.any? # Don't create the already existing nanomaterial
     transaction do
       count.times do
         nano_materials.create.tap do |nano|

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -211,8 +211,24 @@ class Notification < ApplicationRecord
       nano_materials.create.tap do |nano|
         nano.nano_elements.create
       end
+  # Sets up a single component notification or prepares it for the upgrade to multicomponent notification.
+  # Nothing to do if notification is already multicomponent.
+  # Returns number of components added to the notification.
+  def make_single_ready_for_components!(count)
+    return 0 if multi_component? || count.negative?
+
+    transaction do
+      if count > 1 # Turning into a multi component notification
+        reset_previous_state! # Previous state was set to prevent messing state when nanos are added
+        revert_to_details_complete
+      end
+
+      count += 1 if count.zero? # Single component notification
+      count -= 1 if components.any? # Don't create the already existing component
+      count.times { components.create! }
     end
     revert_to_ready_for_nanomaterials
+    count
   end
 
   # =========================================

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -230,7 +230,7 @@ class Notification < ApplicationRecord
       end
 
       count += 1 if count.zero? # Single component notification
-      count -= 1 if components.any? # Don't create the already existing component
+      count -= 1 if components.one? # Don't create the already existing component
       count.times { components.create! }
     end
     count

--- a/cosmetics-web/app/views/responsible_persons/drafts/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/drafts/show.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row opss-switch-cols">
   <div class="govuk-grid-column-one-quarter govuk-!-padding-top-9 opss-switch-cols__right">
     <div class="opss-text-align-right">
-      <%= link_to "View draft", edit_responsible_person_notification_path(@notification.responsible_person, @notification), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset" if @notification.notification_product_wizard_completed? %>
+      <%= link_to "View draft", edit_responsible_person_notification_path(@notification.responsible_person, @notification), class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset" if @notification.product_wizard_completed? %>
     </div>
     <div class="govuk-!-margin-top-7 govuk-!-margin-bottom-4">
       <%= render "responsible_persons/drafts/guides/#{@notification.state}" %>

--- a/cosmetics-web/app/views/responsible_persons/wizard/notification_product/contains_nanomaterials.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/notification_product/contains_nanomaterials.html.erb
@@ -1,14 +1,15 @@
 <% title = "Nanomaterials" %>
-<% page_title title %>
+<% errors = @contains_nanomaterials_form.errors %>
+<% page_title(title, errors: errors.any?) %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: previous_wizard_path %>
 <% end %>
 
 <% if @notification.nano_materials.blank? %>
-  <%= form_with model: @notification, url: wizard_path, method: :put do |form| %>
+  <%= form_with model: @contains_nanomaterials_form, url: wizard_path, scope: :contains_nanomaterials_form, method: :put do |form| %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= error_summary_for(@notification, first_values: {contains_nanomaterials: "yes"}) %>
+        <%= error_summary(errors, map_errors: { contains_nanomaterials: :contains_nanomaterials_yes }) %>
 
         <h1 class="govuk-heading-l"><%= title %></h1>
 
@@ -21,15 +22,29 @@
         </ul>
 
         <% count_input_html = capture do %>
-          <%= render "form_components/govuk_input", form: form, key: :nanomaterial_count,
-              label: { text: "Nanomaterial count" } %>
+          <%= render("form_components/govuk_input",
+                     form: form,
+                     key: :nanomaterials_count,
+                     id: "nanomaterials_count",
+                     label: { text: "How many nanomaterials?" },
+                     classes: "govuk-input--width-3") %>
         <% end %>
-        <%= render "form_components/govuk_radios", form: form, key: :contains_nanomaterials,
-                fieldset: { legend: { text: "Does #{@notification.product_name} contain nanomaterials?",
-                classes: "govuk-label--m" } },
-                items: [{ text: "Yes", value: "yes", conditional: { html: count_input_html },
-                      checked: params[:notification].present? && params[:notification][:contains_nanomaterials] == "yes" },
-                      { text: "No", value: "no", checked: answer_checked?("no") }] %>
+        <%= render("form_components/govuk_radios",
+                   form: form,
+                   key: :contains_nanomaterials,
+                   fieldset: { legend: { text: "Does #{@notification.product_name} contain nanomaterials?",
+                   classes: "govuk-label--m" } },
+                   items: [
+                     { text: "Yes",
+                       value: "yes",
+                       id: "contains_nanomaterials_yes",
+                       conditional: { html: count_input_html },
+                       checked: errors.include?(:nanomaterials_count) || form.object.contains_nanomaterials? },
+                     { text: "No",
+                       value: "no",
+                       id: "contains_nanomaterials_no",
+                       checked: errors.exclude?(:nanomaterials_count) && answer_checked?("no") },
+                    ]) %>
         <%= govukButton text: "Continue" %>
 
       </div>

--- a/cosmetics-web/app/views/responsible_persons/wizard/notification_product/single_or_multi_component.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/notification_product/single_or_multi_component.html.erb
@@ -55,11 +55,12 @@
                        value: "multiple",
                        id: "single_or_multi_component_multiple",
                        conditional: { html: count_input_html },
-                       checked: (params[:notification].present? && params[:notification][:single_or_multi_component] == "multiple") || @notification.components.count > 1 },
+                       checked: errors.include?(:components_count) || form.object.multi_component? },
                      { text: "No, this is a single product",
                        value: "single",
                        id: "single_or_multi_component_single",
-                       checked: (params[:notification].present? && params[:notification][:single_or_multi_component] == "single") || (@notification.components.count == 1 && !(params[:notification].present? && params[:notification][:single_or_multi_component] == "multiple")) },
+                       checked: errors.exclude?(:components_count) &&
+                                  (form.object.single_component? || (form.object.multi_component? && @notification.components.count == 1)) },
                    ]
                   ) %>
         <%= govukButton text: "Continue" %>

--- a/cosmetics-web/app/views/responsible_persons/wizard/notification_product/single_or_multi_component.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/wizard/notification_product/single_or_multi_component.html.erb
@@ -1,23 +1,21 @@
 <% title = "Multi-item kits" %>
-<% page_title title, errors: @notification.errors.any? %>
+<% errors = @single_or_multi_component_form.errors %>
+<% page_title(title, errors: errors.any?) %>
 <% content_for :after_header do %>
   <%= link_to "Back", previous_wizard_path, class: "govuk-back-link" %>
 <% end %>
 
 <% if @notification.components.count <= 1 %>
-  <%= form_with model: @notification, url: wizard_path, method: :put, disabled: true do |form| %>
-
+  <%= form_with model: @single_or_multi_component_form, url: wizard_path, scope: :single_or_multi_component_form, method: :put, disabled: true do |form| %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        <%= error_summary_for(@notification, first_values: {single_or_multi_component: "multiple"}) %>
+        <%= error_summary(errors, map_errors: { single_or_multi_component: :single_or_multi_component_multiple }) %>
 
         <h1 class="govuk-heading-l"><%= title %></h1>
 
         <p>Multi-item kits have items that need to be mixed together or used in a particular order for them to work.</p>
 
         <p class="govuk-!-margin-bottom-1">Examples of multi-item kits include:</p>
-
 
         <ul class="govuk-list govuk-list--bullet">
           <li>hair dye kits</li>
@@ -35,23 +33,36 @@
 
         <% if @notification.components.count == 1 %>
           <p class="govuk-inset-text">
-            Currently product has only 1 item. You can cdd more items by increasing components count.
+            Currently product has only 1 item. You can add more items by increasing components count.
           </p>
         <% end %>
 
         <% count_input_html = capture do %>
-          <%= render "form_components/govuk_input", form: form, key: :components_count,
-            label: { text: "How many items does it contain?" }, value: @notification.components_count > 0 ? @notification.components_count : ''  %>
+          <%= render("form_components/govuk_input",
+                     form: form,
+                     key: :components_count,
+                     id: "components_count",
+                     classes: "govuk-input--width-3",
+                     label: { text: "How many items does it contain?" },
+                     value: @notification.components_count > 0 ? @notification.components_count : '') %>
         <% end %>
-        <%= render "form_components/govuk_radios", form: form, key: :single_or_multi_component,
-            fieldset: { legend: { text: "Is the product a multi-item kit?", classes: "govuk-label--m" } },
-            items: [{ text: "Yes", value: "multiple" , conditional: { html: count_input_html },
-                      checked: (params[:notification].present? && params[:notification][:single_or_multi_component] == "multiple") || @notification.components.count > 1 },
-                    { text: "No, this is a single product", value: "single",
-                      checked: (params[:notification].present? && params[:notification][:single_or_multi_component] == "single") || (@notification.components.count == 1 && !(params[:notification].present? && params[:notification][:single_or_multi_component] == "multiple"))},
-        ] %>
+        <%= render("form_components/govuk_radios",
+                   form: form,
+                   key: :single_or_multi_component,
+                   fieldset: { legend: { text: "Is the product a multi-item kit?", classes: "govuk-label--m" } },
+                   items: [
+                     { text: "Yes",
+                       value: "multiple",
+                       id: "single_or_multi_component_multiple",
+                       conditional: { html: count_input_html },
+                       checked: (params[:notification].present? && params[:notification][:single_or_multi_component] == "multiple") || @notification.components.count > 1 },
+                     { text: "No, this is a single product",
+                       value: "single",
+                       id: "single_or_multi_component_single",
+                       checked: (params[:notification].present? && params[:notification][:single_or_multi_component] == "single") || (@notification.components.count == 1 && !(params[:notification].present? && params[:notification][:single_or_multi_component] == "multiple")) },
+                   ]
+                  ) %>
         <%= govukButton text: "Continue" %>
-
       </div>
     </div>
   <% end %>

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -235,6 +235,14 @@ en:
               not_a_number: "Enter a number for how many nanomaterials"
               greater_than: "Enter a number for how many nanomaterials"
               less_than_or_equal_to: "Maximum nanomaterials count is 10. More can be added later"
+        responsible_persons/wizard/notification_product/single_or_multi_component_form:
+          attributes:
+            single_or_multi_component:
+              inclusion: "Select yes if the product is a multi-item kit, no if its single item"
+            components_count:
+              not_a_number: "Enter a number for how how many items it contains"
+              greater_than: "There is a minimum of 2 items"
+              less_than_or_equal_to: "Maximum items count is 10. More can be added later"
         secondary_authentication/app/auth_form:
           attributes:
             otp_code:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -227,6 +227,14 @@ en:
             selection:
               blank_with_rp_list: "Select a Responsible Person or add a new Responsible Person"
               blank_without_rp_list: "Select add a new Responsible Person"
+        responsible_persons/wizard/notification_product/contains_nanomaterials_form:
+          attributes:
+            contains_nanomaterials:
+              inclusion: "Select yes if the product is a multi-item kit, no if its single item"
+            nanomaterials_count:
+              not_a_number: "Enter a number for how many nanomaterials"
+              greater_than: "Enter a number for how many nanomaterials"
+              less_than_or_equal_to: "Maximum nanomaterials count is 10. More can be added later"
         secondary_authentication/app/auth_form:
           attributes:
             otp_code:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -233,6 +233,7 @@ en:
               inclusion: "Select yes if the product is a multi-item kit, no if its single item"
             nanomaterials_count:
               not_a_number: "Enter a number for how many nanomaterials"
+              not_an_integer: "Enter a number for how many nanomaterials"
               greater_than: "Enter a number for how many nanomaterials"
               less_than_or_equal_to: "Maximum nanomaterials count is 10. More can be added later"
         responsible_persons/wizard/notification_product/single_or_multi_component_form:
@@ -241,6 +242,7 @@ en:
               inclusion: "Select yes if the product is a multi-item kit, no if its single item"
             components_count:
               not_a_number: "Enter a number for how how many items it contains"
+              not_an_integer: "Enter a number for how how many items it contains"
               greater_than: "There is a minimum of 2 items"
               less_than_or_equal_to: "Maximum items count is 10. More can be added later"
         secondary_authentication/app/auth_form:

--- a/cosmetics-web/spec/controllers/notification_product_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_product_controller_spec.rb
@@ -74,19 +74,19 @@ RSpec.describe ResponsiblePersons::Wizard::NotificationProductController, :with_
     end
 
     it "creates a component if single_or_multi_component set to single" do
-      post(:update, params: params.merge(id: :single_or_multi_component, notification: { single_or_multi_component: "single" }))
+      post(:update, params: params.merge(id: :single_or_multi_component, single_or_multi_component_form: { single_or_multi_component: "single" }))
       Notification.find(notification.id).components
       expect(Notification.find(notification.id).components).to have(1).item
     end
 
     it "creates components if single_or_multi_component set to multiple" do
-      post(:update, params: params.merge(id: :single_or_multi_component, notification: { single_or_multi_component: "multiple", components_count: 3 }))
+      post(:update, params: params.merge(id: :single_or_multi_component, single_or_multi_component_form: { single_or_multi_component: "multiple", components_count: 3 }))
       expect(Notification.find(notification.id).components).to have(3).item
     end
 
     it "adds errors if single_or_multi_component is empty" do
-      post(:update, params: params.merge(id: :single_or_multi_component, notification: { single_or_multi_component: nil }))
-      expect(assigns(:notification).errors[:single_or_multi_component]).to eql(["Select yes if the product is a multi-item kit, no if its single item"])
+      post(:update, params: params.merge(id: :single_or_multi_component, single_or_multi_component_form: { single_or_multi_component: nil }))
+      expect(assigns(:single_or_multi_component_form).errors[:single_or_multi_component]).to eql(["Select yes if the product is a multi-item kit, no if its single item"])
     end
 
     it "continues to next step if user submits under_three_years with a valid value" do

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -48,6 +48,20 @@ FactoryBot.define do
       end
     end
 
+    trait :with_nano_material do
+      after(:create) do |notification|
+        create(:nano_material, notification: notification)
+        notification.reload
+      end
+    end
+
+    trait :with_nano_materials do
+      after(:create) do |notification|
+        create_list(:nano_material, 2, notification: notification)
+        notification.reload
+      end
+    end
+
     trait :with_label_image do
       image_uploads { [build(:image_upload, :uploaded_and_virus_scanned)] }
     end

--- a/cosmetics-web/spec/forms/responsible_persons/wizard/notification_product/contains_nanomaterials_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/wizard/notification_product/contains_nanomaterials_form_spec.rb
@@ -1,0 +1,150 @@
+require "rails_helper"
+
+RSpec.describe ResponsiblePersons::Wizard::NotificationProduct::ContainsNanomaterialsForm do
+  subject(:form) do
+    described_class.new(contains_nanomaterials: contains_nanomaterials, nanomaterials_count: nanomaterials_count)
+  end
+
+  let(:contains_nanomaterials) { "yes" }
+  let(:nanomaterials_count) { "3" }
+
+  describe "#contains_nanomaterials?" do
+    context "when contains_nanomaterials is 'yes'" do
+      let(:contains_nanomaterials) { "yes" }
+
+      it { expect(form.contains_nanomaterials?).to be true }
+    end
+
+    context "when contains_nanomaterials is 'no'" do
+      let(:contains_nanomaterials) { "no" }
+
+      it { expect(form.contains_nanomaterials?).to be false }
+    end
+
+    context "when contains_nanomaterials is empty" do
+      let(:contains_nanomaterials) { "" }
+
+      it { expect(form.contains_nanomaterials?).to be false }
+    end
+
+    context "when contains_nanomaterials is neither 'yes' nor 'no'" do
+      let(:contains_nanomaterials) { "maybe" }
+
+      it { expect(form.contains_nanomaterials?).to be false }
+    end
+  end
+
+  describe "#valid?" do
+    ["", "maybe"].each do |invalid_contains_nanomaterials_answer|
+      context "when the contains nanomaterials answer is #{invalid_contains_nanomaterials_answer}" do
+        let(:contains_nanomaterials) { invalid_contains_nanomaterials_answer }
+
+        before { form.validate }
+
+        it "is not valid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the contains nanomaterials attribute" do
+          expect(form.errors.full_messages_for(:contains_nanomaterials)).to eq(["Select yes if the product is a multi-item kit, no if its single item"])
+        end
+
+        context "when the nanomaterials count is also invalid" do
+          let(:nanomaterials_count) { "twelve" }
+
+          it "does not add an error message for the nanomaterials count attribute" do
+            expect(form.errors.full_messages_for(:nanomaterials_count)).to be_empty
+          end
+        end
+      end
+    end
+
+    context "when the contains nanomaticals answer is 'yes'" do
+      let(:contains_nanomaterials) { "yes" }
+
+      before { form.validate }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+
+      it "does not adds an error message for contains nanomaterials" do
+        expect(form.errors.full_messages_for(:contains_nanomaterials)).to be_empty
+      end
+
+      context "when the nanomaterials count is empty" do
+        let(:nanomaterials_count) { "" }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the nanomaterials count attribute" do
+          expect(form.errors.full_messages_for(:nanomaterials_count)).to eq(["Enter a number for how many nanomaterials"])
+        end
+      end
+
+      context "when the nanomaterials count contains a non numeric value" do
+        let(:nanomaterials_count) { "twelve" }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the nanomaterials count attribute" do
+          expect(form.errors.full_messages_for(:nanomaterials_count)).to eq(["Enter a number for how many nanomaterials"])
+        end
+      end
+
+      context "when the nanomaterials count value is too low" do
+        let(:nanomaterials_count) { "0" }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the nanomaterials count attribute" do
+          expect(form.errors.full_messages_for(:nanomaterials_count)).to eq(["Enter a number for how many nanomaterials"])
+        end
+      end
+
+      context "when the nanomaterials count value is too high" do
+        let(:nanomaterials_count) { "11" }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the nanomaterials count attribute" do
+          expect(form.errors.full_messages_for(:nanomaterials_count)).to eq(["Maximum nanomaterials count is 10. More can be added later"])
+        end
+      end
+    end
+
+    context "when the contains nanomaticals answer is 'no'" do
+      let(:contains_nanomaterials) { "no" }
+
+      before { form.validate }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+
+      it "does not adds an error message for contains nanomaterials" do
+        expect(form.errors.full_messages_for(:contains_nanomaterials)).to be_empty
+      end
+
+      context "when the nanomaterials count is invalid" do
+        let(:nanomaterials_count) { "twelve" }
+
+        it "is still valid" do
+          expect(form).to be_valid
+        end
+
+        it "does not add an error message for the nanomaterials count attribute" do
+          expect(form.errors.full_messages_for(:nanomaterials_count)).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/forms/responsible_persons/wizard/notification_product/single_or_multi_component_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/wizard/notification_product/single_or_multi_component_form_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+RSpec.describe ResponsiblePersons::Wizard::NotificationProduct::SingleOrMultiComponentForm do
+  subject(:form) do
+    described_class.new(single_or_multi_component: single_or_multi_component, components_count: components_count)
+  end
+
+  let(:single_or_multi_component) { "multiple" }
+  let(:components_count) { "3" }
+
+  describe "#single_component?" do
+    context "when single_or_multi_component is 'single'" do
+      let(:single_or_multi_component) { "single" }
+
+      it { expect(form.single_component?).to be true }
+    end
+
+    context "when single_or_multi_component is 'multiple'" do
+      let(:single_or_multi_component) { "multiple" }
+
+      it { expect(form.single_component?).to be false }
+    end
+
+    context "when single_or_multi_component is empty" do
+      let(:single_or_multi_component) { "" }
+
+      it { expect(form.single_component?).to be false }
+    end
+
+    context "when single_or_multi_component is neither 'yes' nor 'no'" do
+      let(:single_or_multi_component) { "maybe" }
+
+      it { expect(form.single_component?).to be false }
+    end
+  end
+
+  describe "#multi_component?" do
+    context "when single_or_multi_component is 'multiple'" do
+      let(:single_or_multi_component) { "multiple" }
+
+      it { expect(form.multi_component?).to be true }
+    end
+
+    context "when single_or_multi_component is 'single'" do
+      let(:single_or_multi_component) { "single" }
+
+      it { expect(form.multi_component?).to be false }
+    end
+
+    context "when single_or_multi_component is empty" do
+      let(:single_or_multi_component) { "" }
+
+      it { expect(form.multi_component?).to be false }
+    end
+
+    context "when single_or_multi_component is neither 'yes' nor 'no'" do
+      let(:single_or_multi_component) { "maybe" }
+
+      it { expect(form.multi_component?).to be false }
+    end
+  end
+
+  describe "#valid?" do
+    ["", "maybe"].each do |invalid_single_or_multi_component_answer|
+      context "when the single or multi components answer is #{invalid_single_or_multi_component_answer}" do
+        let(:single_or_multi_component) { invalid_single_or_multi_component_answer }
+
+        before { form.validate }
+
+        it "is not valid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the single or multi components attribute" do
+          expect(form.errors.full_messages_for(:single_or_multi_component)).to eq(["Select yes if the product is a multi-item kit, no if its single item"])
+        end
+
+        context "when the components count is also invalid" do
+          let(:components_count) { "twelve" }
+
+          it "does not add an error message for the components count attribute" do
+            expect(form.errors.full_messages_for(:components_count)).to be_empty
+          end
+        end
+      end
+    end
+
+    context "when the single or multi component answer is 'multiple'" do
+      let(:single_or_multi_component) { "multiple" }
+
+      before { form.validate }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+
+      it "does not adds an error message for single or multi components" do
+        expect(form.errors.full_messages_for(:single_or_multi_component)).to be_empty
+      end
+
+      context "when the components count is empty" do
+        let(:components_count) { "" }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the components count attribute" do
+          expect(form.errors.full_messages_for(:components_count)).to eq(["Enter a number for how how many items it contains"])
+        end
+      end
+
+      context "when the components count contains a non numeric value" do
+        let(:components_count) { "twelve" }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the components count attribute" do
+          expect(form.errors.full_messages_for(:components_count)).to eq(["Enter a number for how how many items it contains"])
+        end
+      end
+
+      context "when the components count value is too low" do
+        let(:components_count) { "1" }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the components count attribute" do
+          expect(form.errors.full_messages_for(:components_count)).to eq(["There is a minimum of 2 items"])
+        end
+      end
+
+      context "when the components count value is too high" do
+        let(:components_count) { "11" }
+
+        it "is invalid" do
+          expect(form).to be_invalid
+        end
+
+        it "adds an error message for the components count attribute" do
+          expect(form.errors.full_messages_for(:components_count)).to eq(["Maximum items count is 10. More can be added later"])
+        end
+      end
+    end
+
+    context "when the single or multi component answer is 'single'" do
+      let(:single_or_multi_component) { "single" }
+
+      before { form.validate }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+
+      it "does not adds an error message for single or multi components" do
+        expect(form.errors.full_messages_for(:single_or_multi_component)).to be_empty
+      end
+
+      context "when the components count is invalid" do
+        let(:components_count) { "twelve" }
+
+        it "is still valid" do
+          expect(form).to be_valid
+        end
+
+        it "does not add an error message for the components count attribute" do
+          expect(form.errors.full_messages_for(:components_count)).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -424,4 +424,60 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
       expect(notification.reference_number_for_display).to eq "UKCP-60162968"
     end
   end
+
+  describe "#make_ready_for_nanomaterials!" do
+    let(:notification) { create(:notification) }
+
+    shared_examples "no changes" do
+      it "returns nil" do
+        expect(notification.make_ready_for_nanomaterials!(nanomaterials_count)).to eq nil
+      end
+
+      it "does not create any nanomaterials" do
+        expect { notification.make_ready_for_nanomaterials!(nanomaterials_count) }
+          .not_to(change { notification.nano_materials.count })
+      end
+
+      it "does not change the notification state" do
+        expect { notification.make_ready_for_nanomaterials!(nanomaterials_count) }
+        .not_to change(notification, :state)
+      end
+    end
+
+    context "when not given a number of nanomaterials" do
+      let(:nanomaterials_count) { nil }
+
+      include_examples "no changes"
+    end
+
+    context "when given a non digit value as nanomaterials count" do
+      let(:nanomaterials_count) { "twelve" }
+
+      include_examples "no changes"
+    end
+
+    context "when given 0 nanomaterials count" do
+      let(:nanomaterials_count) { 0 }
+
+      include_examples "no changes"
+    end
+
+    context "when given a nanomaterials count" do
+      let(:nanomaterials_count) { 2 }
+
+      it "returns true" do
+        expect(notification.make_ready_for_nanomaterials!(nanomaterials_count)).to eq true
+      end
+
+      it "create the given number of nanomaterials" do
+        expect { notification.make_ready_for_nanomaterials!(nanomaterials_count) }
+          .to(change { notification.nano_materials.count }.by(nanomaterials_count))
+      end
+
+      it "sets the notification state to reay for nanomaterials" do
+        expect { notification.make_ready_for_nanomaterials!(nanomaterials_count) }
+          .to change(notification, :state).to(Notification::READY_FOR_NANOMATERIALS.to_s)
+      end
+    end
+  end
 end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -480,4 +480,130 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
       end
     end
   end
+
+  describe "#make_single_ready_for_components!" do
+    subject(:make_ready) { notification.make_single_ready_for_components!(count) }
+
+    shared_examples "nothing changes" do
+      it "returns 0 as number of components created" do
+        expect(make_ready).to eq 0
+      end
+
+      it "does not create any components" do
+        expect { make_ready }.not_to(change { notification.components.count })
+      end
+
+      it "does not change the notification state" do
+        expect { make_ready }.not_to change(notification, :state)
+      end
+    end
+
+    shared_examples "sets up single component" do
+      it { expect(make_ready).to eq 1 }
+
+      it "creates a single component" do
+        expect { make_ready }.to(change { notification.components.count }.by(1))
+      end
+
+      it "does not change the notification state" do
+        expect { make_ready }.not_to change(notification, :state)
+      end
+    end
+
+    context "with a multi component notification" do
+      let(:notification) { create(:notification, :with_components) }
+
+      context "when given a count of 0" do
+        let(:count) { 0 }
+
+        include_examples "nothing changes"
+      end
+
+      context "when given a single count" do
+        let(:count) { 1 }
+
+        include_examples "nothing changes"
+      end
+
+      context "when given a multiple count" do
+        let(:count) { 3 }
+
+        include_examples "nothing changes"
+      end
+    end
+
+    context "with a single component notification" do
+      let(:notification) do
+        create(:notification, :with_component, state: Notification::COMPONENTS_COMPLETE, previous_state: Notification::READY_FOR_COMPONENTS)
+      end
+
+      context "when given a count of 0" do
+        let(:count) { 0 }
+
+        include_examples "nothing changes"
+      end
+
+      context "when given a single count" do
+        let(:count) { 1 }
+
+        include_examples "nothing changes"
+      end
+
+      context "when given a multiple count" do
+        let(:count) { 3 }
+
+        it "returns 2 as number of components created" do
+          expect(make_ready).to eq 2
+        end
+
+        it "creates the missing components to match the given count" do
+          expect { make_ready }.to(change { notification.components.count }.by(2))
+        end
+
+        it "reverts notification state to 'details complete'" do
+          expect { make_ready }.to change(notification, :state).to(Notification::DETAILS_COMPLETE.to_s)
+        end
+
+        it "resets the notification previous state" do
+          expect { make_ready }.to change(notification, :previous_state).to(nil)
+        end
+      end
+    end
+
+    context "with a notification without components" do
+      let(:notification) { create(:notification, state: Notification::READY_FOR_NANOMATERIALS) }
+
+      context "when given a count of 0" do
+        let(:count) { 0 }
+
+        include_examples "sets up single component"
+      end
+
+      context "when given a single count" do
+        let(:count) { 1 }
+
+        include_examples "sets up single component"
+      end
+
+      context "when given a multiple count" do
+        let(:count) { 3 }
+
+        it "returns 3 as number of components created" do
+          expect(make_ready).to eq 3
+        end
+
+        it "creates the missing components to match the given count" do
+          expect { make_ready }.to(change { notification.components.count }.by(3))
+        end
+
+        it "does not change the notification state" do
+          expect { make_ready }.not_to change(notification, :state)
+        end
+
+        it " does not reset the notification previous state" do
+          expect { make_ready }.not_to change(notification, :previous_state)
+        end
+      end
+    end
+  end
 end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -426,57 +426,109 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
   end
 
   describe "#make_ready_for_nanomaterials!" do
-    let(:notification) { create(:notification) }
+    subject(:make_ready) { notification.make_ready_for_nanomaterials!(count) }
 
     shared_examples "no changes" do
-      it "returns nil" do
-        expect(notification.make_ready_for_nanomaterials!(nanomaterials_count)).to eq nil
+      it "returns 0 as number of nanomaterials created" do
+        expect(notification.make_ready_for_nanomaterials!(count)).to eq 0
       end
 
       it "does not create any nanomaterials" do
-        expect { notification.make_ready_for_nanomaterials!(nanomaterials_count) }
+        expect { notification.make_ready_for_nanomaterials!(count) }
           .not_to(change { notification.nano_materials.count })
       end
 
       it "does not change the notification state" do
-        expect { notification.make_ready_for_nanomaterials!(nanomaterials_count) }
+        expect { notification.make_ready_for_nanomaterials!(count) }
         .not_to change(notification, :state)
       end
     end
 
-    context "when not given a number of nanomaterials" do
-      let(:nanomaterials_count) { nil }
+    context "with a notification containing no nanomaterials" do
+      let(:notification) { create(:notification) }
 
-      include_examples "no changes"
-    end
+      context "when not given a number of nanomaterials" do
+        let(:count) { nil }
 
-    context "when given a non digit value as nanomaterials count" do
-      let(:nanomaterials_count) { "twelve" }
-
-      include_examples "no changes"
-    end
-
-    context "when given 0 nanomaterials count" do
-      let(:nanomaterials_count) { 0 }
-
-      include_examples "no changes"
-    end
-
-    context "when given a nanomaterials count" do
-      let(:nanomaterials_count) { 2 }
-
-      it "returns true" do
-        expect(notification.make_ready_for_nanomaterials!(nanomaterials_count)).to eq true
+        include_examples "no changes"
       end
 
-      it "create the given number of nanomaterials" do
-        expect { notification.make_ready_for_nanomaterials!(nanomaterials_count) }
-          .to(change { notification.nano_materials.count }.by(nanomaterials_count))
+      context "when given a non digit value as nanomaterials count" do
+        let(:count) { "twelve" }
+
+        include_examples "no changes"
       end
 
-      it "sets the notification state to reay for nanomaterials" do
-        expect { notification.make_ready_for_nanomaterials!(nanomaterials_count) }
-          .to change(notification, :state).to(Notification::READY_FOR_NANOMATERIALS.to_s)
+      context "when given 0 nanomaterials count" do
+        let(:count) { 0 }
+
+        include_examples "no changes"
+      end
+
+      context "when given a nanomaterials count" do
+        let(:count) { 2 }
+
+        it "returns 2 as the number of nanomaterials created" do
+          expect(make_ready).to eq 2
+        end
+
+        it "creates the missing nanomaterials to match the given count" do
+          expect { make_ready }
+            .to(change { notification.nano_materials.count }.by(2))
+        end
+
+        it "sets the notification state to reay for nanomaterials" do
+          expect { notification.make_ready_for_nanomaterials!(2) }
+            .to change(notification, :state).to(Notification::READY_FOR_NANOMATERIALS.to_s)
+        end
+      end
+    end
+
+    context "with a notification containing a single nanomaterial" do
+      let(:notification) { create(:notification, :with_nano_material) }
+
+      context "when given a nanomaterials count" do
+        let(:count) { 3 }
+
+        it "returns 2 as the number of nanomaterials created" do
+          expect(make_ready).to eq 2
+        end
+
+        it "creates the missing nanomaterials to match the given count" do
+          expect { make_ready }.to(change { notification.nano_materials.count }.by(2))
+        end
+
+        it "sets the notification state to reay for nanomaterials" do
+          expect { make_ready }.to change(notification, :state).to(Notification::READY_FOR_NANOMATERIALS.to_s)
+        end
+      end
+    end
+
+    context "with a notification containing multiple nanomaterials" do
+      let(:notification) { create(:notification, :with_nano_materials) }
+
+      context "when not given a number of nanomaterials" do
+        let(:count) { nil }
+
+        include_examples "no changes"
+      end
+
+      context "when given a non digit value as nanomaterials count" do
+        let(:count) { "twelve" }
+
+        include_examples "no changes"
+      end
+
+      context "when given 0 nanomaterials count" do
+        let(:count) { 0 }
+
+        include_examples "no changes"
+      end
+
+      context "when given a nanomaterials count" do
+        let(:count) { 3 }
+
+        include_examples "no changes"
       end
     end
   end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -484,27 +484,7 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
       end
     end
 
-    context "with a notification containing a single nanomaterial" do
-      let(:notification) { create(:notification, :with_nano_material) }
-
-      context "when given a nanomaterials count" do
-        let(:count) { 3 }
-
-        it "returns 2 as the number of nanomaterials created" do
-          expect(make_ready).to eq 2
-        end
-
-        it "creates the missing nanomaterials to match the given count" do
-          expect { make_ready }.to(change { notification.nano_materials.count }.by(2))
-        end
-
-        it "sets the notification state to reay for nanomaterials" do
-          expect { make_ready }.to change(notification, :state).to(Notification::READY_FOR_NANOMATERIALS.to_s)
-        end
-      end
-    end
-
-    context "with a notification containing multiple nanomaterials" do
+    context "with a notification containing nanomaterials" do
       let(:notification) { create(:notification, :with_nano_materials) }
 
       context "when not given a number of nanomaterials" do

--- a/cosmetics-web/spec/support/helpers/product_wizard.rb
+++ b/cosmetics-web/spec/support/helpers/product_wizard.rb
@@ -65,7 +65,7 @@ def answer_does_product_contains_nanomaterials_with(answer, amount: 1)
   within("fieldset") do
     page.choose(answer)
     if answer == Fspec::YES
-      fill_in "Nanomaterial count", with: amount
+      fill_in "How many nanomaterials?", with: amount
     end
   end
   click_button "Continue"


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1423?atlOrigin=eyJpIjoiYTBlOTY0NmYyYWE4NDAwMjllNzBkYWE1NTczZDFlZWIiLCJwIjoiaiJ9)

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Improvements/Changes over the Nanomaterials/Items wizard pages


Both steps got similar refactors:
- Extracted validation errors to the locales YAML file.
- Manage form and its validations with a form object.
- Move logic from the controller into the Notification model.
- Reduce controller branching.

They also share some changes:
- Add numerical format check over the number of nanomaterials input.
- Validation errors wording changes.

On the nanomaterial step we did:
- Rename of input label.
- Add an error on page title when errors are present.

There is a couple of further minor refactors down the `ResponsiblePersons::Wizard::NotificationProductController`

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2441-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2441-search-web.london.cloudapps.digital/
