### PR TITLE
Re-design pages for  nanos/items are present.

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/product/contains_nanomaterials.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/contains_nanomaterials.html.erb
@@ -51,10 +51,13 @@
     </div>
   <% end %>
 <% else %>
-  <p class="govuk-inset-text">
-    You can add and remove nanomaterials for this notification from product draft page.
-    <br />
-    <br />
-    <%= link_to "Continue", next_step_path, class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset" %>
+  <h1 class="govuk-heading-m">
+    Nanomaterials have already been added
+  </h1>
+
+  <p class="govuk-body">
+      You can add and remove nanomaterials directly from the tasks list page.
   </p>
+
+  <%= link_to "Continue", next_step_path, class: "govuk-button govuk-!-margin-top-8" %>
 <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/product/single_or_multi_component.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/single_or_multi_component.html.erb
@@ -68,10 +68,13 @@
     </div>
   <% end %>
 <% else %>
-  <p class="govuk-inset-text">
-    You can add and remove components for this notification from product draft page.
-    <br />
-    <br />
-    <%= link_to "Continue", next_step_path, class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset" %>
+  <h1 class="govuk-heading-m">
+      Items have already been added to the multi-item kit
+  </h1>
+
+  <p class="govuk-body">
+      You will be able to add and remove items directly from the tasks list page once the multi-item kit task is completed.
   </p>
+
+  <%= link_to "Continue", next_step_path, class: "govuk-button govuk-!-margin-top-8" %>
 <% end %>

--- a/cosmetics-web/spec/support/helpers/product_wizard.rb
+++ b/cosmetics-web/spec/support/helpers/product_wizard.rb
@@ -16,8 +16,7 @@ def complete_product_wizard(name: "Product", items_count: 1, nano_materials_coun
       answer_does_product_contains_nanomaterials_with "No"
     end
   else
-    text = "You can add and remove nanomaterials for this notification from product draft page."
-    expect(page).to have_text(text)
+    expect(page).to have_text("You can add and remove nanomaterials directly from the tasks list page.")
     click_on "Continue"
   end
 
@@ -28,8 +27,7 @@ def complete_product_wizard(name: "Product", items_count: 1, nano_materials_coun
       answer_is_product_multi_item_kit_with "No, this is a single product"
     end
   else
-    text = "You can add and remove components for this notification from product draft page."
-    expect(page).to have_text(text)
+    expect(page).to have_text("You will be able to add and remove items directly from the tasks list page once the multi-item kit task is completed.")
     click_on "Continue"
   end
 


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1409)

When a notification draft already has nanomaterials or items present and
the user re-runs the product creation task, it will be displayed a page
indicating to add/remove the nano/item from the draft instead of the
original form to introduce a number of nanos/items to be created.

This work re-designs those pages.

## Screenshots
![image](https://user-images.githubusercontent.com/1227578/163399384-99f48be8-9db9-441e-9941-a6b759ef91bb.png)
-----------------------------
![image](https://user-images.githubusercontent.com/1227578/163399428-bf000d35-6c9d-455d-b399-05060deec1a0.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2456-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2456-search-web.london.cloudapps.digital/
