### PR TITLE
Redesign draft/notification deletion page.

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/delete_notification_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/delete_notification_controller.rb
@@ -6,7 +6,7 @@ class ResponsiblePersons::DeleteNotificationController < SubmitApplicationContro
   def delete; end
 
   def destroy
-    unless params[:confirmation] == "yes"
+    unless params.dig(:confirmation, :yes) == "yes"
       @notification.errors.add(:confirmation, "Select yes if you want to delete this #{@notification.notification_complete? ? 'notification' : 'draft'}")
       return render(:delete)
     end

--- a/cosmetics-web/app/controllers/responsible_persons/delete_notification_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/delete_notification_controller.rb
@@ -6,6 +6,11 @@ class ResponsiblePersons::DeleteNotificationController < SubmitApplicationContro
   def delete; end
 
   def destroy
+    unless params[:confirmation] == "yes"
+      @notification.errors.add(:confirmation, "Select yes if you want to delete this #{@notification.notification_complete? ? 'notification' : 'draft'}")
+      return render(:delete)
+    end
+
     NotificationDeleteService.new(@notification, current_user).call
 
     tab = @notification.notification_complete? ? "notified" : "incomplete"

--- a/cosmetics-web/app/views/responsible_persons/delete_notification/delete.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/delete_notification/delete.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <%= error_summary(@notification.errors) %>
     <%= form_with url: responsible_person_delete_notification_path(@responsible_person, @notification), method: :delete do |form| %>
       <%= render "form_components/govuk_checkboxes",

--- a/cosmetics-web/app/views/responsible_persons/delete_notification/delete.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/delete_notification/delete.html.erb
@@ -6,21 +6,22 @@
     responsible_person_notification_draft_path(@notification.responsible_person, @notification)
   end
 %>
-<% content_for :page_title, "Delete #{type}" %>
+<% page_title "Delete #{type}", errors: @notification.errors.any? %>
 <% content_for :after_header do %>
   <%= link_to "Back", back_path, class: "govuk-back-link" %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= error_summary(@notification.errors) %>
-    <%= form_with url: responsible_person_delete_notification_path(@responsible_person, @notification), method: :delete do |form| %>
+    <%= error_summary(@notification.errors, map_errors: { confirmation: :yes }) %>
+    <%= form_with model: @notification, scope: :confirmation, url: responsible_person_delete_notification_path(@responsible_person, @notification), html: { novalidate: true}, method: :delete do |form| %>
       <%= render "form_components/govuk_checkboxes",
             form: form,
-            key: :confirmation_check,
+            id: "confirmation",
+            key: :confirmation,
             hint: { text: "The #{@notification.product_name} product notification #{ @notification.notification_complete? ? '' : 'draft ' }will be deleted." },
             fieldset: { legend: { text: "Do you want to delete this #{type}?", classes: "govuk-fieldset__legend--l", isPageHeading: true } },
-            items: [{ key: :confirmation, value: "yes", text: "Yes", checked: false }] %>
+            items: [{ id: "yes", key: :yes, value: "yes", text: "Yes", checked: false }] %>
 
       <div class="govuk-button-group">
         <%= govukButton(text: "Delete") %>

--- a/cosmetics-web/app/views/responsible_persons/delete_notification/delete.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/delete_notification/delete.html.erb
@@ -1,17 +1,31 @@
-<% content_for :page_title, "Delete notification" %>
+<% type = @notification.notification_complete? ? 'notification' : 'draft' %>
+<%
+  back_path = if @notification.notification_complete?
+    responsible_person_notification_path(@notification.responsible_person, @notification)
+  else
+    responsible_person_notification_draft_path(@notification.responsible_person, @notification)
+  end
+%>
+<% content_for :page_title, "Delete #{type}" %>
 <% content_for :after_header do %>
-  <%= link_to "Back", responsible_person_notification_draft_path(@notification.responsible_person, @notification), class: "govuk-back-link" %>
+  <%= link_to "Back", back_path, class: "govuk-back-link" %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Are you sure you want to delete <%= @notification.product_name %>?</h1>
-    <p class="govuk-!-margin-bottom-6">This will remove this notification and cannot be undone.</p>
+    <%= error_summary(@notification.errors) %>
     <%= form_with url: responsible_person_delete_notification_path(@responsible_person, @notification), method: :delete do |form| %>
-      <%= govukButton text: "Delete notification", classes: "govuk-button--warning" %>
-    <% end %>
-    <% if @notification.notification_complete? %>
-      <%= link_to "Return to notification summary", responsible_person_notification_path(@responsible_person, @notification), class: 'govuk-link govuk-link--no-visited-state govuk-!-font-size-19' %>
+      <%= render "form_components/govuk_checkboxes",
+            form: form,
+            key: :confirmation_check,
+            hint: { text: "The #{@notification.product_name} product notification #{ @notification.notification_complete? ? '' : 'draft ' }will be deleted." },
+            fieldset: { legend: { text: "Do you want to delete this #{type}?", classes: "govuk-fieldset__legend--l", isPageHeading: true } },
+            items: [{ key: :confirmation, value: "yes", text: "Yes", checked: false }] %>
+
+      <div class="govuk-button-group">
+        <%= govukButton(text: "Delete") %>
+        <%= link_to("Cancel", back_path, class: "govuk-link  govuk-link--no-visited-state" ) %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/cosmetics-web/spec/features/notifications_deleting_spec.rb
+++ b/cosmetics-web/spec/features/notifications_deleting_spec.rb
@@ -17,8 +17,15 @@ RSpec.describe "Notifications delete", type: :feature do
     click_on draft_notification.product_name
     click_on "task list page"
     click_on "Delete this draft"
-    expect(page).to have_h1("Are you sure you want to delete #{draft_notification.product_name}?")
-    click_button "Delete notification"
+
+    expect(page).to have_h1("Do you want to delete this draft?")
+    expect(page).to have_text("The #{draft_notification.product_name} product notification draft will be deleted.")
+    click_button "Delete"
+
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Select yes if you want to delete this draft", href: "#confirmation")
+    check "Yes"
+    click_button "Delete"
 
     assert_text "#{draft_notification.product_name} notification deleted"
   end
@@ -28,8 +35,15 @@ RSpec.describe "Notifications delete", type: :feature do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
     click_on notification.product_name
     click_on "Delete this notification"
-    expect(page).to have_h1("Are you sure you want to delete #{notification.product_name}?")
-    click_button "Delete notification"
+
+    expect(page).to have_h1("Do you want to delete this notification?")
+    expect(page).to have_text("The #{notification.product_name} product notification will be deleted.")
+    click_button "Delete"
+
+    expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+    expect(page).to have_link("Select yes if you want to delete this notification", href: "#confirmation")
+    check "Yes"
+    click_button "Delete"
 
     assert_text "#{notification.product_name} notification deleted"
 

--- a/cosmetics-web/spec/features/notifications_deleting_spec.rb
+++ b/cosmetics-web/spec/features/notifications_deleting_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Notifications delete", type: :feature do
     click_button "Delete"
 
     expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-    expect(page).to have_link("Select yes if you want to delete this draft", href: "#confirmation")
+    expect(page).to have_link("Select yes if you want to delete this draft", href: "#yes")
     check "Yes"
     click_button "Delete"
 
@@ -41,7 +41,7 @@ RSpec.describe "Notifications delete", type: :feature do
     click_button "Delete"
 
     expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-    expect(page).to have_link("Select yes if you want to delete this notification", href: "#confirmation")
+    expect(page).to have_link("Select yes if you want to delete this notification", href: "#yes")
     check "Yes"
     click_button "Delete"
 

--- a/cosmetics-web/spec/requests/responsible_persons/delete_notification_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/delete_notification_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
 
     context "when deletion is confirmed" do
       it "redirects" do
-        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: "yes")
+        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: { yes: "yes" })
 
         expect(response.status).to eq 302
       end
@@ -25,7 +25,7 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
       it "creates log record with current user" do
         expect(NotificationDeleteLog.count).to eq 0
 
-        delete responsible_person_delete_notification_path(responsible_person, notification, confirmation: "yes")
+        delete responsible_person_delete_notification_path(responsible_person, notification, confirmation: { yes: "yes" })
 
         expect(NotificationDeleteLog.first.submit_user).to eq user
       end
@@ -33,14 +33,14 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
       it "removes record" do
         draft_notification
         expect {
-          delete responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: "yes")
+          delete responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: { yes: "yes" })
         }.to change(Notification.deleted, :count).from(0).to(1)
       end
     end
 
     context "when deletion is not confirmed" do
       it "renders the deletion page" do
-        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: "0")
+        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: { yes: "0" })
 
         expect(response.status).to eq 200
         expect(response).to render_template("responsible_persons/delete_notification/delete")
@@ -48,21 +48,21 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
 
       it "does not create a notification delete log" do
         expect {
-          delete responsible_person_delete_notification_path(responsible_person, notification, confirmation: "0")
+          delete responsible_person_delete_notification_path(responsible_person, notification, confirmation: { yes: "0" })
         }.not_to change(NotificationDeleteLog, :count)
       end
 
       it "does not remove record" do
         notification
         expect {
-          delete responsible_person_delete_notification_url(responsible_person, notification, confirmation: "0")
+          delete responsible_person_delete_notification_url(responsible_person, notification, confirmation: { yes: "0" })
         }.not_to change(Notification, :count)
       end
     end
 
     context "when 2FA time passed", :with_2fa do
       before do
-        get delete_responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: "yes")
+        get delete_responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: { yes: "yes" })
         post secondary_authentication_sms_url,
              params: {
                secondary_authentication_form: {
@@ -76,18 +76,18 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
 
       it "does not remove record" do
         expect {
-          delete responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: "yes")
+          delete responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: { yes: "yes" })
         }.not_to change(Notification, :count)
       end
 
       it "redirects to 2FA" do
         draft_notification
-        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: "yes")
+        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: { yes: "yes" })
         expect(response).to redirect_to("/two-factor/sms")
       end
 
       it "redirects info page to 2FA" do
-        get delete_responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: "yes")
+        get delete_responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: { yes: "yes" })
 
         expect(response.status).to be(302)
       end

--- a/cosmetics-web/spec/requests/responsible_persons/delete_notification_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/delete_notification_spec.rb
@@ -15,30 +15,54 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
       sign_in_as_member_of_responsible_person(responsible_person, user)
     end
 
-    it "redirects" do
-      delete responsible_person_delete_notification_path(responsible_person, draft_notification)
+    context "when deletion is confirmed" do
+      it "redirects" do
+        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: "yes")
 
-      expect(response.status).to eq 302
+        expect(response.status).to eq 302
+      end
+
+      it "creates log record with current user" do
+        expect(NotificationDeleteLog.count).to eq 0
+
+        delete responsible_person_delete_notification_path(responsible_person, notification, confirmation: "yes")
+
+        expect(NotificationDeleteLog.first.submit_user).to eq user
+      end
+
+      it "removes record" do
+        draft_notification
+        expect {
+          delete responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: "yes")
+        }.to change(Notification.deleted, :count).from(0).to(1)
+      end
     end
 
-    it "creates log record with current user" do
-      expect(NotificationDeleteLog.count).to eq 0
+    context "when deletion is not confirmed" do
+      it "renders the deletion page" do
+        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: "0")
 
-      delete responsible_person_delete_notification_path(responsible_person, notification)
+        expect(response.status).to eq 200
+        expect(response).to render_template("responsible_persons/delete_notification/delete")
+      end
 
-      expect(NotificationDeleteLog.first.submit_user).to eq user
-    end
+      it "does not create a notification delete log" do
+        expect {
+          delete responsible_person_delete_notification_path(responsible_person, notification, confirmation: "0")
+        }.not_to change(NotificationDeleteLog, :count)
+      end
 
-    it "removes record" do
-      draft_notification
-      expect {
-        delete responsible_person_delete_notification_url(responsible_person, draft_notification)
-      }.to change(Notification.deleted, :count).from(0).to(1)
+      it "does not remove record" do
+        notification
+        expect {
+          delete responsible_person_delete_notification_url(responsible_person, notification, confirmation: "0")
+        }.not_to change(Notification, :count)
+      end
     end
 
     context "when 2FA time passed", :with_2fa do
       before do
-        get delete_responsible_person_delete_notification_url(responsible_person, draft_notification)
+        get delete_responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: "yes")
         post secondary_authentication_sms_url,
              params: {
                secondary_authentication_form: {
@@ -52,18 +76,18 @@ RSpec.describe "Delete Notifications page", :with_stubbed_antivirus, :with_stubb
 
       it "does not remove record" do
         expect {
-          delete responsible_person_delete_notification_url(responsible_person, draft_notification)
+          delete responsible_person_delete_notification_url(responsible_person, draft_notification, confirmation: "yes")
         }.not_to change(Notification, :count)
       end
 
       it "redirects to 2FA" do
         draft_notification
-        delete responsible_person_delete_notification_path(responsible_person, draft_notification)
+        delete responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: "yes")
         expect(response).to redirect_to("/two-factor/sms")
       end
 
       it "redirects info page to 2FA" do
-        get delete_responsible_person_delete_notification_path(responsible_person, draft_notification)
+        get delete_responsible_person_delete_notification_path(responsible_person, draft_notification, confirmation: "yes")
 
         expect(response.status).to be(302)
       end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1391)



<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description

Users will need to confirm before deleting the draft/notification pages.
A validation error will be displayed if the user submits the deletion without checking the confirmation.
Modifying wording to be correct for both drafts and submitted notifications.

## Screenshots

### For drafts
![Screenshot from 2022-04-21 16-14-36](https://user-images.githubusercontent.com/1227578/164501120-30e65faf-312a-4d5b-acec-2c9fa0b03578.png)
----
![Screenshot from 2022-04-21 16-14-25](https://user-images.githubusercontent.com/1227578/164501129-b4254eb0-5682-4ff8-9e6e-03c2238f20a5.png)
----
### For submitted notifications
![Screenshot from 2022-04-21 16-05-59](https://user-images.githubusercontent.com/1227578/164501296-24369ab9-3ff4-4bc3-b6b0-1b70524da035.png)
----
![Screenshot from 2022-04-21 16-06-18](https://user-images.githubusercontent.com/1227578/164501308-aed7ebbe-ca7b-45cb-be3b-28c78c2e7451.png)
----


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2473-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2473-search-web.london.cloudapps.digital/
