### PR TITLE
Fix sign-in flaky feature tests

### DIFF
--- a/cosmetics-web/spec/features/account/sign_in_spec.rb
+++ b/cosmetics-web/spec/features/account/sign_in_spec.rb
@@ -167,7 +167,8 @@ RSpec.feature "Signing in as a user", :with_2fa, :with_stubbed_mailer, :with_stu
         fill_in_credentials
 
         expect_to_be_on_secondary_authentication_sms_page
-        complete_secondary_authentication_sms_with(otp_code.reverse)
+        wrong_code = otp_code.sub(/[0-9]/) { |x| x == "0" ? "1" : x.to_i - 1 }
+        complete_secondary_authentication_sms_with(wrong_code)
 
         expect_to_be_on_secondary_authentication_sms_page
         expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
@@ -363,7 +364,8 @@ RSpec.feature "Signing in as a user", :with_2fa, :with_stubbed_mailer, :with_stu
         fill_in_credentials
 
         expect_to_be_on_secondary_authentication_sms_page
-        complete_secondary_authentication_sms_with(otp_code.reverse)
+        wrong_code = otp_code.sub(/[0-9]/) { |x| x == "0" ? "1" : x.to_i - 1 }
+        complete_secondary_authentication_sms_with(wrong_code)
 
         expect_to_be_on_secondary_authentication_sms_page
         expect(page).to have_css("h2#error-summary-title", text: "There is a problem")


### PR DESCRIPTION
[Flaky test run example](https://github.com/UKGovernmentBEIS/beis-opss-cosmetics/runs/6211813498?check_suite_focus=true)

We had these tests randomly failing for a while on our automated test runs, forcing us to re-run the specs in order to unblock the Pull Request for merging.

**Cause of the flaky specs:**
In order to calculate a wrong OTP Code, we were reversing the user OTP
Code generated by the service while having 2FA enabled.

This is easy and works well when the generated code is "12345", having
"54321" as the wrong code.
But what happens when the user's OTP code is a palindrome? "12121" turns into... "12121". So the "wrong code" is the same as the right code. And when asserting over entering the wrong code and getting an error... the test fails because it actually managed to sign-in with the right code.

Resolved it by replacing the first digit of the OTP code. If it is a '0' it will become '1'. If not, will decrease the value by 1.

This way we ensure we will still have 5 digits and the resulting code will be different, even with palindromes.
