### PR TITLE
Add a User method to reset 2FA

### DIFF
--- a/cosmetics-web/app/models/user.rb
+++ b/cosmetics-web/app/models/user.rb
@@ -71,6 +71,18 @@ class User < ApplicationRecord
     secondary_authentication_methods.size > 1
   end
 
+  # Needed for user support requests. We call it from Rails Console.
+  def reset_secondary_authentication!
+    update(mobile_number: nil,
+           mobile_number_verified: false,
+           direct_otp: nil,
+           direct_otp_sent_at: nil,
+           encrypted_totp_secret_key: nil,
+           last_totp_at: nil,
+           secondary_authentication_methods: nil,
+           account_security_completed: false)
+  end
+
 private
 
   def secondary_authentication_set?


### PR DESCRIPTION
Resetting the user's secondary authentication is a common user support request, and we have been copy&pasting this query for each request.

Adding it into the user model so we can call
 - `user.reset_secondary_authentication!`

instead of building the query each time (that may be prone to errors or be lost between different devs).
