### PR TITLE
Fix RP invitation to new unconfirmed user email

### DIFF
--- a/cosmetics-web/app/models/concerns/new_email_concern.rb
+++ b/cosmetics-web/app/models/concerns/new_email_concern.rb
@@ -10,17 +10,23 @@ module NewEmailConcern
     send_new_email_confirmation_email
   end
 
+  def confirm_new_email!
+    return if new_email.blank?
+
+    update!(
+      email: new_email,
+      new_email: nil,
+      new_email_confirmation_token: nil,
+      new_email_confirmation_token_expires_at: nil,
+    )
+  end
+
   class_methods do
     def confirm_new_email!(token)
       user = User.where("new_email_confirmation_token_expires_at > ?", Time.zone.now).find_by! new_email_confirmation_token: token
 
       old_email = user.email
-      user.update!(
-        email: user.new_email,
-        new_email: nil,
-        new_email_confirmation_token: nil,
-        new_email_confirmation_token_expires_at: nil,
-      )
+      user.confirm_new_email!
       NotifyMailer.get_mailer(user).update_email_address_notification_email(user, old_email).deliver_later
     rescue ActiveRecord::RecordNotFound
       raise ArgumentError

--- a/cosmetics-web/app/models/user.rb
+++ b/cosmetics-web/app/models/user.rb
@@ -83,6 +83,12 @@ class User < ApplicationRecord
            account_security_completed: false)
   end
 
+  def uses_email_address?(email_address)
+    return false if email_address.blank?
+
+    email.casecmp(email_address).zero? || (new_email.present? && new_email.casecmp(email_address).zero?)
+  end
+
 private
 
   def secondary_authentication_set?

--- a/cosmetics-web/spec/models/user/new_email_concern_spec.rb
+++ b/cosmetics-web/spec/models/user/new_email_concern_spec.rb
@@ -82,7 +82,49 @@ RSpec.describe User, type: :model do # rubocop:todo RSpec/FilePath
       end
     end
 
-    describe ".confirm_new_email!(token)" do
+    describe "#confirm_new_email!" do
+      let(:user) do
+        create(:submit_user,
+               email: old_email,
+               new_email: new_email,
+               new_email_confirmation_token: expected_token,
+               new_email_confirmation_token_expires_at: new_email_expiration)
+      end
+
+      context "when the new email is not set" do
+        let(:user) { create(:submit_user, email: old_email, new_email: nil) }
+
+        it "returns nil" do
+          expect(user.confirm_new_email!).to be_nil
+        end
+
+        it "does not replace the email" do
+          expect { user.confirm_new_email! }.not_to change(user, :email).from(old_email)
+        end
+      end
+
+      it "replaces email with new email" do
+        expect { user.confirm_new_email! }.to change(user, :email).from(old_email).to(new_email)
+      end
+
+      it "removes new email" do
+        expect { user.confirm_new_email! }.to change(user, :new_email).from(new_email).to(nil)
+      end
+
+      it "removes the new email confirmation token" do
+        expect { user.confirm_new_email! }.to change(user, :new_email_confirmation_token)
+                                          .from(expected_token)
+                                          .to(nil)
+      end
+
+      it "removes the new email confirmation token expiration" do
+        expect { user.confirm_new_email! }.to change(user, :new_email_confirmation_token_expires_at)
+                                          .from(new_email_expiration)
+                                          .to(nil)
+      end
+    end
+
+    describe ".confirm_new_email!" do
       shared_examples "invalid token" do
         it "does not change email" do
           begin

--- a/cosmetics-web/spec/support/shared_examples/common_user_tests.rb
+++ b/cosmetics-web/spec/support/shared_examples/common_user_tests.rb
@@ -407,4 +407,45 @@ RSpec.shared_examples "common user tests" do
       end
     end
   end
+
+  describe "#uses_email_address?" do
+    before do
+      user.email = "user@example.com"
+      user.new_email = "usernew@example.com"
+    end
+
+    it "is false for blank email address" do
+      expect(user.uses_email_address?("")).to eq false
+    end
+
+    it "is false for no email address" do
+      expect(user.uses_email_address?(nil)).to eq false
+    end
+
+    it "is false when the email address is neither the user email or new email" do
+      expect(user.uses_email_address?("userdifferent@example.com")).to eq false
+    end
+
+    it "is false when the email address is not the user email and user has no new email" do
+      user.new_email = nil
+
+      expect(user.uses_email_address?("userdifferent@example.com")).to eq false
+    end
+
+    it "is true when the email address matches the user email" do
+      expect(user.uses_email_address?("user@example.com")).to eq true
+    end
+
+    it "is true when the email address matches the new user email" do
+      expect(user.uses_email_address?("usernew@example.com")).to eq true
+    end
+
+    it "is true when the email address matches the user email with different capitalisation" do
+      expect(user.uses_email_address?("User@EXAMPLE.com")).to eq true
+    end
+
+    it "is true when the email address matches the user new email with different capitalisation" do
+      expect(user.uses_email_address?("userNEW@example.com")).to eq true
+    end
+  end
 end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1443)


When a Responsible Person team member invitation was sent to an email address that matches an existing user's "new email" that has not been confirmed, accepting the invitation was causing the creation of a new user.

The new user has the email address of the existing user's new email.
This causes multiple issues:
- Both users become invalid due to sharing email values.
- Both users in our service belong to a single person.

To resolve this, when a user receives a team invitation to their new unconfirmed email and follows the link inside the valid confirmation time period:

1. No new user will be created. Instead, finds the user by new_email and adds this user to the team.
2. Since the user opened this confirmation link from their new_email inbox, this invitation email will also confirm the email change. So, on top of joining the team, the user will have their email change to the new_email address.


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2495-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2495search-web.london.cloudapps.digital/
