### PR TITLE
Fix label images display for MSA users

### DIFF
--- a/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
+++ b/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
@@ -195,10 +195,10 @@ module ResponsiblePersons::NotificationsHelper
      .compact
   end
 
-  def notification_summary_label_image_link(image, responsible_person, notification)
+  def notification_summary_label_image_link(image, responsible_person, notification, allow_edits: false)
     if image.passed_antivirus_check?
       link_to(image.filename, url_for(image.file), class: "govuk-link govuk-link--no-visited-state", target: "_blank", rel: "noopener")
-    elsif image.file_exists?
+    elsif image.file_exists? && allow_edits
       "Processing image #{image.file.filename}..." \
       "<br>" \
       "#{link_to('Refresh', edit_responsible_person_notification_path(responsible_person, notification), class: 'govuk-link govuk-link--no-visited-state')}".html_safe

--- a/cosmetics-web/app/views/notifications/_product_details_label_images.html.erb
+++ b/cosmetics-web/app/views/notifications/_product_details_label_images.html.erb
@@ -3,12 +3,12 @@
   <ul class="govuk-list govuk-list--bullet">
     <% image_uploads.each do |image| %>
       <li>
-        <%= notification_summary_label_image_link(image, @responsible_person, @notification) %>
+        <%= notification_summary_label_image_link(image, @responsible_person, @notification, allow_edits: allow_edits) %>
       </li>
     <% end %>
   </ul>
 <% elsif image_uploads.one? %>
-  <%= notification_summary_label_image_link(image_uploads.first, @responsible_person, @notification) %>
+  <%= notification_summary_label_image_link(image_uploads.first, @responsible_person, @notification, allow_edits: allow_edits) %>
 <% else %>
   N/A
 <% end %>


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1510)
[Error tracking issue](https://sentry.io/organizations/beis/issues/3281115279/?project=1398436)

The view for label images is shared between MSA users and Submit users.

When the label image has not passed the antivirus check, it shows a "Refresh" link that reloads the edit page for Submit users.

The same link was being called from Search MSA users, causing a routing error (as MSA users are not associated with a Responsible Person and the route parameter is missing).

MSA users shouldn't even know if the image is processing or not. Just having it displayed when is available and not displayed when it is not.

The fix only shows the link if edits are allowed for the user when loading the page (submit user belonging to the RP who created the notification).


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2498-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2498-search-web.london.cloudapps.digital/

