### PR TITLE
Add ingredients exact concentration new notification

### DIFF
--- a/cosmetics-web/app/assets/application/stylesheets/opss/_opss-shared.scss
+++ b/cosmetics-web/app/assets/application/stylesheets/opss/_opss-shared.scss
@@ -21,6 +21,9 @@
 
 $std-font-family: "GDS Transport", "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
+/*input[type="checkbox"]:disabled, input[type="checkbox"]:disabled + label {color:  govuk-colour("mid-grey"); }
+input[type="checkbox"]:disabled + label {opacity: 1 !important; }*/
+
 /* not normalised by gds library - starts */
 figure,
 figcaption {
@@ -276,7 +279,9 @@ abbr[title]{
         }
     }
 }
-kbd {
+
+kbd,
+samp {
     font-family: inherit;
     font-weight: inherit;
 }
@@ -315,6 +320,90 @@ kbd {
     top: 2px;
 }
 
+.opss-2-col-flow,
+.opss-3-col-flow {
+    dl div dd:last-of-type {
+        margin-bottom: 0 !important;
+    }
+}
+
+@include govuk-media-query($from: desktop) {
+    .opss-desktop-min-height--s {
+        min-height: 180px;
+    }
+    .opss-desktop-min-height--m {
+        min-height: 300px;
+    }
+    .opss-desktop-padding-0 {
+        padding: 0 !important ;
+    }
+    .opss-desktop-padding-top-3 {
+        padding-top: govuk-spacing(3) !important ;
+    }
+    .opss-desktop-padding-bottom-4 {
+        padding-bottom: govuk-spacing(4) !important ;
+    }
+
+    .opss-summary-list__row--split {
+        margin-top: govuk-spacing(9);
+    }
+
+    .opss-2-col-flow {
+        -moz-column-count: 2; -webkit-column-count: 2; column-count: 2;
+        column-gap: 80px;
+
+        .opss-summary-list-mixed > div {
+            break-inside: avoid-column;
+        }
+        .opss-summary-list-mixed.opss-summary-list-mixed--sm {
+            margin-bottom: 0;
+
+            dt {
+                width: 36% !important;
+                @include word-wrap;
+            }
+
+            /*dt + dd {    //FF dosen't like
+                text-align: center;
+            }*/
+        }
+    }
+    .opss-3-col-flow {
+        -moz-column-count: 3; -webkit-column-count: 3; column-count: 3;
+        column-gap: govuk-spacing(3);
+
+        .opss-summary-list-mixed > div {
+            break-inside: avoid-column;
+        }
+        .opss-summary-list-mixed.opss-summary-list-mixed--sm {
+            margin-bottom: 0;
+
+            dt {
+                width: inherit !important;
+                @include word-wrap;
+
+                span {
+                    @include opss-font-size($s: 14px, $l: 1.2);
+                    /*position: relative; top: -1px;*/
+                }
+            }
+        }
+    }
+
+    @-moz-document url-prefix() {/*firefox only: col flow bug */
+        .opss-2-col-flow,
+        .opss-3-col-flow {
+            .govuk-summary-list {
+                display: unset;
+            }
+            .govuk-summary-list__row {
+                display: table;
+                width: 100%;
+            }
+        }
+    }
+}
+
 .opss-list {
     @include govuk-media-query($from: tablet) {
         &.opss-list--inline {
@@ -327,6 +416,89 @@ kbd {
             }
         }
     }
+}
+
+@mixin menu-inset-anchors {
+    ul li {
+        padding-bottom: 0;
+        @include opss-font-size($s: 16px, $l: 1.2);
+
+        &:before {
+            content: "—";
+            margin-left: - govuk-spacing(4);
+            color: $govuk-secondary-text-colour;
+        }
+    }
+}
+
+ul.opss-left-nav {
+    padding: 0;
+
+    ul.govuk-list {
+        margin-top: 0;
+    }
+
+    & > li.opss-left-nav__active {
+        @include menu-inset-anchors;
+    }
+
+    li {
+        margin-bottom: 0;
+        padding: 8px 0 5px 0;
+        @include opss-font-size($s: 17px, $l: 1.2);
+
+            ul {
+                padding-left: govuk-spacing(4);
+                margin-bottom: 0;
+            }
+
+            ul li.opss-left-nav__active {/* 3rd nested ULs */
+                @include menu-inset-anchors;
+            }
+
+            a {
+                text-decoration: none !important;
+                text-underline-offset: 0.1em;
+
+                &:hover {
+                    text-decoration: underline !important;
+                    text-decoration-thickness: 0.2em !important;
+                    text-decoration-thickness: 3px !important;
+                    -webkit-text-decoration-skip-ink: none;
+                    text-decoration-skip-ink: none;
+                    -webkit-text-decoration-skip: none;
+                    text-decoration-skip: none;
+                }
+
+                span {
+                    font-size: 90%;
+                }
+            }
+    }
+
+    /*& > li > ul.govuk-list { // 2nd nested ULs
+        padding-top: govuk-spacing(1); margin: govuk-spacing(4) 0 govuk-spacing(2) 0;
+    } */
+
+    & > li:first-child {
+        padding-top: 5px;
+    }
+
+    .opss-left-nav__active {
+        ul {
+            padding-left: govuk-spacing(6);
+        }
+
+        & > a {
+            font-weight: bold;
+            margin-left: govuk-spacing(2);
+        }
+
+        display: block;
+        margin-left: - govuk-spacing(2) - 4;
+        border-left: 4px solid $govuk-brand-colour;
+    }
+
 }
 
 .opss-secondary-text {
@@ -416,15 +588,15 @@ kbd {
     }
 
     &.opss-details-img--thumbnail + .opss-img-caption {
-        max-width: 174px; 
+        max-width: 174px;
         white-space: nowrap;
         overflow: hidden;
-        text-overflow: ellipsis; 
+        text-overflow: ellipsis;
     }
 }
 
 .opss-img-caption {
-    font-family: $std-font-family; 
+    font-family: $std-font-family;
     @include opss-font-size($s: 14px, $l: 1.25);
 }
 
@@ -533,11 +705,11 @@ dl.opss-summary-list-aside {
     @include govuk-media-query($from: desktop) {
         &.opss-summary-list-mixed--compact > div {
             dt, dd {
-                margin-top: 0; 
-                margin-bottom: 0; 
-                padding-top: 0; 
-                padding-bottom: govuk-spacing(1);  
-                @include opss-font-size($s: 16px, $l: 1.2); 
+                margin-top: 0;
+                margin-bottom: 0;
+                padding-top: 0;
+                padding-bottom: govuk-spacing(1);
+                @include opss-font-size($s: 16px, $l: 1.2);
                 color: $govuk-secondary-text-colour;
             }
         }
@@ -568,27 +740,53 @@ dl.opss-summary-list-aside {
             padding-bottom: govuk-spacing(0);
         }
     }
+    .opss-summary-list-mixed.opss-summary-list-mixed--sm-font {/* a mixed and small font version */
+        margin-bottom: govuk-spacing(4);
+
+        dt, dd {
+            @include opss-font-size($s: 16px, $l: 1.2);
+            padding-top: govuk-spacing(1);
+            padding-bottom: govuk-spacing(1);
+        }
+
+        .govuk-accordion__section-content & {
+            margin-bottom: govuk-spacing(7);
+
+            div:last-child {
+                dt, dd {
+                    border-bottom: none;
+                }
+            }
+        }
+    }
+    .opss-summary-list-mixed.opss-summary-list--equal-widths {
+        div {
+            dt,  dd {
+                width: 33%;
+            }
+        }
+    }
 }
 
 dd dl.opss-nested-definition-list {
-    margin: 0; 
+    margin: 0;
     @include opss-font-size($s: 16px, $l: 1.6);
 
     & > div {
-        width: 100%; 
+        width: 100%;
     }
 
     dt {
-        font-weight: bold; 
-        display: inline-block; 
-        margin: 0 govuk-spacing(2) 0 0; 
+        font-weight: bold;
+        display: inline-block;
+        margin: 0 govuk-spacing(2) 0 0;
         width: 45%;
     }
 
     dd {
-        display: inline-block; 
-        padding-right: 0; 
-        margin-left: 0; 
+        display: inline-block;
+        padding-right: 0;
+        margin-left: 0;
     }
 }
 
@@ -608,6 +806,7 @@ dd dl.opss-nested-definition-list {
     @include govuk-media-query($from: desktop) {
         & > div {
             display: inline-block;
+            width: 100%;
         }
     }
 
@@ -816,9 +1015,9 @@ dd dl.opss-nested-definition-list {
         tbody tr {
             th, td {
                 border-bottom: 1px solid $govuk-border-colour;
-                padding-top: govuk-spacing(2); 
-                padding-bottom: govuk-spacing(2); 
-                vertical-align: middle; 
+                padding-top: govuk-spacing(2);
+                padding-bottom: govuk-spacing(2);
+                vertical-align: middle;
             }
         }
     }
@@ -850,7 +1049,7 @@ dd dl.opss-nested-definition-list {
         @include govuk-media-query($from: tablet) {
             thead th:nth-child(1) {width: 50%; }
         }
-    }    
+    }
 }
 
 .opss-table-stripes {
@@ -859,7 +1058,7 @@ dd dl.opss-nested-definition-list {
             border-top: 1px solid govuk-colour("light-grey");
         }
     }
-    tbody tr:first-child, 
+    tbody tr:first-child,
     tbody tr:last-child {
         th, td {
             border-bottom: none;
@@ -869,8 +1068,8 @@ dd dl.opss-nested-definition-list {
     &.opss-table-items--sm {
         tbody tr {
             th, td {
-                padding-top: govuk-spacing(2); 
-                padding-bottom: govuk-spacing(2); 
+                padding-top: govuk-spacing(2);
+                padding-bottom: govuk-spacing(2);
             }
         }
     }

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -272,8 +272,9 @@ private
   end
 
   def update_add_ingredient_exact_concentration
-    @exact_concentration_form =
-      ResponsiblePersons::Notifications::ExactConcentrationForm.new(exact_concentration_params)
+    @exact_concentration_form = ResponsiblePersons::Notifications::ExactConcentrationForm.new(
+      exact_concentration_params.merge(component: @component),
+    )
     return rerender_current_step unless @exact_concentration_form.valid?
 
     exact_formula = @component.exact_formulas.new(

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -26,7 +26,9 @@ class ResponsiblePersons::Notifications::Components::BuildController < SubmitApp
         :select_sub_category,
         :select_sub_sub_category,
         :select_formulation_type,
-        :upload_formulation, # only for range and exact
+        :add_ingredient_exact_concentration, # only for exact
+        :want_to_add_another_ingredient, # only for exact
+        :upload_formulation, # only for range
         :select_frame_formulation, # only for frame formulation
         :contains_poisonous_ingredients, # only for frame formulation
         :upload_poisonus_ingredients, # only for frame formulation
@@ -55,11 +57,14 @@ class ResponsiblePersons::Notifications::Components::BuildController < SubmitApp
     select_sub_category: :select_root_category,
     select_sub_sub_category: :select_sub_category,
     select_formulation_type: :select_sub_sub_category,
+    add_ingredient_exact_concentration: :select_formulation_type,
+    want_to_add_another_ingredient: :select_formulation_type,
     upload_formulation: :select_formulation_type, # only for range and exact,
     select_frame_formulation: :select_formulation_type, # only for frame formulation,
     contains_poisonous_ingredients: :select_formulation_type, # only for frame formulation,
     upload_poisonus_ingredients: :contains_poisonous_ingredients, # only for frame formulation,
     select_ph_option: {
+      select_formulation_type: -> { @component.exact? },
       contains_poisonous_ingredients: -> { @component.predefined? },
       upload_formulation: -> { true },
     },
@@ -80,6 +85,8 @@ class ResponsiblePersons::Notifications::Components::BuildController < SubmitApp
       else
         return jump_to_step(:number_of_shades)
       end
+    when :add_ingredient_exact_concentration
+      @exact_concentration_form = ResponsiblePersons::Notifications::ExactConcentrationForm.new
     when :completed
       @component.update_state("component_complete")
       # TODO: write spec
@@ -116,6 +123,10 @@ class ResponsiblePersons::Notifications::Components::BuildController < SubmitApp
       update_select_category_step
     when :select_formulation_type
       update_select_formulation_type
+    when :add_ingredient_exact_concentration
+      update_add_ingredient_exact_concentration
+    when :want_to_add_another_ingredient
+      update_want_to_add_another_ingredient
     when :select_frame_formulation
       update_frame_formulation
     when :upload_formulation
@@ -260,6 +271,36 @@ private
     render_next_step @component
   end
 
+  def update_add_ingredient_exact_concentration
+    @exact_concentration_form =
+      ResponsiblePersons::Notifications::ExactConcentrationForm.new(exact_concentration_params)
+    return rerender_current_step unless @exact_concentration_form.valid?
+
+    exact_formula = @component.exact_formulas.new(
+      inci_name: @exact_concentration_form.name,
+      quantity: @exact_concentration_form.exact_concentration,
+      cas_number: @exact_concentration_form.cas_number,
+      poisonous: @exact_concentration_form.poisonous,
+    )
+    if exact_formula.save
+      render_next_step @component
+    else
+      rerender_current_step
+    end
+  end
+
+  def update_want_to_add_another_ingredient
+    case params[:add_another_ingredient]
+    when "yes"
+      jump_to_step(:add_ingredient_exact_concentration)
+    when "no"
+      jump_to_step(:select_ph_option)
+    else
+      @component.errors.add(:add_another_ingredient, "Select yes if you want to add an ingredient")
+      rerender_current_step
+    end
+  end
+
   # for frame formulation only
   def update_frame_formulation
     if @component.update_with_context(component_params, :select_frame_formulation)
@@ -384,6 +425,16 @@ private
         exposure_routes: [],
         cmrs_attributes: %i[id name cas_number ec_number],
         shades: [],
+      )
+  end
+
+  def exact_concentration_params
+    params.fetch(:exact_concentration_form, {})
+      .permit(
+        :name,
+        :exact_concentration,
+        :cas_number,
+        :poisonous,
       )
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -275,15 +275,7 @@ private
     @exact_concentration_form = ResponsiblePersons::Notifications::ExactConcentrationForm.new(
       exact_concentration_params.merge(component: @component),
     )
-    return rerender_current_step unless @exact_concentration_form.valid?
-
-    exact_formula = @component.exact_formulas.new(
-      inci_name: @exact_concentration_form.name,
-      quantity: @exact_concentration_form.exact_concentration,
-      cas_number: @exact_concentration_form.cas_number,
-      poisonous: @exact_concentration_form.poisonous,
-    )
-    if exact_formula.save
+    if @exact_concentration_form.save
       render_next_step @component
     else
       rerender_current_step

--- a/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
@@ -2,10 +2,10 @@ module ResponsiblePersons::Notifications
   class ExactConcentrationForm < Form
     include StripWhitespace
 
-    attribute :name
-    attribute :exact_concentration
-    attribute :cas_number
-    attribute :poisonous
+    attribute :name, :string
+    attribute :exact_concentration, :float
+    attribute :cas_number, :string
+    attribute :poisonous, :boolean
     attribute :component
 
     validates :name, presence: true

--- a/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
@@ -10,7 +10,7 @@ module ResponsiblePersons::Notifications
 
     validates :name, presence: true
     validate :unique_name
-    validates :exact_concentration, presence: true
+    validates :exact_concentration, presence: true, numericality: { allow_blank: true, greater_than: 0 }
     validates_with CasNumberValidator
 
     def save

--- a/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
@@ -1,0 +1,12 @@
+module ResponsiblePersons::Notifications
+  class ExactConcentrationForm < Form
+    attribute :name
+    attribute :exact_concentration
+    attribute :cas_number
+    attribute :poisonous
+
+    validates :name, presence: true
+    validates :exact_concentration, presence: true
+    validates_with CasNumberValidator
+  end
+end

--- a/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
@@ -13,6 +13,17 @@ module ResponsiblePersons::Notifications
     validates :exact_concentration, presence: true
     validates_with CasNumberValidator
 
+    def save
+      return false unless component.present? && valid?
+
+      component.exact_formulas.create(
+        inci_name: name,
+        quantity: exact_concentration,
+        cas_number: cas_number,
+        poisonous: poisonous,
+      )
+    end
+
   private
 
     def unique_name

--- a/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
@@ -16,10 +16,10 @@ module ResponsiblePersons::Notifications
   private
 
     def unique_name
-      return if name.blank?
+      return if name.blank? || component.blank?
 
       if ExactFormula.where(component_id: component).where("LOWER(inci_name) = ?", name.downcase).any?
-        errors.add(:name, :taken)
+        errors.add(:name, :taken, entity: component.notification.is_multicomponent? ? "item" : "product")
       end
     end
   end

--- a/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/exact_concentration_form.rb
@@ -1,12 +1,26 @@
 module ResponsiblePersons::Notifications
   class ExactConcentrationForm < Form
+    include StripWhitespace
+
     attribute :name
     attribute :exact_concentration
     attribute :cas_number
     attribute :poisonous
+    attribute :component
 
     validates :name, presence: true
+    validate :unique_name
     validates :exact_concentration, presence: true
     validates_with CasNumberValidator
+
+  private
+
+    def unique_name
+      return if name.blank?
+
+      if ExactFormula.where(component_id: component).where("LOWER(inci_name) = ?", name.downcase).any?
+        errors.add(:name, :taken)
+      end
+    end
   end
 end

--- a/cosmetics-web/app/models/cmr.rb
+++ b/cosmetics-web/app/models/cmr.rb
@@ -2,10 +2,9 @@ class Cmr < ApplicationRecord
   belongs_to :component
 
   validates :name, presence: true
-  validates :cas_number, format: { with: /\A(\d{2,7})-?(\d{2})-?(\d)\z/ }, allow_blank: true
   validates :ec_number, format: { with: /\A(\d{3})-?(\d{3})-?(\d)\z/ }, allow_blank: true
-  validate :cas_number_length
   validate :ec_number_length
+  validates_with CasNumberValidator
 
   before_save :remove_hyphens
 
@@ -26,12 +25,6 @@ private
   def remove_hyphens
     cas_number&.delete!("-")
     ec_number&.delete!("-")
-  end
-
-  def cas_number_length
-    unless cas_number.blank? || cas_number.delete("^0-9").length.between?(5, 10)
-      errors.add(:cas_number, "CAS number must contain between 5 to 10 digits")
-    end
   end
 
   def ec_number_length

--- a/cosmetics-web/app/models/exact_formula.rb
+++ b/cosmetics-web/app/models/exact_formula.rb
@@ -1,7 +1,17 @@
 class ExactFormula < ApplicationRecord
   belongs_to :component
 
+  validates_with CasNumberValidator
+
+  before_save :normalise_cas_number
+
   def display_name
     "#{inci_name}: #{quantity}"
+  end
+
+private
+
+  def normalise_cas_number
+    cas_number&.delete!("-")
   end
 end

--- a/cosmetics-web/app/models/exact_formula.rb
+++ b/cosmetics-web/app/models/exact_formula.rb
@@ -1,6 +1,8 @@
 class ExactFormula < ApplicationRecord
   belongs_to :component
 
+  validates :inci_name, presence: true
+  validates :quantity, presence: true
   validates_with CasNumberValidator
 
   before_save :normalise_cas_number

--- a/cosmetics-web/app/validators/cas_number_validator.rb
+++ b/cosmetics-web/app/validators/cas_number_validator.rb
@@ -1,0 +1,13 @@
+class CasNumberValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.cas_number.blank?
+
+    unless /\A(\d{2,7})-?(\d{2})-?(\d)\z/.match?(record.cas_number)
+      record.errors.add :cas_number, "CAS number is invalid"
+    end
+
+    unless record.cas_number.delete("^0-9").length.between?(5, 10)
+      record.errors.add(:cas_number, "CAS number must contain between 5 to 10 digits")
+    end
+  end
+end

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/_poison_tables.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/_poison_tables.html.erb
@@ -1,0 +1,412 @@
+<p class="govuk-body-s opss-secondary-text">
+  The National Poisons Information Service (<abbr>NPIS</abbr>) needs to know about these ingredients in the product.
+</p>
+
+<table class="govuk-table opss-table-items opss-table-items--sm opss-table-items--first-col-50 opss-table-stripes">
+  <caption class="govuk-table__caption govuk-table__caption--s">Alcohols</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">CAS Number</th>
+      <th scope="col" class="govuk-table__header">Amount</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Alcohol denatured <br> Including any substances used to denature the alcohol</td>
+      <td class="govuk-table__cell">–</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Ethanol</td>
+      <td class="govuk-table__cell">64‑17‑5</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Isopropanol</td>
+      <td class="govuk-table__cell">67‑63‑0</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">n‑Butyl alcohol</td>
+      <td class="govuk-table__cell">71‑36‑3</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">n‑Propyl alcohol (also known as Propyl alcohol)</td>
+      <td class="govuk-table__cell">71‑23‑8</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">t‑Butyl alcohol</td>
+      <td class="govuk-table__cell">75‑65‑0</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="govuk-table opss-table-items opss-table-items--sm opss-table-items--first-col-50 opss-table-stripes">
+  <caption class="govuk-table__caption govuk-table__caption--s">Cresols</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">CAS Number</th>
+      <th scope="col" class="govuk-table__header">Amount</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">m‑Cresol</td>
+      <td class="govuk-table__cell">108‑39‑4</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">o‑Cresol</td>
+      <td class="govuk-table__cell">95‑48‑7</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">p‑Cresol</td>
+      <td class="govuk-table__cell">106‑44‑5</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Mixed Cresols</td>
+      <td class="govuk-table__cell">1319‑77‑3</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="govuk-table opss-table-items opss-table-items--sm opss-table-items--first-col-50 opss-table-stripes">
+  <caption class="govuk-table__caption govuk-table__caption--s">Essential oils, Camphor, Eucalyptol or Menthol</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">CAS Number</th>
+      <th scope="col" class="govuk-table__header">Amount</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Essential oils</td>
+      <td class="govuk-table__cell">–</td>
+      <td class="govuk-table__cell">More than 0.5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Camphor</td>
+      <td class="govuk-table__cell">464‑49‑3, 76‑22‑2</td>
+      <td class="govuk-table__cell">More than 0.15%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Eucalyptol</td>
+      <td class="govuk-table__cell">470‑82‑6 </td>
+      <td class="govuk-table__cell">More than 0.5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Menthol</td>
+      <td class="govuk-table__cell">1490‑04‑6, 2216‑51‑5, 89‑78‑1, 15356‑70‑4</td>
+      <td class="govuk-table__cell">More than 0.5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Total amount of essential oils, Camphor, Eucalyptol or Menthol</td>
+      <td class="govuk-table__cell">–</td>
+      <td class="govuk-table__cell">More than 0.5%&nbsp;w/w</td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="govuk-table opss-table-items opss-table-items--sm opss-table-items--first-col-50 opss-table-stripes">
+  <caption class="govuk-table__caption govuk-table__caption--s">Glycols and Glycol ethers</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">CAS Number</th>
+      <th scope="col" class="govuk-table__header">Amount</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Buteth‑2 acetate</td>
+      <td class="govuk-table__cell">124‑17‑4</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Butoxydiglycol</td>
+      <td class="govuk-table__cell">112‑34‑5</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Butoxyethanol</td>
+      <td class="govuk-table__cell">111‑76‑2</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Butoxyethyl acetate</td>
+      <td class="govuk-table__cell">112‑07‑02</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Diethoxydiglycol</td>
+      <td class="govuk-table__cell">112‑36‑7</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Dipropylene glycol</td>
+      <td class="govuk-table__cell">110‑98‑5, 25265‑71‑8</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Dipropylene glycol dimethyl ether</td>
+      <td class="govuk-table__cell">111109‑77‑4</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Ethoxydiglycol</td>
+      <td class="govuk-table__cell">111‑90‑0</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Ethoxydiglycol acetate</td>
+      <td class="govuk-table__cell">112‑15‑2</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Ethylene glycol only (also known as Glycol)</td>
+      <td class="govuk-table__cell">107‑21‑1</td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Isobornyl dipropylene glycol ethers</td>
+      <td class="govuk-table__cell">958872‑63‑4</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Methoxyisopropanol</td>
+      <td class="govuk-table__cell">107‑98‑2</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Methoxyisopropyl acetate</td>
+      <td class="govuk-table__cell">108‑65‑6</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">PPG‑2 methyl ether</td>
+      <td class="govuk-table__cell">13429‑07‑7, 34590‑94‑8</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">PPG‑2 methyl ether acetate</td>
+      <td class="govuk-table__cell">88917‑22‑0</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Propylene glycol</td>
+      <td class="govuk-table__cell">57‑55‑6</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Propylene glycol butyl ether</td>
+      <td class="govuk-table__cell">5131‑66‑8</td>
+      <td class="govuk-table__cell">More than 10%&nbsp;w/w</td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="govuk-table opss-table-items opss-table-items--sm opss-table-items--first-col-50 opss-table-stripes">
+  <caption class="govuk-table__caption govuk-table__caption--s">Hydrocarbon solvents</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">CAS Number</th>
+      <th scope="col" class="govuk-table__header">Amount</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Cyclohexane</td>
+      <td class="govuk-table__cell">110‑82‑7</td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Hydrogenated didodecene</td>
+      <td class="govuk-table__cell">151006‑61‑0</td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Isopentane </td>
+      <td class="govuk-table__cell">78‑78‑4</td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Pentane</td>
+      <td class="govuk-table__cell">109‑66‑0</td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Toluene</td>
+      <td class="govuk-table__cell">108‑88‑3</td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Turpentine</td>
+      <td class="govuk-table__cell">8006‑64‑2, 9005‑90‑7, 8052‑14‑0</td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="govuk-table opss-table-items opss-table-items--sm opss-table-items--first-col-50 opss-table-stripes">
+  <caption class="govuk-table__caption govuk-table__caption--s">Other</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">CAS Number</th>
+      <th scope="col" class="govuk-table__header">Amount</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Brucine sulfate</td>
+      <td class="govuk-table__cell">4845‑99‑2</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Butanone (also known as MEK)  </td>
+      <td class="govuk-table__cell">  78‑93‑3</td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"> Butyl acetate </td>
+      <td class="govuk-table__cell">  123‑86‑4 </td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Butyrolactone</td>
+      <td class="govuk-table__cell">  96‑48‑0</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Chloroplatinic acid</td>
+      <td class="govuk-table__cell">16941‑12‑1</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Copper sulphate</td>
+      <td class="govuk-table__cell">7758‑98‑7</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Cyclohexanone</td>
+      <td class="govuk-table__cell">  108‑94‑1 </td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Dimethyltolylamine</td>
+      <td class="govuk-table__cell">99‑97‑8</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"> Ethyl acetate</td>
+      <td class="govuk-table__cell">  141‑78‑6 </td>
+      <td class="govuk-table__cell">More than 1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Ethyl ether</td>
+      <td class="govuk-table__cell">  60‑29‑7</td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Methyl acetate</td>
+      <td class="govuk-table__cell">79‑20‑9</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">MIBK (also known as Methyl isobutyl ketone) </td>
+      <td class="govuk-table__cell">  108‑10‑1 </td>
+      <td class="govuk-table__cell">More than 5%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Potassium chlorate</td>
+      <td class="govuk-table__cell">3811‑04‑9</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Sodium chlorate</td>
+      <td class="govuk-table__cell">7775‑09‑9</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Triethyl phosphate</td>
+      <td class="govuk-table__cell">78‑40‑0</td>
+      <td class="govuk-table__cell">More than 0.1%&nbsp;w/w</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Vitamin A or any of its derivatives (calculated as Retinol)</td>
+      <td class="govuk-table__cell">68‑26‑8, 11103‑57‑4</td>
+      <td class="govuk-table__cell">More than 0.2%&nbsp;w/w or 0.09&nbsp;grams</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Xanthine derivatives (for example, caffeine, theophylline, theobromine, plant extracts containing xanthine derivatives, for example, paulinia cupana (guarana) extracts or powders)</td>
+      <td class="govuk-table__cell">–</td>
+      <td class="govuk-table__cell">More than 0.5%&nbsp;w/w</td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="govuk-table opss-table-items opss-table-items--sm opss-table-items--first-col-50 opss-table-stripes">
+  <caption class="govuk-table__caption govuk-table__caption--s">Ingredient groups</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Amount</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-three-quarters">Alkaline agents (including ammonium hydroxide liberators)</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-three-quarters">Cationic surfactants with 3 or 4 chains or groups with a length shorter than Carbon 12 (including straight, branched, cyclic or aromatic groups) if the surfactant is for non‑preservative purposes</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-three-quarters">Compounds that release hydrogen peroxide</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-three-quarters">Fluoride compound (calculated as fluorine)</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="govuk-table opss-table-items opss-table-items--sm opss-table-items--first-col-50 opss-table-stripes">
+  <caption class="govuk-table__caption govuk-table__caption--s">Any ingredients acting as</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Amount</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-three-quarters">Anti‑dandruff agents</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-three-quarters">Anti‑hair loss agents</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-three-quarters">Anti‑pigmenting and depigmenting agents</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-three-quarters">Chemical exfoliating agents</td>
+      <td class="govuk-table__cell">Any</td>
+    </tr>
+  </tbody>
+</table>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -96,7 +96,7 @@
       </ol>
 
       <p class="govuk-body-s opss-secondary-text">
-        These ingredients have already been added to the product. <!-- or .... already been added to the item. -->
+        These ingredients have already been added to the <%= @component.notification.is_multicomponent? ? "item" : "product" %>.
       </p>
     </div>
   <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -1,9 +1,11 @@
 <% title = "Add the ingredients" %>
 
-<% page_title title, errors: @component.errors.any? %>
+<% page_title title, errors: @exact_concentration_form.errors.any? %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: previous_wizard_path %>
 <% end %>
+
+<%= error_summary(@exact_concentration_form.errors) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -23,18 +25,28 @@
 
     <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-6">
 
-    <%= form_with model: @ingredients_exact_concentration_form, url: wizard_path, method: :put, html: { novalidate: true } do |form| %>
+    <%= form_with model: @exact_concentration_form, scope: :exact_concentration_form, url: wizard_path, method: :put, html: { novalidate: true } do |form| %>
       <div class="govuk-form-group">
-        <%= render "components/govuk_fieldset", legend: { text: "Ingredient 1", classes: "govuk-fieldset__legend--s" } do %>
-          <%= render "form_components/govuk_input", form: form, key: :name, label: { text: "What is the name?" } %>
+        <%= render "components/govuk_fieldset", legend: { text: "Ingredient #{@component.exact_formulas.count + 1}", classes: "govuk-fieldset__legend--s" } do %>
+          <%= render "form_components/govuk_input", form: form, id: "name", key: :name, label: { text: "What is the name?" } %>
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-half">
-              <div class="govuk-form-group">
+              <% concentration_error = @exact_concentration_form.errors[:exact_concentration]&.first %>
+              <div class="govuk-form-group <%= "govuk-form-group--error" if concentration_error %>">
                 <%= govukLabel(for: :exact_concentration, text: "What is the exact concentration?", classes: "govuk-label--s govuk-!-font-weight-regular")%>
+                <% if concentration_error %>
+                  <%= render "components/govuk_error_message", id: "exact_concentration-error", text: concentration_error %>
+                <% end %>
                 <div class="govuk-input__wrapper">
-                  <%= form.text_field :exact_concentration, class: "govuk-input govuk-input--width-3", maxlength: 3 %>
-                  <div class="govuk-input__suffix" aria-hidden="true"><span title="Percentage weight by weight">% w/w</span></div>
+                  <%= form.text_field(:exact_concentration,
+                                      id: "exact_concentration",
+                                      class: "govuk-input govuk-input--width-3 #{'govuk-input--error' if concentration_error}",
+                                      maxlength: 3,
+                                      "aria-describedby" => ("exact_concentration-error" if concentration_error)) %>
+                  <div class="govuk-input__suffix" aria-hidden="true">
+                    <span title="Percentage weight by weight">% w/w</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -45,6 +57,7 @@
                   <%= render "form_components/govuk_input",
                             form: form,
                             key: :cas_number,
+                            id: "cas_number",
                             label: { text: "What is the CAS number?", classes: "govuk-label--s govuk-!-font-weight-regular" },
                             classes: "govuk-input--width-10" %>
                 </div>
@@ -56,9 +69,10 @@
             <div class="govuk-grid-column-one-half">
               <%= render "form_components/govuk_checkboxes",
                         form: form,
-                        key: :poisonous,
+                        key: :poisonous_check,
+                        id: "poisonous_check",
                         classes: " govuk-!-padding-top-6",
-                        items: [{ key: :poisonous_yes,  text: "Is it poisonous?" }] %>
+                        items: [{ key: :poisonous,  text: "Is it poisonous?" }] %>
             </div>
           </div>
         <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -1,0 +1,68 @@
+<% title = "Add the ingredients" %>
+
+<% page_title title, errors: @component.errors.any? %>
+<% content_for :after_header do %>
+  <%= govukBackLink text: "Back", href: previous_wizard_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3"><%= title %></h1>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body-s opss-secondary-text">For every ingredient:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-font-size-16 opss-secondary-text">
+      <li>Use the International Nomenclature of Cosmetic Ingredients (<abbr>INCI</abbr>) name, where available</li>
+      <li>Confirm if poisonous - especially if the details match ingredients listed in the following poison tables </li>
+    </ul>
+
+    <%= govukDetails(summaryText: "Show the poison tables", classes: "govuk-!-margin-left-0 govuk-!-font-size-16") do %>
+      <%= render "poison_tables" %>
+    <% end %>
+
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-6">
+
+    <%= form_with model: @ingredients_exact_concentration_form, url: wizard_path, method: :put, html: { novalidate: true } do |form| %>
+      <div class="govuk-form-group">
+        <%= render "components/govuk_fieldset", legend: { text: "Ingredient 1", classes: "govuk-fieldset__legend--s" } do %>
+          <%= render "form_components/govuk_input", form: form, key: :name, label: { text: "What is the name?" } %>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half">
+              <div class="govuk-form-group">
+                <%= govukLabel(for: :exact_concentration, text: "What is the exact concentration?", classes: "govuk-label--s govuk-!-font-weight-regular")%>
+                <div class="govuk-input__wrapper">
+                  <%= form.text_field :exact_concentration, class: "govuk-input govuk-input--width-3", maxlength: 3 %>
+                  <div class="govuk-input__suffix" aria-hidden="true"><span title="Percentage weight by weight">% w/w</span></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="govuk-grid-column-one-half">
+              <div class="govuk-form-group">
+                <div class="govuk-checkboxes opss-float-right-desktop">
+                  <%= render "form_components/govuk_input",
+                            form: form,
+                            key: :cas_number,
+                            label: { text: "What is the CAS number?", classes: "govuk-label--s govuk-!-font-weight-regular" },
+                            classes: "govuk-input--width-10" %>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half">
+              <%= render "form_components/govuk_checkboxes",
+                        form: form,
+                        key: :poisonous,
+                        items: [{ key: :poisonous_yes,  text: "Is it poisonous?" }] %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <%= govukButton text: "Save and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -77,7 +77,12 @@
           </div>
         <% end %>
       </div>
-      <%= govukButton text: "Save and continue" %>
+      <div class="govuk-button-group">
+        <%= govukButton text: "Save and continue" %>
+        <% if @component.exact_formulas.any? %>
+          <%= link_to("Skip", wizard_path(:select_ph_option), class: "govuk-link govuk-link--no-visited-state") %>
+        <% end %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -85,4 +85,19 @@
       </div>
     <% end %>
   </div>
+  <% if @component.exact_formulas.any? %>
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-s">Already added</h2>
+
+      <ol class="govuk-list govuk-list--number govuk-!-font-size-16 opss-secondary-text">
+        <% @component.exact_formulas.each do |exact_formula| %>
+          <li><%= exact_formula.inci_name %></li>
+        <% end %>
+      </ol>
+
+      <p class="govuk-body-s opss-secondary-text">
+        These ingredients have already been added to the product. <!-- or .... already been added to the item. -->
+      </p>
+    </div>
+  <% end %>
 </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -57,6 +57,7 @@
               <%= render "form_components/govuk_checkboxes",
                         form: form,
                         key: :poisonous,
+                        classes: " govuk-!-padding-top-6",
                         items: [{ key: :poisonous_yes,  text: "Is it poisonous?" }] %>
             </div>
           </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/want_to_add_another_ingredient.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/want_to_add_another_ingredient.html.erb
@@ -1,0 +1,43 @@
+<% title = "Do you want to add another ingredient?" %>
+
+<% page_title title, errors: @component.errors.any? %>
+<% content_for :after_header do %>
+  <%= govukBackLink text: "Back", href: previous_wizard_path %>
+<% end %>
+
+
+<% if @component.errors.any? %>
+  <%= error_summary(@component.errors, map_errors: { add_another_ingredient: "add_another_ingredient_yes" }) %>
+<% else %>
+  <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        Success
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <h3 class="govuk-notification-banner__heading">
+        The ingredient was added
+      </h3>
+      <p class="govuk-body">The ingredient was successfully added to the product<!-- or item-->.</p>
+    </div>
+  </div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <%= form_with model: @component, scope: "", url: wizard_path, method: :put, html: { novalidate: true } do |form| %>
+      <%= render "form_components/govuk_radios",
+                 form: form,
+                 key: :add_another_ingredient,
+                 idPrefix: "add_another_ingredient",
+                 fieldset: { legend: { text: "Do you want to add another ingredient?",
+                                       classes: "govuk-fieldset__legend--l",
+                                       isPageHeading: true } },
+                 items: [{ text: "Yes", value: :yes },
+                         { text: "No", value: :no }] %>
+      <%= govukButton text: "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/want_to_add_another_ingredient.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/want_to_add_another_ingredient.html.erb
@@ -19,7 +19,7 @@
       <h3 class="govuk-notification-banner__heading">
         The ingredient was added
       </h3>
-      <p class="govuk-body">The ingredient was successfully added to the product<!-- or item-->.</p>
+      <p class="govuk-body">The ingredient was successfully added to the <%= @component.notification.is_multicomponent? ? "item" : "product" %>.</p>
     </div>
   </div>
 <% end %>

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -241,6 +241,7 @@ en:
               taken: "Enter a name which is unique to this %{entity}"
             exact_concentration:
               blank: "Enter the concentration"
+              greater_than: "Enter a number for the concentration"
         responsible_persons/notifications/product/contains_nanomaterials_form:
           attributes:
             contains_nanomaterials:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -238,7 +238,7 @@ en:
           attributes:
             name:
               blank: "Enter a name"
-              taken: "Enter a name which is unique to this product"
+              taken: "Enter a name which is unique to this %{entity}"
             exact_concentration:
               blank: "Enter the concentration"
         responsible_persons/notifications/product/contains_nanomaterials_form:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -147,6 +147,12 @@ en:
             phone_number:
               blank: "Telephone number can not be blank"
               invalid: "Enter a valid telephone number, like 0344 411 1444 or +44 7700 900 982"
+        exact_formula:
+          attributes:
+            inci_name:
+              blank: "Enter a name"
+            quantity:
+              blank: "Enter the concentration"
   activemodel:
     attributes:
       registration/account_security_form:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -238,6 +238,7 @@ en:
           attributes:
             name:
               blank: "Enter a name"
+              taken: "Enter a name which is unique to this product"
             exact_concentration:
               blank: "Enter the concentration"
         responsible_persons/notifications/product/contains_nanomaterials_form:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -234,6 +234,12 @@ en:
           attributes:
             component_id:
               blank: "Select an item"
+        responsible_persons/notifications/exact_concentration_form:
+          attributes:
+            name:
+              blank: "Enter a name"
+            exact_concentration:
+              blank: "Enter the concentration"
         responsible_persons/notifications/product/contains_nanomaterials_form:
           attributes:
             contains_nanomaterials:

--- a/cosmetics-web/db/migrate/20220519155041_add_cas_number_and_poisonous_to_exact_formulas.rb
+++ b/cosmetics-web/db/migrate/20220519155041_add_cas_number_and_poisonous_to_exact_formulas.rb
@@ -1,0 +1,10 @@
+class AddCasNumberAndPoisonousToExactFormulas < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      change_table :exact_formulas, bulk: true do |t|
+        t.string :cas_number
+        t.boolean :poisonous, default: false, null: false
+      end
+    end
+  end
+end

--- a/cosmetics-web/db/migrate/20220520183803_change_nullable_attributes_on_exact_formulas.rb
+++ b/cosmetics-web/db/migrate/20220520183803_change_nullable_attributes_on_exact_formulas.rb
@@ -1,0 +1,6 @@
+class ChangeNullableAttributesOnExactFormulas < ActiveRecord::Migration[6.1]
+  def change
+    add_check_constraint :exact_formulas, "inci_name IS NOT NULL", name: "exact_formulas_inci_name_null", validate: false
+    add_check_constraint :exact_formulas, "quantity IS NOT NULL", name: "exact_formulas_quantity_null", validate: false
+  end
+end

--- a/cosmetics-web/db/migrate/20220520184518_validate_change_nullable_attributes_on_exact_formulas.rb
+++ b/cosmetics-web/db/migrate/20220520184518_validate_change_nullable_attributes_on_exact_formulas.rb
@@ -1,0 +1,12 @@
+class ValidateChangeNullableAttributesOnExactFormulas < ActiveRecord::Migration[6.1]
+  def change
+    validate_check_constraint :exact_formulas, name: "exact_formulas_inci_name_null"
+    validate_check_constraint :exact_formulas, name: "exact_formulas_quantity_null"
+
+    change_column_null :exact_formulas, :inci_name, false
+    change_column_null :exact_formulas, :quantity, false
+
+    remove_check_constraint :exact_formulas, name: "exact_formulas_inci_name_null"
+    remove_check_constraint :exact_formulas, name: "exact_formulas_quantity_null"
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_141342) do
+ActiveRecord::Schema.define(version: 2022_05_19_155041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -135,6 +135,8 @@ ActiveRecord::Schema.define(version: 2022_04_29_141342) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "component_id"
+    t.string "cas_number"
+    t.boolean "poisonous", default: false, null: false
     t.index ["component_id"], name: "index_exact_formulas_on_component_id"
   end
 

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_19_155041) do
+ActiveRecord::Schema.define(version: 2022_05_20_184518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -130,8 +130,8 @@ ActiveRecord::Schema.define(version: 2022_05_19_155041) do
   end
 
   create_table "exact_formulas", force: :cascade do |t|
-    t.string "inci_name"
-    t.decimal "quantity"
+    t.string "inci_name", null: false
+    t.decimal "quantity", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "component_id"

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/exact_concentration_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/exact_concentration_form_spec.rb
@@ -77,4 +77,48 @@ RSpec.describe ResponsiblePersons::Notifications::ExactConcentrationForm do
       end
     end
   end
+
+  describe "#save" do
+    context "when the form has no component" do
+      let(:component) { nil }
+
+      it "returns false" do
+        expect(form.save).to be false
+      end
+
+      it "does not create an exact formula" do
+        expect { form.save }.not_to change(ExactFormula, :count)
+      end
+    end
+
+    context "when the form is invalid" do
+      let(:name) { "" }
+
+      it "returns false" do
+        expect(form.save).to eq false
+      end
+
+      it "does not create an exact formula" do
+        expect { form.save }.not_to change(ExactFormula, :count)
+      end
+    end
+
+    context "when the form is valid" do
+      it "creates an exact formula" do
+        expect { form.save }.to change(ExactFormula, :count).by(1)
+      end
+
+      # rubocop :disable RSpec/ExampleLength
+      it "returns the created exact formula" do
+        expect(form.save).to be_an_instance_of(ExactFormula).and have_attributes(
+          component_id: component.id,
+          inci_name: name,
+          quantity: exact_concentration.to_f,
+          cas_number: "111111",
+          poisonous: true,
+        )
+      end
+      # rubocop :enable RSpec/ExampleLength
+    end
+  end
 end

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/exact_concentration_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/exact_concentration_form_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe ResponsiblePersons::Notifications::ExactConcentrationForm do
       expect(form.errors[:cas_number]).to eq ["CAS number is invalid"]
     end
 
+    it "is not valid when the concentration is not a number" do
+      form.exact_concentration = "not a number"
+      expect(form).not_to be_valid
+      expect(form.errors[:exact_concentration]).to eq ["Enter a number for the concentration"]
+    end
+
+    it "is not valid when the concentration is 0" do
+      form.exact_concentration = 0.0
+      expect(form).not_to be_valid
+      expect(form.errors[:exact_concentration]).to eq ["Enter a number for the concentration"]
+    end
+
     describe "name taken validation" do
       it "is invalid when the ingredient already exists for the component" do
         create(:exact_formula, component: component, inci_name: name)

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/exact_concentration_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/exact_concentration_form_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe ResponsiblePersons::Notifications::ExactConcentrationForm do
+  subject(:form) do
+    described_class.new(component: component,
+                        name: name,
+                        cas_number: cas_number,
+                        exact_concentration: exact_concentration,
+                        poisonous: poisonous)
+  end
+
+  let(:component) { create(:component) }
+  let(:name) { "Ingredient Name" }
+  let(:cas_number) { "111-11-1" }
+  let(:exact_concentration) { "4.2" }
+  let(:poisonous) { "1" }
+
+  describe "validation" do
+    it "is invalid without a name" do
+      form.name = ""
+      expect(form).not_to be_valid
+      expect(form.errors[:name]).to eq ["Enter a name"]
+    end
+
+    it "is invalid without an exact concentration" do
+      form.exact_concentration = ""
+      expect(form).not_to be_valid
+      expect(form.errors[:exact_concentration]).to eq ["Enter the concentration"]
+    end
+
+    it "is valid when poisonous is not present" do
+      form.poisonous = nil
+      expect(form).to be_valid
+    end
+
+    it "is valid when cas number is not present" do
+      form.cas_number = nil
+      expect(form).to be_valid
+    end
+
+    it "is not valid for cas number with wrong formatting" do
+      form.cas_number = "111111-11-11"
+      expect(form).not_to be_valid
+      expect(form.errors[:cas_number]).to eq ["CAS number is invalid"]
+    end
+
+    describe "name taken validation" do
+      it "is invalid when the ingredient already exists for the component" do
+        create(:exact_formula, component: component, inci_name: name)
+        expect(form).not_to be_valid
+        expect(form.errors[:name]).to eq ["Enter a name which is unique to this product"]
+      end
+
+      it "is valid when the ingredient already exists for a different component in the same notification" do
+        component2 = create(:component, notification: component.notification)
+        create(:exact_formula, component: component2, inci_name: name)
+      end
+
+      it "is invalid when the ingredient differs only in capitalisation from an existing component ingredient" do
+        create(:exact_formula, component: component, inci_name: name.downcase)
+        expect(form).not_to be_valid
+        expect(form.errors[:name]).to eq ["Enter a name which is unique to this product"]
+      end
+
+      it "is invalid when the ingredient differs only in leading/trailing espaces from an existing component ingredient" do
+        create(:exact_formula, component: component, inci_name: name)
+        form.name = " #{name} "
+        expect(form).not_to be_valid
+        expect(form.errors[:name]).to eq ["Enter a name which is unique to this product"]
+      end
+
+      it "shows a specific error message for already existing name in the multicomponent notification" do
+        allow(component.notification).to receive(:is_multicomponent?).and_return(true)
+        create(:exact_formula, component: component, inci_name: name)
+        expect(form).not_to be_valid
+        expect(form.errors[:name]).to eq ["Enter a name which is unique to this item"]
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/models/exact_formula_spec.rb
+++ b/cosmetics-web/spec/models/exact_formula_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe ExactFormula, type: :model do
+  it "normalises cas number on saving" do
+    exact_formula = build(:exact_formula, cas_number: "123-45-6")
+    expect { exact_formula.save! }.to change(exact_formula, :cas_number).from("123-45-6").to("123456")
+  end
+end

--- a/cosmetics-web/spec/support/helpers/item_wizard.rb
+++ b/cosmetics-web/spec/support/helpers/item_wizard.rb
@@ -43,7 +43,7 @@ def complete_item_wizard(name, item_number: nil, single_item: false, nanos: [], 
 
   answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration", item_name: label_name
 
-  upload_ingredients_pdf
+  fill_ingredients_exact_concentrations(single_item: single_item)
 
   answer_what_is_ph_range_of_product_with "The minimum pH is 3 or higher, and the maximum pH is 10 or lower"
   expect_task_has_been_completed_page
@@ -145,11 +145,27 @@ def answer_how_do_you_want_to_give_formulation_with(answer, item_name: nil)
   click_button "Continue"
 end
 
-def upload_ingredients_pdf
-  unless page.has_css?("#formulation-files-table")
-    page.attach_file "spec/fixtures/files/testPdf.pdf"
+def fill_ingredients_exact_concentrations(single_item: false)
+  if page.has_no_css?("li", text: "FooBar ingredient")
+    expect(page).to have_css("h1", text: "Add the ingredients")
+    expect(page).to have_css("legend.govuk-fieldset__legend--s", text: "Ingredient 1")
+    fill_in "name", with: "FooBar ingredient"
+    fill_in "exact_concentration", with: "0.5"
+    fill_in "cas_number", with: "123456-78-9"
+    click_on "Save and continue"
+
+    expect(page).to have_css("h1", text: "Do you want to add another ingredient?")
+    expect(page).to have_css("p", text: "The ingredient was successfully added to the #{single_item ? 'product' : 'item'}.")
+    page.choose "Yes"
+    click_button "Continue"
   end
-  click_button "Continue"
+
+  expect(page).to have_css("h1", text: "Add the ingredients")
+  expect(page).to have_css("legend.govuk-fieldset__legend--s", text: "Ingredient 2")
+  expect(page).to have_css("h2", text: "Already added")
+  expect(page).to have_css("ol.govuk-list--number li", text: "FooBar ingredient")
+
+  click_link "Skip"
 end
 
 def answer_what_is_ph_range_of_product_with(answer)

--- a/cosmetics-web/spec/validators/cas_number_validator_spec.rb
+++ b/cosmetics-web/spec/validators/cas_number_validator_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe CasNumberValidator do
     "51a-43-4",
   ]
 
-  invalid_length_cas_numbers = [
-    "1-12-1",
-    "12345678-12-1",
-    "1234567-12-12",
+  invalid_length_cas_numbers = %w[
+    1-12-1
+    12345678-12-1
+    1234567-12-12
   ]
 
   valid_cas_numbers.each do |cas_number|

--- a/cosmetics-web/spec/validators/cas_number_validator_spec.rb
+++ b/cosmetics-web/spec/validators/cas_number_validator_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe CasNumberValidator do
+  subject(:validator) { validator_class.new(cas_number) }
+
+  let(:error_msg) { "Enter a valid name" }
+
+  let(:validator_class) do
+    Class.new do
+      include ActiveModel::Validations
+      attr_accessor :cas_number
+
+      validates_with CasNumberValidator
+
+      def initialize(cas_number)
+        @cas_number = cas_number
+      end
+
+      def self.name
+        "ValidatorClass"
+      end
+    end
+  end
+
+  before do
+    validator.validate
+  end
+
+  valid_cas_numbers = [
+    nil,
+    "",
+    "51-43-4",
+    "150-05-0",
+    "16065-83-1",
+    "1234567-37-4",
+    "12121",
+    "1234567121",
+  ]
+
+  invalid_cas_numbers = [
+    "51 43 4",
+    "1234567-1-1",
+    "123456-12-12",
+    "123456-123-1",
+    "51a-43-4",
+  ]
+
+  invalid_length_cas_numbers = [
+    "1-12-1",
+    "12345678-12-1",
+    "1234567-12-12",
+  ]
+
+  valid_cas_numbers.each do |cas_number|
+    context "with valid cas number (#{cas_number})" do
+      let(:cas_number) { cas_number }
+
+      it "is valid" do
+        expect(validator).to be_valid
+      end
+
+      it "does not populate an error message" do
+        expect(validator.errors.messages[:cas_number]).to be_empty
+      end
+    end
+  end
+
+  invalid_cas_numbers.each do |cas_number|
+    context "with invalid cas number (#{cas_number})" do
+      let(:cas_number) { cas_number }
+
+      it "is not valid" do
+        expect(validator).not_to be_valid
+      end
+
+      it "populates an error message" do
+        expect(validator.errors.messages[:cas_number]).to eq ["CAS number is invalid"]
+      end
+    end
+  end
+
+  invalid_length_cas_numbers.each do |cas_number|
+    context "with invalid cas number (#{cas_number})" do
+      let(:cas_number) { cas_number }
+
+      it "is not valid" do
+        expect(validator).not_to be_valid
+      end
+
+      it "populates error messages" do
+        expect(validator.errors.messages[:cas_number])
+          .to eq ["CAS number is invalid", "CAS number must contain between 5 to 10 digits"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1500)

## Description
<!--- Describe your changes in detail -->
Until now, when a user creates a notification and marks the ingredients for the item/product as "exact ingredients", they have been uploading formulation PDFs. 
From now on, we will prompt them to introduce the ingredients information manually. For each ingredient, they will  add:
- The ingredient's name.
- Its exact concentration
- (Optionally) CAS number.
- Flag if the ingredient is poisonous.

Page for adding exact ingredients information:
![Screenshot from 2022-06-07 10-18-21](https://user-images.githubusercontent.com/1227578/172344578-95adc5c9-61fc-40a3-bcc8-6bf519f174ef.png)
----

Page displayed after adding an ingredient:
![Screenshot from 2022-06-07 10-18-33](https://user-images.githubusercontent.com/1227578/172344611-09942d5c-be16-49ad-99bd-ff2f0091f405.png)
----

Summary pre-notification submission displaying the ingredients exact concentrations:
![Screenshot from 2022-06-07 10-17-59](https://user-images.githubusercontent.com/1227578/172344626-f7bcda81-5f99-4edd-8a92-91e23d3d0bd3.png)
----

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2501-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2501-search-web.london.cloudapps.digital/
