### PR TITLE
New frame formulation poisonous ingredient flow

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/_add_ingredient_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/_add_ingredient_concentration.html.erb
@@ -9,7 +9,13 @@
     <p class="govuk-body-s opss-secondary-text">For every ingredient:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-font-size-16 opss-secondary-text">
       <li>Use the International Nomenclature of Cosmetic Ingredients (<abbr>INCI</abbr>) name, where available</li>
-      <li>Confirm if poisonous - especially if the details match ingredients listed in the following poison tables </li>
+      <li>
+        <% if local_assigns[:poisonous] == true %>
+          The exact concentration of a poisonous ingredient is required - especially if the details match ingredients listed in the following poison tables
+        <% else %>
+          Confirm if poisonous - especially if the details match ingredients listed in the following poison tables
+        <% end %>
+      </li>
     </ul>
 
     <%= link_to "Skip poisonous ingredients tables.", "#skip-to-form", class: "govuk-skip-link opss-skip-link" %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/_ingredient_exact_concentration_fields.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/_ingredient_exact_concentration_fields.html.erb
@@ -1,0 +1,25 @@
+<%= render "form_components/govuk_input",
+            form: form,
+            id: "name",
+            key: :name,
+            label: { text: "What is the name?" },
+            attributes: { spellcheck: "false" } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= render "exact_concentration_input", model: model, form: form %>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-form-group">
+      <div class="govuk-checkboxes opss-float-right-desktop">
+        <%= render "form_components/govuk_input",
+                    form: form,
+                    key: :cas_number,
+                    id: "cas_number",
+                    label: { text: "What is the CAS number?", classes: "govuk-label--s govuk-!-font-weight-regular" },
+                    classes: "govuk-input--width-10" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -8,32 +8,7 @@
 <%= error_summary(@ingredient_concentration_form.errors) %>
 
 <%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form do |form| %>
-  <%= render "form_components/govuk_input",
-             form: form,
-             id: "name",
-             key: :name,
-             label: { text: "What is the name?" },
-             attributes: { spellcheck: "false" } %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
-      <%= render "exact_concentration_input", model: @ingredient_concentration_form, form: form %>
-    </div>
-
-    <div class="govuk-grid-column-one-half">
-      <div class="govuk-form-group">
-        <div class="govuk-checkboxes opss-float-right-desktop">
-          <%= render "form_components/govuk_input",
-                     form: form,
-                     key: :cas_number,
-                     id: "cas_number",
-                     label: { text: "What is the CAS number?", classes: "govuk-label--s govuk-!-font-weight-regular" },
-                     classes: "govuk-input--width-10" %>
-        </div>
-      </div>
-    </div>
-  </div>
-
+  <%= render "ingredient_exact_concentration_fields", model: @ingredient_concentration_form, form: form %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <%= render "form_components/govuk_checkboxes",

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_poisonous_ingredient.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_poisonous_ingredient.html.erb
@@ -8,32 +8,7 @@
 <%= error_summary(@ingredient_concentration_form.errors) %>
 
 <%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form, poisonous: true do |form| %>
-  <%= render "form_components/govuk_input",
-             form: form,
-             id: "name",
-             key: :name,
-             label: { text: "What is the name?" },
-             attributes: { spellcheck: "false" } %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
-      <%= render "exact_concentration_input", model: @ingredient_concentration_form, form: form %>
-    </div>
-
-    <div class="govuk-grid-column-one-half">
-      <div class="govuk-form-group">
-        <div class="govuk-checkboxes opss-float-right-desktop">
-          <%= render "form_components/govuk_input",
-                     form: form,
-                     key: :cas_number,
-                     id: "cas_number",
-                     label: { text: "What is the CAS number?", classes: "govuk-label--s govuk-!-font-weight-regular" },
-                     classes: "govuk-input--width-10" %>
-        </div>
-      </div>
-    </div>
-  </div>
-
+  <%= render "ingredient_exact_concentration_fields", model: @ingredient_concentration_form, form: form %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <%= render "form_components/govuk_checkboxes",

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_poisonous_ingredient.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_poisonous_ingredient.html.erb
@@ -1,4 +1,4 @@
-<% title = "Add the ingredients" %>
+<% title = "Add the poisonous ingredients" %>
 
 <% page_title title, errors: @ingredient_concentration_form.errors.any? %>
 <% content_for :after_header do %>
@@ -7,7 +7,7 @@
 
 <%= error_summary(@ingredient_concentration_form.errors) %>
 
-<%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form do |form| %>
+<%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form, poisonous: true do |form| %>
   <%= render "form_components/govuk_input",
              form: form,
              id: "name",
@@ -43,7 +43,8 @@
                  classes: " govuk-!-padding-top-6",
                  items: [{ key: :poisonous,
                            text: "Is it poisonous?",
-                           value: true }] %>
+                           disabled: "disabled",
+                           attributes: { checked: "checked", "aria-disabled" => "true" } }] %>
     </div>
   </div>
 <% end %>

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications/components/build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications/components/build_controller_spec.rb
@@ -77,19 +77,25 @@ RSpec.describe ResponsiblePersons::Notifications::Components::BuildController, t
       expect(assigns(:component).cmrs).to all(have_attributes(name: be_nil))
     end
 
-    describe "upload poisonus ingredients page" do
-      before { get(:show, params: params.merge(id: :upload_poisonus_ingredients)) }
+    describe "add component predefined frame formulation poisonous ingredient" do
+      let(:component_type) { "predefined" }
+
+      before { get(:show, params: params.merge(id: :add_poisonous_ingredient)) }
 
       render_views
 
-      describe "back link" do
-        context "with a component with predefined formulation" do
-          let(:component_type) { "predefined" }
+      # rubocop:disable RSpec/MultipleExpectations
+      it "shows the page for adding poisonous ingredients to a predefined formulation component" do
+        expect(response.body).to match(/<title>Add the poisonous ingredients .+<\/title>/)
+        expect(response.body).to include("What is the exact concentration?")
+        expect(response.body).not_to include("What is the concentration range?")
+      end
+      # rubocop:enable RSpec/MultipleExpectations
 
-          it "links to the poisonous materials page" do
-            expect(response.body).to have_back_link_to(responsible_person_notification_component_build_path(responsible_person, notification, component, :contains_poisonous_ingredients))
-          end
-        end
+      it " contains a back link to the 'contains poisonous ingredients' page" do
+        expect(response.body).to have_back_link_to(
+          responsible_person_notification_component_build_path(responsible_person, notification, component, :contains_poisonous_ingredients),
+        )
       end
     end
 
@@ -257,8 +263,8 @@ RSpec.describe ResponsiblePersons::Notifications::Components::BuildController, t
         end
 
         context "when the answer is true" do
-          it "redirects to the upload formulation page" do
-            expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, notification, component, :upload_poisonus_ingredients))
+          it "redirects to the add poisonous ingredient" do
+            expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, notification, component, :add_poisonous_ingredient))
           end
         end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1499)

## Description
<!--- Describe your changes in detail -->
When the user selects to add poisonous ingredients to a frame formulation components will be shown a form to manually add each poisonous ingredient and their exact concentration.

The form and flow will be almost identical to adding exact ingredients to a component, but with slight differences in the wording and with the "Poisonous" check to be pre-selected and enforced (users won't be able to uncheck them).

![image](https://user-images.githubusercontent.com/1227578/174591212-7274580f-f16e-40e1-9a28-4ea5012befcb.png)

## Review apps

<!--- Edit links after PR is created -->
https://cosmetics-pr-2518-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2518-search-web.london.cloudapps.digital/
