### PR TITLE
Remove missing formulation file validation

### DIFF
--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -135,14 +135,6 @@ class Component < ApplicationRecord
     get_category_name(root_category)
   end
 
-  def formulation_file_required?
-    return false if formulation_file.attached?
-
-    (range? && range_formulas&.empty?) ||
-      (exact? && exact_formulas&.empty?) ||
-      (predefined? && contains_poisonous_ingredients)
-  end
-
   def formulation_file_failed_antivirus_check?
     formulation_file.attached? && formulation_file.metadata["safe"] == false
   end

--- a/cosmetics-web/app/validators/accept_and_submit_validator.rb
+++ b/cosmetics-web/app/validators/accept_and_submit_validator.rb
@@ -29,9 +29,7 @@ class AcceptAndSubmitValidator < ActiveModel::Validator
 
   def validate_frame_formulation_uploads(notification)
     notification.components.each do |component|
-      if component.formulation_file_required?
-        notification.errors.add :formulation_uploads, "Item #{component.name} is missing formulation file"
-      elsif component.formulation_file_pending_antivirus_check?
+      if component.formulation_file_pending_antivirus_check?
         notification.errors.add :formulation_uploads, "File #{component.formulation_file.filename} is still being processed"
       elsif component.formulation_file_failed_antivirus_check?
         notification.errors.add :formulation_uploads, "File #{component.formulation_file.filename} failed antivirus check. Remove file and try again"

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -115,59 +115,6 @@ RSpec.describe Component, type: :model do
     end
   end
 
-  describe "formulation_required", :with_stubbed_antivirus do
-    context "when component uses frame formulation" do
-      it "returns false for predefined formulation when no file attached" do
-        expect(predefined_component.formulation_file_required?).to be false
-      end
-    end
-
-    context "when component uses frame formulation and has harmful ingredients" do
-      let(:contains_poisonous_ingredients) { true }
-
-      it "returns false when there is no file" do
-        expect(predefined_component.formulation_file_required?).to be true
-      end
-
-      it "returns false for predefined formulation even if no file attached" do
-        predefined_component.formulation_file.attach text_file
-        expect(predefined_component.formulation_file_required?).to be false
-      end
-    end
-
-    context "when component uses range formulation" do
-      it "returns true if file is not attached" do
-        expect(ranges_component.formulation_file_required?).to be true
-      end
-
-      it "returns false if file is attached" do
-        ranges_component.formulation_file.attach text_file
-        expect(ranges_component.formulation_file_required?).to be false
-      end
-
-      it "returns false if manually entered data present" do
-        ranges_component.range_formulas.create
-        expect(ranges_component.formulation_file_required?).to be false
-      end
-    end
-
-    context "when component uses exact formulation" do
-      it "returns true for exact formulation if no file attached" do
-        expect(exact_component.formulation_file_required?).to be true
-      end
-
-      it "returns false if file is attached" do
-        exact_component.formulation_file.attach text_file
-        expect(exact_component.formulation_file_required?).to be false
-      end
-
-      it "returns false if manually entered data present" do
-        exact_component.exact_formulas.create
-        expect(exact_component.formulation_file_required?).to be false
-      end
-    end
-  end
-
   describe "updating special_applicator" do
     it "adds errors if special_applicator updated to be blank" do
       predefined_component.special_applicator = nil

--- a/cosmetics-web/spec/validators/accept_and_submit_validator_spec.rb
+++ b/cosmetics-web/spec/validators/accept_and_submit_validator_spec.rb
@@ -70,12 +70,4 @@ RSpec.describe AcceptAndSubmitValidator, :with_stubbed_antivirus do
       expect(notification.errors.messages_for(:formulation_uploads)).to eq(["File #{component.formulation_file.filename} is still being processed"])
     end
   end
-
-  describe "formulation file is missing" do
-    let(:component) { create(:ranges_component, name: "Item 1", notification: notification) } # ranges component requires file
-
-    it "complains about missing file" do
-      expect(notification.errors.messages_for(:formulation_uploads)).to eq(["Item #{component.name} is missing formulation file"])
-    end
-  end
 end


### PR DESCRIPTION
Since now none of the add ingredient flows requires uploading a formulation file.

<!--- Edit links after PR is created -->
https://cosmetics-pr-2523-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2523-search-web.london.cloudapps.digital/
