### PR TITLE
Allow to edit/delete poisonous ingredients from predefined formulation components

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -84,10 +84,8 @@ class ResponsiblePersons::Notifications::Components::BuildController < SubmitApp
       else
         return jump_to_step(:number_of_shades)
       end
-    when :add_ingredient_exact_concentration, :add_ingredient_range_concentration
+    when :add_ingredient_exact_concentration, :add_ingredient_range_concentration, :add_poisonous_ingredient
       @ingredient_concentration_form = ingredient_concentration_form
-    when :add_poisonous_ingredient
-      @ingredient_concentration_form = ResponsiblePersons::Notifications::IngredientConcentrationForm.new
     when :want_to_add_another_ingredient
       @success_banner = ActiveModel::Type::Boolean.new.cast(params[:success_banner])
     when :completed
@@ -333,7 +331,9 @@ private
     end
 
     @component.update!(contains_poisonous_ingredients: params[:component][:contains_poisonous_ingredients])
-    unless @component.contains_poisonous_ingredients?
+    if @component.contains_poisonous_ingredients?
+      jump_to(:add_poisonous_ingredient, ingredient_number: 0) if @component.ingredients.any?
+    else
       jump_to(:select_ph_option)
     end
     render_next_step @component

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -262,20 +262,16 @@ private
     @component.update_formulation_type(formulation_type)
     return rerender_current_step if @component.errors.present?
 
-    if @component.predefined? # predefined == frame_formulation
-      jump_to_step(:select_frame_formulation)
-    elsif @component.range?
-      if @component.ingredients.any?
-        jump_to_step(:add_ingredient_range_concentration, ingredient_number: 0) # Display first existing ingredient for edit
-      else
-        jump_to_step(:add_ingredient_range_concentration)
-      end
-    elsif @component.exact?
-      if @component.ingredients.any?
-        jump_to_step(:add_ingredient_exact_concentration, ingredient_number: 0) # Display first existing ingredient for edit
-      else
-        jump_to_step(:add_ingredient_exact_concentration)
-      end
+    step = {
+      "predefined" => :select_frame_formulation,
+      "exact" => :add_ingredient_exact_concentration,
+      "range" => :add_ingredient_range_concentration,
+    }[@component.notification_type]
+
+    if @component.ingredients.any? && !@component.predefined?
+      jump_to_step(step, ingredient_number: 0) # Display first existing ingredient for edit
+    else
+      jump_to_step(step)
     end
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -260,18 +260,11 @@ private
     formulation_type = params.dig(:component, :notification_type)
     model.save_routing_answer(step, formulation_type)
     @component.update_formulation_type(formulation_type)
-
-    if @component.errors.present?
-      return rerender_current_step
-    end
+    return rerender_current_step if @component.errors.present?
 
     if @component.predefined? # predefined == frame_formulation
       jump_to_step(:select_frame_formulation)
-    elsif @component.frame_formulation.present?
-      @component.update(frame_formulation: nil)
-    end
-
-    if @component.range?
+    elsif @component.range?
       if @component.ingredients.any?
         jump_to_step(:add_ingredient_range_concentration, ingredient_number: 0) # Display first existing ingredient for edit
       else

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/delete_ingredients_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/delete_ingredients_controller.rb
@@ -9,7 +9,7 @@ class ResponsiblePersons::Notifications::Components::DeleteIngredientsController
     when "no"
       redirect_to ingredient_path
     when "yes"
-      delete_ingredient
+      delete_ingredient!
       render :success, locals: { post_deletion_path: post_deletion_path }
     else
       @ingredient.errors.add(:confirmation, "Select yes if you want to remove this ingredient")
@@ -19,7 +19,7 @@ class ResponsiblePersons::Notifications::Components::DeleteIngredientsController
 
 private
 
-  def delete_ingredient
+  def delete_ingredient!
     # TODO: Move this logic to the Component model once the ingredient model is unified.
     @ingredient.destroy
     @component.reload

--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -196,7 +196,8 @@ class Component < ApplicationRecord
     self.notification_type = type
     return unless save(context: :select_formulation_type)
 
-    # Purge formulation files added in old flow. Now ingredients need to be added manually or use a predefined formulation.
+    # Purge formulation files added in old flow.
+    # Now ingredients need to be added manually or use a predefined formulation.
     formulation_file.purge
 
     if old_type != notification_type

--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -137,7 +137,7 @@ class Component < ApplicationRecord
 
   def missing_ingredients?
     if predefined?
-      (contains_poisonous_ingredients && ingredients.none?) == true
+      contains_poisonous_ingredients? && ingredients.none?
     else
       ingredients.none?
     end

--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -93,6 +93,12 @@ class Component < ApplicationRecord
 
   before_save :remove_other_special_applicator, unless: :other_special_applicator?
 
+  # Deletes all the associated poisonous ingredients from predefined components when
+  # "contains_poisonous_ingredients" is set to "false"
+  after_update :remove_poisonous_ingredients!,
+               if: [:predefined?, -> { ingredients.any? }],
+               unless: :contains_poisonous_ingredients?
+
   aasm whiny_transitions: false, column: :state do
     state :empty, initial: true
     state :component_complete
@@ -252,5 +258,9 @@ private
     if (maximum_ph - minimum_ph).round(2) > 1.0
       errors.add(:maximum_ph, "The maximum pH cannot be more than 1 higher than the minimum pH")
     end
+  end
+
+  def remove_poisonous_ingredients!
+    exact_formulas.destroy_all
   end
 end

--- a/cosmetics-web/app/validators/accept_and_submit_validator.rb
+++ b/cosmetics-web/app/validators/accept_and_submit_validator.rb
@@ -2,7 +2,7 @@ class AcceptAndSubmitValidator < ActiveModel::Validator
   def validate(notification)
     validate_nano_materials(notification)
     validate_image_uploads(notification)
-    validate_frame_formulation_uploads(notification)
+    validate_ingredients(notification)
   end
 
   def validate_nano_materials(notification)
@@ -27,7 +27,7 @@ class AcceptAndSubmitValidator < ActiveModel::Validator
     end
   end
 
-  def validate_frame_formulation_uploads(notification)
+  def validate_ingredients(notification)
     notification.components.each do |component|
       if component.missing_ingredients?
         notification.errors.add :formulation_uploads, "The notification has not listed any ingredients"

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/select_formulation_type.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/select_formulation_type.html.erb
@@ -10,7 +10,7 @@
 <% warning_html = if @component.notification_type.present?
     govukWarningText(iconFallbackText: "Warning",
                      classes: "govuk-!-margin-top-3 opss-warning-text--m",
-                     text: "Changing this setting will remove any ingredients already added")
+                     text: "Changing the formulation type will remove all ingredients already added")
   end
 %>
 

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/delete_ingredients/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/delete_ingredients/show.html.erb
@@ -1,14 +1,6 @@
 <% page_title "Remove ingredient", errors: @notification.errors.any? %>
 <% content_for :after_header do %>
-  <% ingredients_page = if @component.range?
-                          :add_ingredient_range_concentration
-                        elsif @component.exact?
-                          :add_ingredient_exact_concentration
-                        end %>
-
-  <%= link_to("Back", responsible_person_notification_component_build_path(
-                @notification.responsible_person, @notification, @component, ingredients_page, ingredient_number: @ingredient_number
-              ), class: "govuk-back-link") %>
+  <%= link_to("Back", edit_ingredient_path, class: "govuk-back-link") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/cosmetics-web/spec/factories/component.rb
+++ b/cosmetics-web/spec/factories/component.rb
@@ -3,7 +3,27 @@ FactoryBot.define do
     notification_type { "predefined" }
     notification
 
-    factory :predefined_component
+    factory :predefined_component do
+      notification_type { "predefined" }
+
+      trait :completed do
+        state { "component_complete" }
+        physical_form { "foam" }
+        sub_sub_category { "shampoo" }
+        frame_formulation { "skin_care_cream_lotion_gel" }
+        contains_poisonous_ingredients { true }
+        ph { "between_3_and_10" }
+        routing_questions_answers do
+          {
+            "contains_cmrs" => "no",
+            "number_of_shades" => "single-or-no-shades",
+            "select_formulation_type" => "predefined",
+            "contains_special_applicator" => "no",
+            "contains_poisonous_ingredients" => "true",
+          }
+        end
+      end
+    end
 
     factory :ranges_component do
       notification_type { "range" }

--- a/cosmetics-web/spec/features/notification_wizard/ingredients/editing_ingredients_on_components_spec.rb
+++ b/cosmetics-web/spec/features/notification_wizard/ingredients/editing_ingredients_on_components_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe "Editing ingredients on components", :with_stubbed_antivirus, typ
     answer_item_subcategory_with "Hair and scalp care and cleansing products"
     answer_item_sub_subcategory_with "Shampoo"
     # Change component from exact concentration to range
-    expect(page).to have_text("Changing this setting will remove any ingredients already added")
+    expect(page).to have_text("Changing the formulation type will remove all ingredients already added")
     answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration"
 
     # Starts from scratch without ingredients
@@ -260,7 +260,7 @@ RSpec.describe "Editing ingredients on components", :with_stubbed_antivirus, typ
     answer_item_subcategory_with "Hair and scalp care and cleansing products"
     answer_item_sub_subcategory_with "Shampoo"
     # Change component from exact concentration to range
-    expect(page).to have_text("Changing this setting will remove any ingredients already added")
+    expect(page).to have_text("Changing the formulation type will remove all ingredients already added")
     answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration"
 
     # Starts from scratch without ingredients

--- a/cosmetics-web/spec/features/notification_wizard/ingredients/editing_ingredients_on_components_spec.rb
+++ b/cosmetics-web/spec/features/notification_wizard/ingredients/editing_ingredients_on_components_spec.rb
@@ -149,9 +149,102 @@ RSpec.describe "Editing ingredients on components", :with_stubbed_antivirus, typ
     )
   end
 
-  scenario "Changing the formulation type for a component with existing ingredients" do
+  scenario "Editing ingredients on a predefined formulation notification" do
+    component = create(:predefined_component, :completed, notification: notification)
+    create(:exact_formula, inci_name: "Ingredient A", quantity: 4.0, poisonous: true, component: component)
+    create(:exact_formula, inci_name: "Ingredient B", quantity: 3.0, poisonous: true, component: component)
+
+    visit "/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/draft"
+
+    expect_product_details_task_completed
+
+    click_link "Product details"
+    answer_is_item_available_in_shades_with "No"
+    answer_what_is_physical_form_of_item_with "Foam"
+    answer_what_is_product_contained_in_with "A typical non-pressurised bottle, jar, sachet or other package"
+    answer_does_item_contain_cmrs_with "No"
+    answer_item_category_with "Hair and scalp products"
+    answer_item_subcategory_with "Hair and scalp care and cleansing products"
+    answer_item_sub_subcategory_with "Shampoo"
+    answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation"
+
+    expect_to_be_on__frame_formulation_select_page
+    answer_select_formulation_with "Skin Care Cream, Lotion, Gel"
+    answer_contain_poisonous_ingredients_with("Yes")
+
+    expect_to_be_on_add_ingredients_page(ingredient_number: 1, forced_poisonous: true, already_added: ["Ingredient A", "Ingredient B"])
+    expect(page).to have_field("What is the name?", with: "Ingredient A")
+    expect(page).to have_field("What is the exact concentration?", with: "4.0")
+    expect(page).to have_field("What is the CAS number?")
+    expect(page).not_to have_link("Skip", exact: true)
+
+    fill_in "What is the name?", with: "Ingredient A poisonous"
+    fill_in "exact_concentration", with: "5.1"
+    click_on "Save and continue"
+
+    expect_to_be_on_add_ingredients_page(ingredient_number: 2, forced_poisonous: true, already_added: ["Ingredient A poisonous", "Ingredient B"])
+    expect(page).to have_field("What is the name?", with: "Ingredient B")
+    expect(page).to have_field("What is the exact concentration?", with: "3.0")
+    expect(page).to have_field("What is the CAS number?")
+    expect(page).not_to have_link("Skip", exact: true)
+
+    fill_in "What is the name?", with: "Ingredient B poisonous"
+    fill_in "What is the CAS number?", with: "123456-78-9"
+    click_on "Save and continue"
+
+    answer_add_another_ingredient_with("No", success_banner: false)
+    expect_to_be_on__what_is_ph_range_of_product_page
+
+    # Updated the values in Database.
+    expect(component.exact_formulas).to have(2).items
+    expect(component.exact_formulas.first).to have_attributes(
+      inci_name: "Ingredient A poisonous",
+      quantity: 5.1,
+      poisonous: true,
+      cas_number: nil,
+    )
+    expect(component.exact_formulas.second).to have_attributes(
+      inci_name: "Ingredient B poisonous",
+      quantity: 3.0,
+      poisonous: true,
+      cas_number: "123456789",
+    )
+  end
+
+  scenario "Changing the formulation type from range to exact for a component with existing ingredients" do
     component = create(:ranges_component, :completed, notification: notification)
     create(:range_formula, inci_name: "Ingredient A", component: component)
+    create(:exact_formula, inci_name: "Ingredient B", poisonous: true, component: component)
+
+    visit "/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/draft"
+
+    expect_product_details_task_completed
+
+    click_link "Product details"
+    answer_is_item_available_in_shades_with "No"
+    answer_what_is_physical_form_of_item_with "Foam"
+    answer_what_is_product_contained_in_with "A typical non-pressurised bottle, jar, sachet or other package"
+    answer_does_item_contain_cmrs_with "No"
+    answer_item_category_with "Hair and scalp products"
+    answer_item_subcategory_with "Hair and scalp care and cleansing products"
+    answer_item_sub_subcategory_with "Shampoo"
+    # Change component from exact concentration to range
+    expect(page).to have_text("Changing this setting will remove any ingredients already added")
+    answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration"
+
+    # Starts from scratch without ingredients
+    expect(component.ingredients).to eq []
+    expect_to_be_on_add_ingredients_page
+    expect(page).to have_field("What is the name?")
+    expect(page).not_to have_field("What is the name?", with: "Ingredient A")
+    expect(page).not_to have_css("h2", text: "Already added")
+    expect(page).not_to have_css("ol.govuk-list--number li", text: "Ingredient A")
+    expect(page).not_to have_css("ol.govuk-list--number li", text: "Ingredient B")
+  end
+
+  scenario "Changing the formulation type from predefined formulation to exact for a component with existing poisonous ingredients" do
+    component = create(:predefined_component, :using_frame_formulation, :completed, notification: notification)
+    create(:exact_formula, inci_name: "Ingredient A", poisonous: true, component: component)
     create(:exact_formula, inci_name: "Ingredient B", poisonous: true, component: component)
 
     visit "/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/draft"

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -140,6 +140,15 @@ RSpec.describe Component, type: :model do
     end
   end
 
+  describe "updating 'contains_poisonous_ingredients' attribute on predefined components" do
+    it "deletes all poisonous ingredients when setting it to 'false'" do
+      component = described_class.create(name: "Component X", notification: notification, notification_type: "predefined", contains_poisonous_ingredients: true)
+      create_list(:exact_formula, 2, poisonous: true, component: component)
+      expect { component.update(contains_poisonous_ingredients: false) }
+        .to change { component.exact_formulas.count }.from(2).to(0)
+    end
+  end
+
   describe "#ph" do
     context "when not specified" do
       before { predefined_component.ph = nil }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket 1503](https://regulatorydelivery.atlassian.net/browse/COSBETA-1503)

## Description
<!--- Describe your changes in detail -->
As done with range/exact formulations, when a user revisits the component details tasks, will find the existing ingredients (in this case the poisonous ingredients) prefilled one by one. The user will be able to edit the details or remove the ingredients.

When changing the formulation type from predefined to exact/range all the existing predefined formulation poisonous ingredients will be wiped.
Same if when revisiting the flow the user answers "No" to the "contains poisonous ingredients?" question.

## Review apps

<!--- Edit links after PR is created -->
https://cosmetics-pr-2536-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2536-search-web.london.cloudapps.digital/
