### PR TITLE
Bug - don't create nanomaterials if no is selected.

### DIFF
--- a/cosmetics-web/app/forms/responsible_persons/notifications/product/contains_nanomaterials_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/product/contains_nanomaterials_form.rb
@@ -13,5 +13,13 @@ module ResponsiblePersons::Notifications::Product
     def contains_nanomaterials?
       contains_nanomaterials == "yes"
     end
+
+    def nanomaterials_count
+      if contains_nanomaterials?
+        super
+      else
+        0
+      end
+    end
   end
 end

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications/product_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications/product_controller_spec.rb
@@ -132,6 +132,12 @@ RSpec.describe ResponsiblePersons::Notifications::ProductController, :with_stubb
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
+    it "does not create nanomaterials when No is selected" do
+      expect {
+        put(:update, params: params.merge(id: :contains_nanomaterials, contains_nanomaterials_form: { nanomaterials_count: "3", contains_nanomaterials: "no" }))
+      }.not_to(change(NanoElement, :count))
+    end
+
     context "when the notification is already submitted" do
       subject(:request) { post(:update, params: params.merge(id: :add_product_name, notification: { product_name: "Super Shampoo" })) }
 

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/product/contains_nanomaterials_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/product/contains_nanomaterials_form_spec.rb
@@ -134,6 +134,14 @@ RSpec.describe ResponsiblePersons::Notifications::Product::ContainsNanomaterials
         expect(form.errors.full_messages_for(:contains_nanomaterials)).to be_empty
       end
 
+      context "when the nanomaterials count is higher" do
+        let(:nanomaterials_count) { "3" }
+
+        it "returns 0 as count" do
+          expect(form.nanomaterials_count).to eq 0
+        end
+      end
+
       context "when the nanomaterials count is invalid" do
         let(:nanomaterials_count) { "twelve" }
 


### PR DESCRIPTION
To reproduce:
Select "Yes" on question "Does {notification_name} contains nanomaterials" and enter amount:
![Screenshot 2022-07-25 093404](https://user-images.githubusercontent.com/11747/180734168-bd30f22d-1c29-4aaf-897f-d55bea2187b5.png)
Than change your answer to "No":
![Screenshot 2022-07-25 093450](https://user-images.githubusercontent.com/11747/180734354-eb106ce0-9bce-4b7c-a7d1-a0bd3b6e7253.png)
After submit, there will be 4 nanomaterials created.

This PR contains fix.