### PR TITLE
Redirect WickedWizard invalid steps to 404 page

### DIFF
--- a/cosmetics-web/app/controllers/concerns/wizard_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/wizard_concern.rb
@@ -6,6 +6,10 @@ module WizardConcern
     helper_method :next_step_path
     before_action :check_minimum_state
     helper_method :model
+
+    rescue_from Wicked::Wizard::InvalidStepError do
+      raise ActionController::RoutingError, "Invalid step"
+    end
   end
 
   def notification


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1526)

When a user manually introduces a non-existing step in the URL for a WickedWizard controller, the services throws an exception (raised as `Wicked::Wizard::InvalidStepError`).
Instead of raising a production exception, raise a Routing Error that will be mapped to the 404 error page by Rails.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2552-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2552-search-web.london.cloudapps.digital/
